### PR TITLE
[ENH]: OpenAI Embedding Models Support

### DIFF
--- a/openai/client_test.go
+++ b/openai/client_test.go
@@ -2,7 +2,6 @@ package openai
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -22,30 +21,63 @@ func Test_openai_client(t *testing.T) {
 	}
 
 	t.Run("Test DefaultApiService Add", func(t *testing.T) {
-		ef := NewOpenAIEmbeddingFunction(apiKey)
+		ef, efErr := NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 
 		documents := []string{
 			"Document 1 content here",
 			"Document 2 content here",
 			// Add more documents as needed
 		}
-		resp, rerr := ef.EmbedDocuments(context.Background(), documents)
-		require.Nil(t, rerr)
+		resp, reqErr := ef.EmbedDocuments(context.Background(), documents)
+		require.NoError(t, reqErr)
 		require.NotNil(t, resp)
-		fmt.Printf("resp: %v\n", resp)
-		// assert.Equal(t, 201, httpRes.StatusCode)
 		require.Empty(t, ef.apiClient.OrgID)
 	})
 
 	t.Run("Test Adding Organization Id with NewOpenAIClient", func(t *testing.T) {
-		apiClient := NewOpenAIClient(apiKey, WithOpenAIOrganizationID("org-123"))
+		apiClient, efError := NewOpenAIClient(apiKey, WithOpenAIOrganizationID("org-123"))
+		require.NoError(t, efError)
 
 		require.Equal(t, "org-123", apiClient.OrgID)
 	})
 
 	t.Run("Test Adding Organization Id with NewOpenAIEmbeddingFunction", func(t *testing.T) {
-		ef := NewOpenAIEmbeddingFunction(apiKey, WithOpenAIOrganizationID("org-123"))
+		ef, efError := NewOpenAIEmbeddingFunction(apiKey, WithOpenAIOrganizationID("org-123"))
+		require.NoError(t, efError)
 
 		require.Equal(t, "org-123", ef.apiClient.OrgID)
+	})
+
+	t.Run("Test With Model text-embedding-3-small", func(t *testing.T) {
+		ef, erErr := NewOpenAIEmbeddingFunction(apiKey, WithModel(TextEmbedding3Small))
+		require.NoError(t, erErr)
+		documents := []string{
+			"Document 1 content here",
+		}
+		resp, reqErr := ef.EmbedDocuments(context.Background(), documents)
+		require.Nil(t, reqErr)
+		require.NotNil(t, resp)
+		require.Empty(t, ef.apiClient.OrgID)
+		require.Len(t, resp[0], 1536)
+	})
+
+	t.Run("Test With Model text-embedding-3-large", func(t *testing.T) {
+		ef, efErr := NewOpenAIEmbeddingFunction(apiKey, WithModel(TextEmbedding3Large))
+		require.NoError(t, efErr)
+		documents := []string{
+			"Document 1 content here",
+		}
+		resp, reqErr := ef.EmbedDocuments(context.Background(), documents)
+		require.Nil(t, reqErr)
+		require.NotNil(t, resp)
+		require.Empty(t, ef.apiClient.OrgID)
+		require.Len(t, resp[0], 3072)
+	})
+
+	t.Run("Test With Invalid Model", func(t *testing.T) {
+		_, efErr := NewOpenAIEmbeddingFunction(apiKey, WithModel("invalid-model"))
+		require.Error(t, efErr)
+		require.Contains(t, efErr.Error(), "invalid model name invalid-model")
 	})
 }

--- a/openai/options.go
+++ b/openai/options.go
@@ -1,17 +1,46 @@
 package openai
 
+import "fmt"
+
 // Option is a function type that can be used to modify the client.
-type Option func(c *OpenAIClient)
+type Option func(c *OpenAIClient) error
+
+type EmbeddingModel string
+
+const (
+	TextEmbeddingAda002 EmbeddingModel = "text-embedding-ada-002"
+	TextEmbedding3Small EmbeddingModel = "text-embedding-3-small"
+	TextEmbedding3Large EmbeddingModel = "text-embedding-3-large"
+)
 
 // WithOpenAIOrganizationID is an option for setting the OpenAI org id.
 func WithOpenAIOrganizationID(openAiAPIKey string) Option {
-	return func(c *OpenAIClient) {
+	return func(c *OpenAIClient) error {
 		c.SetOrgID(openAiAPIKey)
+		return nil
 	}
 }
 
-func applyClientOptions(c *OpenAIClient, opts ...Option) {
-	for _, opt := range opts {
-		opt(c)
+// WithModel is an option for setting the model to use. Must be one of: text-embedding-ada-002, text-embedding-3-small, text-embedding-3-large
+func WithModel(model EmbeddingModel) Option {
+	return func(c *OpenAIClient) error {
+		if string(model) == "" {
+			return fmt.Errorf("empty model name")
+		}
+		if model != TextEmbeddingAda002 && model != TextEmbedding3Small && model != TextEmbedding3Large {
+			return fmt.Errorf("invalid model name %s. Must be one of: %v", model, []string{string(TextEmbeddingAda002), string(TextEmbedding3Small), string(TextEmbedding3Large)})
+		}
+		c.Model = string(model)
+		return nil
 	}
+}
+
+func applyClientOptions(c *OpenAIClient, opts ...Option) error {
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/test/chroma_client_test.go
+++ b/test/chroma_client_test.go
@@ -48,7 +48,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -75,7 +76,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -118,7 +120,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -182,7 +185,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -251,7 +255,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -298,7 +303,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -350,7 +356,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -397,7 +404,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -442,7 +450,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -482,7 +491,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -534,7 +544,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -580,7 +591,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {
@@ -626,7 +638,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("OPENAI_API_KEY")
 		}
-		embeddingFunction := openai.NewOpenAIEmbeddingFunction(apiKey)
+		embeddingFunction, efErr := openai.NewOpenAIEmbeddingFunction(apiKey)
+		require.NoError(t, efErr)
 		distanceFunction := chroma.L2
 		_, errRest := client.Reset(context.Background())
 		if errRest != nil {


### PR DESCRIPTION
Refs: #28

Added support for all three embedding models

BREAKING: The new models option requires error handling, causing a breaking change in the OpenAI client API