### PR TITLE
feat: Cohere models support

### DIFF
--- a/cohere/cohere_test.go
+++ b/cohere/cohere_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_cohere_client(t *testing.T) {
+func Test_ef(t *testing.T) {
 	apiKey := os.Getenv("COHERE_API_KEY")
 	if apiKey == "" {
 		err := godotenv.Load("../.env")
@@ -21,9 +21,10 @@ func Test_cohere_client(t *testing.T) {
 		}
 		apiKey = os.Getenv("COHERE_API_KEY")
 	}
-	ef := NewCohereEmbeddingFunction(apiKey)
 
 	t.Run("Test Create Embed", func(t *testing.T) {
+		ef, err := NewCohereEmbeddingFunction(apiKey)
+		require.NoError(t, err)
 		documents := []string{
 			"Document 1 content here",
 			"Document 2 content here",
@@ -32,5 +33,60 @@ func Test_cohere_client(t *testing.T) {
 		resp, rerr := ef.EmbedDocuments(context.Background(), documents)
 		require.Nil(t, rerr)
 		require.NotNil(t, resp)
+	})
+
+	t.Run("Test Create Embed with model option", func(t *testing.T) {
+		ef, err := NewCohereEmbeddingFunction(apiKey, WithModel("embed-multilingual-v3.0"))
+		require.NoError(t, err)
+		documents := []string{
+			"Document 1 content here",
+			"Document 2 content here",
+			// Add more documents as needed
+		}
+		resp, rerr := ef.EmbedDocuments(context.Background(), documents)
+		require.Nil(t, rerr)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("Test Create Embed with model option embeddings type uint8", func(t *testing.T) {
+		ef, err := NewCohereEmbeddingFunction(apiKey, WithModel("embed-multilingual-v3.0"), WithEmbeddingTypes(EmbeddingTypeUInt8))
+		require.NoError(t, err)
+		documents := []string{
+			"Document 1 content here",
+			"Document 2 content here",
+			// Add more documents as needed
+		}
+		resp, err := ef.EmbedDocuments(context.Background(), documents)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp, 2)
+		require.Empty(t, resp[0].ArrayOfFloat32)
+		require.NotNil(t, resp[0].ArrayOfInt32)
+	})
+
+	t.Run("Test Create Embed with model option embeddings type int8", func(t *testing.T) {
+		ef, err := NewCohereEmbeddingFunction(apiKey, WithModel("embed-multilingual-v3.0"), WithEmbeddingTypes(EmbeddingTypeInt8))
+		require.NoError(t, err)
+		documents := []string{
+			"Document 1 content here",
+			"Document 2 content here",
+			// Add more documents as needed
+		}
+		resp, err := ef.EmbedDocuments(context.Background(), documents)
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.Len(t, resp, 2)
+		require.Empty(t, resp[0].ArrayOfFloat32)
+		require.NotNil(t, resp[0].ArrayOfInt32)
+	})
+
+	t.Run("Test Create Embed for query", func(t *testing.T) {
+		ef, err := NewCohereEmbeddingFunction(apiKey, WithModel("embed-multilingual-v3.0"))
+		require.NoError(t, err)
+		resp, err := ef.EmbedQuery(context.Background(), "This is a query")
+		require.Nil(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.ArrayOfFloat32)
+		require.Empty(t, resp.ArrayOfInt32)
 	})
 }

--- a/cohere/option.go
+++ b/cohere/option.go
@@ -1,0 +1,63 @@
+package cohere
+
+import "fmt"
+
+type Option func(p *CohereClient) error
+
+// WithBaseURL sets the base URL for the Cohere API - the default is https://api.cohere.ai
+func WithBaseURL(baseURL string) Option {
+	return func(p *CohereClient) error {
+		p.BaseURL = baseURL
+		return nil
+	}
+}
+
+// WithModel sets the default model for the Cohere API - Available models:
+// embed-english-v3.0 1024
+// embed-multilingual-v3.0 1024
+// embed-english-light-v3.0 384
+// embed-multilingual-light-v3.0 384
+// embed-english-v2.0 4096 (default)
+// embed-english-light-v2.0 1024
+// embed-multilingual-v2.0 768
+func WithModel(model string) Option {
+	return func(p *CohereClient) error {
+		p.DefaultModel = model
+		return nil
+	}
+}
+
+// WithTruncateMode sets the default truncate mode for the Cohere API - Available modes:
+// NONE
+// START
+// END (default)
+func WithTruncateMode(truncate TruncateMode) Option {
+	return func(p *CohereClient) error {
+		p.DefaultTruncateMode = truncate
+		return nil
+	}
+}
+
+// WithEmbeddingTypes sets the default embedding types for the Cohere API - Available types:
+// float (default)
+// int8
+// uint8
+// binary
+// ubinary
+// TODO we do not have support for returning multiple embedding types from the EmbeddingFunction, so for float->int8, unit8 are supported and returned in the that order
+func WithEmbeddingTypes(embeddingTypes ...EmbeddingType) Option {
+	return func(p *CohereClient) error {
+		// if embeddingstypes contains binary or ubinary error
+		for _, et := range embeddingTypes {
+			if et == EmbeddingTypeBinary || et == EmbeddingTypeUBinary {
+				return fmt.Errorf("embedding types binary and ubinary are not supported")
+			}
+		}
+		// if embeddingstypes is empty, set to default
+		if len(embeddingTypes) == 0 {
+			embeddingTypes = []EmbeddingType{EmbeddingTypeFloat32}
+		}
+		p.DefaultEmbeddingTypes = embeddingTypes
+		return nil
+	}
+}

--- a/hf/hf_test.go
+++ b/hf/hf_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/joho/godotenv"
@@ -33,7 +34,9 @@ func Test_huggingface_client(t *testing.T) {
 			// Add more documents as needed
 		}
 		resp, rerr := ef.EmbedDocuments(context.Background(), documents)
-
+		if strings.Contains(rerr.Error(), "429 Too Many Requests") {
+			t.Skipf("Skipping test due to rate limiting")
+		}
 		require.Nil(t, rerr)
 		require.NotNil(t, resp)
 		assert.Equal(t, 2, len(resp))

--- a/hf/hf_test.go
+++ b/hf/hf_test.go
@@ -34,7 +34,7 @@ func Test_huggingface_client(t *testing.T) {
 			// Add more documents as needed
 		}
 		resp, rerr := ef.EmbedDocuments(context.Background(), documents)
-		if strings.Contains(rerr.Error(), "429 Too Many Requests") {
+		if rerr != nil && strings.Contains(rerr.Error(), "429 Too Many Requests") {
 			t.Skipf("Skipping test due to rate limiting")
 		}
 		require.Nil(t, rerr)

--- a/test/chroma_client_test.go
+++ b/test/chroma_client_test.go
@@ -616,7 +616,7 @@ func Test_chroma_client(t *testing.T) {
 		data := []byte(`{"name":"` + collectionName1 + `"}`)
 		resp, err := http.Post(client.ApiClient.GetConfig().Servers[0].URL+"/api/v1/collections", "application/json", bytes.NewBuffer(data))
 		require.NoError(t, err)
-		fmt.Printf("Response: %v", resp)
+		require.NotNil(t, resp)
 		collections, gcerr := client.ListCollections(context.Background())
 		require.NoError(t, gcerr)
 		require.Len(t, collections, 1)
@@ -760,7 +760,8 @@ func Test_chroma_client(t *testing.T) {
 			}
 			apiKey = os.Getenv("COHERE_API_KEY")
 		}
-		embeddingFunction := cohere.NewCohereEmbeddingFunction(apiKey)
+		embeddingFunction, err := cohere.NewCohereEmbeddingFunction(apiKey)
+		require.NoError(t, err)
 		_, errRest := client.Reset(context.Background())
 		require.NoError(t, errRest)
 		newCollection, err := client.CreateCollection(context.Background(), collectionName, metadata, true, embeddingFunction, types.COSINE)

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
@@ -630,7 +631,7 @@ func TestNewEmbeddingFromInt32(t *testing.T) {
 	}
 }
 
-func TestNewEmbeddings(t *testing.T) {
+func TestNewEmbedding(t *testing.T) {
 	type args struct {
 		embeddings []interface{}
 	}
@@ -687,12 +688,80 @@ func TestNewEmbeddings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewEmbedding(tt.args.embeddings)
+			if !tt.wantErr {
+				require.NoError(t, err)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEmbedding() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.True(t, got.Compare(tt.want), "NewEmbedding() got = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func TestNewEmbeddings(t *testing.T) {
+	type args struct {
+		embeddings []interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*Embedding
+		wantErr bool
+	}{
+		{
+			name:    "empty embedding",
+			args:    args{embeddings: []interface{}{}},
+			want:    make([]*Embedding, 0),
+			wantErr: false,
+		},
+		{
+			name: "float32 embeddings",
+			args: args{
+				embeddings: []interface{}{
+					[]interface{}{0.26666668, 0.53333336, .2, 0.46666667, 0.26666668, 0.46666667, 0.6, 0.06666667, 0.13333334, 0.33333334},
+					[]interface{}{0.26666668, 0.5, .2, 0.46666667, 0.2, 0.46666667, 0.6, 0.06666667, 0.13333334, 0.3},
+				},
+			},
+			want: []*Embedding{
+				{
+					ArrayOfFloat32: &[]float32{0.26666668, 0.53333336, .2, 0.46666667, 0.26666668, 0.46666667, 0.6, 0.06666667, 0.13333334, 0.33333334},
+				},
+				{
+					ArrayOfFloat32: &[]float32{0.26666668, 0.5, .2, 0.46666667, 0.2, 0.46666667, 0.6, 0.06666667, 0.13333334, 0.3},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "int32 embeddings",
+			args: args{
+				embeddings: []interface{}{
+					[]interface{}{1, 2, 3, 4, 5, 6},
+					[]interface{}{6, 5, 4, 3, 2, 1},
+				},
+			},
+			want: []*Embedding{
+				{
+					ArrayOfInt32: &[]int32{1, 2, 3, 4, 5, 6},
+				},
+				{
+					ArrayOfInt32: &[]int32{6, 5, 4, 3, 2, 1},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewEmbeddings(tt.args.embeddings)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewEmbeddings() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !CompareEmbeddings(got, tt.want) {
 				t.Errorf("NewEmbeddings() got = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
- Added some additional ways to parse Embeddings and test them
- Added a fix in the HF tests to ensure test is ignore on 429 rate limit errors
- Cohere EF now supports the new API

Refs: #39
