### PR TITLE
fix: Making collection name mandatory in NewCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ information: [Chroma Go Docs](https://go-client.chromadb.dev/auth/)
 - ✅ Collection Delete - delete documents in collection
 - ✅ Authentication (Basic, Token with Authorization header, Token with X-Chroma-Token header)
 
-## Embedding Functions Support
+## Embedding API and Models Support
 
 - ✅ OpenAI Embedding Support
 - ✅ Cohere API (including Multi-language support)
@@ -42,6 +42,7 @@ information: [Chroma Go Docs](https://go-client.chromadb.dev/auth/)
 - ✅ Cloudflare Workers AI Embedding Support
 - ✅ TogetherAI Embedding Support
 - ✅ VoyageAI Embedding Support
+- ✅ MistralAI API Embedding Support
 
 ## Installation
 

--- a/chroma.go
+++ b/chroma.go
@@ -284,17 +284,17 @@ func (c *Client) CreateCollection(ctx context.Context, collectionName string, me
 	return NewCollection(c.ApiClient, resp.Id, resp.Name, getMetadataFromAPI(mtd), embeddingFunction, c.Tenant, c.Database), nil
 }
 
-func (c *Client) NewCollection(ctx context.Context, options ...collection.Option) (*Collection, error) {
+func (c *Client) NewCollection(ctx context.Context, name string, options ...collection.Option) (*Collection, error) {
 	b := &collection.Builder{Metadata: make(map[string]interface{})}
 	for _, option := range options {
 		if err := option(b); err != nil {
 			return nil, err
 		}
 	}
-	if b.Name == "" {
+	if name == "" {
 		return nil, fmt.Errorf("collection name cannot be empty")
 	}
-
+	b.Name = name
 	var distanceFunction types.DistanceFunction
 	if df := b.Metadata[types.HNSWSpace]; df == nil {
 		b.Metadata[types.HNSWSpace] = types.L2

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -19,16 +19,6 @@ type Builder struct {
 
 type Option func(*Builder) error
 
-func WithName(name string) Option {
-	return func(c *Builder) error {
-		if name == "" {
-			return fmt.Errorf("collection name cannot be empty")
-		}
-		c.Name = name
-		return nil
-	}
-}
-
 func WithEmbeddingFunction(embeddingFunction types.EmbeddingFunction) Option {
 	return func(c *Builder) error {
 		c.EmbeddingFunction = embeddingFunction

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -11,12 +11,6 @@ import (
 )
 
 func TestCollectionBuilder(t *testing.T) {
-	t.Run("With Name", func(t *testing.T) {
-		b := &Builder{}
-		err := WithName("test")(b)
-		require.NoError(t, err, "Unexpected error: %v", err)
-		require.Equal(t, "test", b.Name)
-	})
 
 	t.Run("With Embedding Function", func(t *testing.T) {
 		b := &Builder{}

--- a/test/chroma_client_test.go
+++ b/test/chroma_client_test.go
@@ -951,7 +951,7 @@ func Test_chroma_client(t *testing.T) {
 		require.NoError(t, errRest)
 		newCollection, err := client.NewCollection(
 			context.Background(),
-			collection.WithName("test-collection"),
+			"test-collection",
 			collection.WithMetadata("key1", "value1"),
 			collection.WithEmbeddingFunction(types.NewConsistentHashEmbeddingFunction()),
 			collection.WithHNSWDistanceFunction(types.L2),
@@ -981,7 +981,7 @@ func Test_chroma_client(t *testing.T) {
 		require.NoError(t, errRest)
 		newCollection, err := client.NewCollection(
 			context.Background(),
-			collection.WithName("test-collection"),
+			"test-collection",
 			collection.WithMetadata("key1", "value1"),
 			collection.WithEmbeddingFunction(types.NewConsistentHashEmbeddingFunction()),
 		)
@@ -1010,7 +1010,7 @@ func Test_chroma_client(t *testing.T) {
 		require.NoError(t, errRest)
 		_, err := client.NewCollection(
 			context.Background(),
-			collection.WithName("test-collection"),
+			"test-collection",
 			collection.WithMetadata("key1", "value1"),
 		)
 		require.NoError(t, err)
@@ -1027,11 +1027,12 @@ func Test_chroma_client(t *testing.T) {
 		require.Contains(t, err.Error(), "embedding function is required")
 	})
 
-	t.Run("[Err] Test With Collection Builder - no collection name", func(t *testing.T) {
+	t.Run("[Err] Test With Collection Builder - empty collection name", func(t *testing.T) {
 		_, errRest := client.Reset(context.Background())
 		require.NoError(t, errRest)
 		_, err := client.NewCollection(
 			context.Background(),
+			"",
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "collection name cannot be empty")
@@ -1042,7 +1043,7 @@ func Test_chroma_client(t *testing.T) {
 		require.NoError(t, errRest)
 		newCollection, err := client.NewCollection(
 			context.Background(),
-			collection.WithName("test-collection"),
+			"test-collection",
 			collection.WithMetadata("key1", "value1"),
 			collection.WithEmbeddingFunction(types.NewConsistentHashEmbeddingFunction()),
 			collection.WithHNSWDistanceFunction(types.L2),
@@ -1076,7 +1077,7 @@ func Test_chroma_client(t *testing.T) {
 		require.NoError(t, errRest)
 		newCollection, err := client.NewCollection(
 			context.Background(),
-			collection.WithName("test-collection"),
+			"test-collection",
 			collection.WithMetadata("key1", "value1"),
 			collection.WithEmbeddingFunction(types.NewConsistentHashEmbeddingFunction()),
 			collection.WithHNSWDistanceFunction(types.L2),


### PR DESCRIPTION
Closes #91
