### PR TITLE
Cerebras Embeddings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/amikos-tech/chroma-go)
+        - prefix(github.com/guiperry/chroma-go_cerebras)
         - blank
         - dot
       custom-order: true

--- a/README.md
+++ b/README.md
@@ -83,18 +83,18 @@ From release `0.2.0` the Chroma Go client also supports Reranking functions. The
 > There are many new changes leading up to `v0.2.0`, as documented below. If you'd like to use them please install the
 > latest version of the client.
 > ```bash
-> go get github.com/amikos-tech/chroma-go@main
+> go get github.com/guiperry/chroma-go_cerebras@main
 > ```
 
 ```bash
-go get github.com/amikos-tech/chroma-go
+go get github.com/guiperry/chroma-go_cerebras
 ```
 
 Import `v1`:
 
 ```go
 import (
-chroma "github.com/amikos-tech/chroma-go"
+chroma "github.com/guiperry/chroma-go_cerebras"
 )
 ```
 
@@ -134,7 +134,7 @@ import (
 	"fmt"
 	"log"
 
-	chroma "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	chroma "github.com/guiperry/chroma-go_cerebras/pkg/api/v2"
 )
 
 func main() {

--- a/chroma.go
+++ b/chroma.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver" //nolint:gci
-	"github.com/amikos-tech/chroma-go/collection"
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	defaultef "github.com/amikos-tech/chroma-go/pkg/embeddings/default_ef"
-	openapiclient "github.com/amikos-tech/chroma-go/swagger"
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/collection"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	defaultef "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/default_ef"
+	openapiclient "github.com/guiperry/chroma-go_cerebras/swagger"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 type ClientConfiguration struct {

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -3,8 +3,8 @@ package collection
 import (
 	"fmt"
 
-	"github.com/amikos-tech/chroma-go/metadata"
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/metadata"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 type Builder struct {

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func TestCollectionBuilder(t *testing.T) {

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -15,7 +15,7 @@ package main
 import (
 	"context"
 	"log"
-	chroma "github.com/amikos-tech/chroma-go"
+	chroma "github.com/guiperry/chroma-go_cerebras"
 )
 
 func main() {
@@ -39,8 +39,8 @@ package main
 import (
     "context"
     "log"
-    chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/types"
+    chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func main() {
@@ -66,8 +66,8 @@ package main
 import (
     "context"
     "log"
-    chroma "github.com/amikos-tech/chroma-go"
-    "github.com/amikos-tech/chroma-go/types"
+    chroma "github.com/guiperry/chroma-go_cerebras"
+    "github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func main() {
@@ -93,8 +93,8 @@ package main
 import (
     "context"
     "log"
-    chroma "github.com/amikos-tech/chroma-go"
-    "github.com/amikos-tech/chroma-go/types"
+    chroma "github.com/guiperry/chroma-go_cerebras"
+    "github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func main() {

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -28,7 +28,7 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go"
+	chroma "github.com/guiperry/chroma-go_cerebras"
 )
 
 func main() {

--- a/docs/docs/embeddings.md
+++ b/docs/docs/embeddings.md
@@ -36,7 +36,7 @@ import (
 	"context"
 	"fmt"
 
-	defaultef "github.com/amikos-tech/chroma-go/pkg/embeddings/default_ef"
+	defaultef "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/default_ef"
 )
 
 func main() {
@@ -81,7 +81,7 @@ import (
 	"fmt"
 	"os"
 
-	openai "github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	openai "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
 )
 
 func main() {
@@ -110,7 +110,7 @@ import (
 	"fmt"
 	"os"
 
-	cohere "github.com/amikos-tech/chroma-go/pkg/embeddings/cohere"
+	cohere "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/cohere"
 )
 
 func main() {
@@ -136,7 +136,7 @@ import (
 	"fmt"
 	"os"
 
-	huggingface "github.com/amikos-tech/chroma-go/pkg/embeddings/hf"
+	huggingface "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/hf"
 )
 
 func main() {
@@ -165,7 +165,7 @@ import (
 	"context"
 	"fmt"
 
-	huggingface "github.com/amikos-tech/chroma-go/hf"
+	huggingface "github.com/guiperry/chroma-go_cerebras/hf"
 )
 
 func main() {
@@ -205,7 +205,7 @@ package main
 import (
 	"context"
 	"fmt"
-	ollama "github.com/amikos-tech/chroma-go/pkg/embeddings/ollama"
+	ollama "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/ollama"
 )
 
 func main() {
@@ -242,7 +242,7 @@ package main
 import (
 	"context"
 	"fmt"
-	cf "github.com/amikos-tech/chroma-go/pkg/embeddings/cloudflare"
+	cf "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/cloudflare"
 )
 
 func main() {
@@ -279,7 +279,7 @@ package main
 import (
 	"context"
 	"fmt"
-	t "github.com/amikos-tech/chroma-go/pkg/embeddings/together"
+	t "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/together"
 )
 
 func main() {
@@ -314,7 +314,7 @@ package main
 import (
 	"context"
 	"fmt"
-	t "github.com/amikos-tech/chroma-go/pkg/embeddings/voyage"
+	t "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/voyage"
 )
 
 func main() {
@@ -349,7 +349,7 @@ package main
 import (
 	"context"
 	"fmt"
-	g "github.com/amikos-tech/chroma-go/pkg/embeddings/gemini"
+	g "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/gemini"
 )
 
 func main() {
@@ -382,7 +382,7 @@ package main
 import (
 	"context"
 	"fmt"
-	mistral "github.com/amikos-tech/chroma-go/pkg/embeddings/mistral"
+	mistral "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/mistral"
 )
 
 func main() {
@@ -415,7 +415,7 @@ package main
 import (
 	"context"
 	"fmt"
-	nomic "github.com/amikos-tech/chroma-go/pkg/embeddings/nomic"
+	nomic "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/nomic"
 )
 
 func main() {
@@ -449,7 +449,7 @@ package main
 import (
 	"context"
 	"fmt"
-	jina "github.com/amikos-tech/chroma-go/pkg/embeddings/jina"
+	jina "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/jina"
 )
 
 func main() {

--- a/docs/docs/filtering.md
+++ b/docs/docs/filtering.md
@@ -16,10 +16,10 @@ package main
 import (
 	"context"
 	"fmt"
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
-	"github.com/amikos-tech/chroma-go/types"
-	"github.com/amikos-tech/chroma-go/where"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
+	"github.com/guiperry/chroma-go_cerebras/types"
+	"github.com/guiperry/chroma-go_cerebras/where"
 )
 
 func main() {
@@ -70,10 +70,10 @@ package main
 import (
 	"context"
 	"fmt"
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
-	"github.com/amikos-tech/chroma-go/types"
-	"github.com/amikos-tech/chroma-go/where_document"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
+	"github.com/guiperry/chroma-go_cerebras/types"
+	"github.com/guiperry/chroma-go_cerebras/where_document"
 )
 
 func main() {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,7 +7,7 @@ An experimental Go client for ChromaDB.
 Add the library to your project:
 
 ```bash
-go get github.com/amikos-tech/chroma-go
+go get github.com/guiperry/chroma-go_cerebras
 ```
 
 ## Getting Started
@@ -25,9 +25,9 @@ Import the library:
 package main
 
 import (
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/collection"
-	"github.com/amikos-tech/chroma-go/types"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/collection"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 ```
 
@@ -41,7 +41,7 @@ New client:
 package main
 
 import (
-	chroma "github.com/amikos-tech/chroma-go"
+	chroma "github.com/guiperry/chroma-go_cerebras"
 	"fmt"
 )
 
@@ -75,9 +75,9 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/types"
-	openai "github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/types"
+	openai "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
 )
 
 func main() {
@@ -131,9 +131,9 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
-	"github.com/amikos-tech/chroma-go/types"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func main() {
@@ -181,8 +181,8 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
 )
 
 func main() {
@@ -226,8 +226,8 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
 )
 
 func main() {

--- a/docs/docs/rerankers.md
+++ b/docs/docs/rerankers.md
@@ -18,7 +18,7 @@ package rerankings
 import (
 	"context"
 
-	chromago "github.com/amikos-tech/chroma-go"
+	chromago "github.com/guiperry/chroma-go_cerebras"
 )
 
 type RankedResult struct {
@@ -53,7 +53,7 @@ package main
 import (
 	"context"
 	"fmt"
-	cohere "github.com/amikos-tech/chroma-go/pkg/rerankings/cohere"
+	cohere "github.com/guiperry/chroma-go_cerebras/pkg/rerankings/cohere"
 	"os"
 )
 
@@ -97,7 +97,7 @@ package main
 import (
 	"context"
 	"fmt"
-	jina "github.com/amikos-tech/chroma-go/pkg/rerankings/jina"
+	jina "github.com/guiperry/chroma-go_cerebras/pkg/rerankings/jina"
 	"os"
 )
 
@@ -141,7 +141,7 @@ package main
 import (
 	"context"
 	"fmt"
-	hf "github.com/amikos-tech/chroma-go/pkg/rerankings/hf"
+	hf "github.com/guiperry/chroma-go_cerebras/pkg/rerankings/hf"
 	"os"
 )
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: ChromaDB Go Client
 site_url: https://go-client.chromadb.dev
-repo_url: https://github.com/amikos-tech/chroma-go
+repo_url: https://github.com/guiperry/chroma-go_cerebras
 copyright: "Amikos Tech LTD, 2024 (core ChromaDB contributors)"
 theme:
   name: material

--- a/examples/v2/basic/go.mod
+++ b/examples/v2/basic/go.mod
@@ -2,9 +2,9 @@ module main
 
 go 1.24
 
-replace github.com/amikos-tech/chroma-go => ../../../
+replace github.com/guiperry/chroma-go_cerebras => ../../../
 
-require github.com/amikos-tech/chroma-go v0.2.0
+require github.com/guiperry/chroma-go_cerebras v0.2.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/examples/v2/basic/main.go
+++ b/examples/v2/basic/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	chroma "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	chroma "github.com/guiperry/chroma-go_cerebras/pkg/api/v2"
 )
 
 func main() {

--- a/examples/v2/custom_embedding_function/go.mod
+++ b/examples/v2/custom_embedding_function/go.mod
@@ -2,9 +2,9 @@ module main
 
 go 1.24.1
 
-replace github.com/amikos-tech/chroma-go => ../../../
+replace github.com/guiperry/chroma-go_cerebras => ../../../
 
-require github.com/amikos-tech/chroma-go v0.2.0
+require github.com/guiperry/chroma-go_cerebras v0.2.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/examples/v2/embedding_function_basic/go.mod
+++ b/examples/v2/embedding_function_basic/go.mod
@@ -2,9 +2,9 @@ module main
 
 go 1.24.1
 
-replace github.com/amikos-tech/chroma-go => ../../../
+replace github.com/guiperry/chroma-go_cerebras => ../../../
 
-require github.com/amikos-tech/chroma-go v0.2.0
+require github.com/guiperry/chroma-go_cerebras v0.2.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/examples/v2/embedding_function_basic/main.go
+++ b/examples/v2/embedding_function_basic/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	chroma "github.com/amikos-tech/chroma-go/pkg/api/v2"
-	openai "github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	chroma "github.com/guiperry/chroma-go_cerebras/pkg/api/v2"
+	openai "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/openai"
 )
 
 func main() {

--- a/examples/v2/reranking_function_basic/go.mod
+++ b/examples/v2/reranking_function_basic/go.mod
@@ -2,9 +2,9 @@ module main
 
 go 1.24.1
 
-replace github.com/amikos-tech/chroma-go => ../../../
+replace github.com/guiperry/chroma-go_cerebras => ../../../
 
-require github.com/amikos-tech/chroma-go v0.2.0
+require github.com/guiperry/chroma-go_cerebras v0.2.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/examples/v2/tenant_and_db/go.mod
+++ b/examples/v2/tenant_and_db/go.mod
@@ -2,9 +2,9 @@ module main
 
 go 1.24.1
 
-replace github.com/amikos-tech/chroma-go => ../../../
+replace github.com/guiperry/chroma-go_cerebras => ../../../
 
-require github.com/amikos-tech/chroma-go v0.2.0
+require github.com/guiperry/chroma-go_cerebras v0.2.0
 
 require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect

--- a/examples/v2/tenant_and_db/main.go
+++ b/examples/v2/tenant_and_db/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	chroma "github.com/amikos-tech/chroma-go/pkg/api/v2"
 	"log"
 	"math/rand"
+
+	chroma "github.com/guiperry/chroma-go_cerebras/pkg/api/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/amikos-tech/chroma-go
+module github.com/guiperry/chroma-go_cerebras
 
 go 1.23.0
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,7 +1,7 @@
 package metadata
 
 import (
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 type MetadataBuilder struct {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/amikos-tech/chroma-go/test"
+	"github.com/guiperry/chroma-go_cerebras/test"
 )
 
 func TestWithMetadata(t *testing.T) {

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
-	defaultef "github.com/amikos-tech/chroma-go/pkg/embeddings/default_ef"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
+	defaultef "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/default_ef"
 )
 
 type Client interface {

--- a/pkg/api/v2/client_http.go
+++ b/pkg/api/v2/client_http.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
 )
 
 type APIClientV2 struct {

--- a/pkg/api/v2/client_http_integration_test.go
+++ b/pkg/api/v2/client_http_integration_test.go
@@ -5,12 +5,13 @@ package v2
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/Masterminds/semver"
 	"github.com/docker/docker/api/types/container"
@@ -20,7 +21,7 @@ import (
 	tcchroma "github.com/testcontainers/testcontainers-go/modules/chroma"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 func TestClientHTTPIntegration(t *testing.T) {

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/require"
 
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 func MetadataModel() gopter.Gen {

--- a/pkg/api/v2/collection.go
+++ b/pkg/api/v2/collection.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Collection interface {

--- a/pkg/api/v2/collection_http.go
+++ b/pkg/api/v2/collection_http.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type CollectionModel struct {

--- a/pkg/api/v2/collection_http_integration_test.go
+++ b/pkg/api/v2/collection_http_integration_test.go
@@ -5,15 +5,16 @@ package v2
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 )

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // func bootStrapServer(t *testing.T) *httptest.Server {

--- a/pkg/api/v2/record.go
+++ b/pkg/api/v2/record.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Record interface {

--- a/pkg/api/v2/record_test.go
+++ b/pkg/api/v2/record_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 func TestSimpleRecord(t *testing.T) {

--- a/pkg/api/v2/results.go
+++ b/pkg/api/v2/results.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type GetResult interface {

--- a/pkg/api/v2/results_test.go
+++ b/pkg/api/v2/results_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 func TestGetResultDeserialization(t *testing.T) {

--- a/pkg/commons/cohere/cohere_commons.go
+++ b/pkg/commons/cohere/cohere_commons.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/pkg/errors"
 
-	httpc "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	httpc "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type APIVersion string

--- a/pkg/embeddings/cerebras/README.md
+++ b/pkg/embeddings/cerebras/README.md
@@ -1,0 +1,151 @@
+# Cerebras LLM Embedding Generation
+
+## Overview
+
+This document outlines an innovative approach to using Cerebras LLM's "tool calling" functionality for embedding generation. Rather than delegating to an external service, we leverage the LLM's inherent capabilities to generate embeddings directly.
+
+Our findings suggest that Cerebras LLM models can generate embeddings effectively, making the concept of an `EmbeddingToolExecutor` unnecessary for this specific task. Our vision is to allow Cerebras (and its underlying LLM models) to handle embeddings end-to-end.
+
+## Technical Approach
+
+The Cerebras API supports a chat/completions style endpoint with a `tools` parameter. This allows us to define functions that the LLM can choose to "call," outputting a structured JSON object with the function name and necessary arguments. Our application then processes this output and continues the conversation.
+
+Our experimental `cerebras.go` file, with `EmbeddingToolSchema`, `EmbeddingParameters`, and `EmbeddingResults`, provides a foundation for defining such a tool. The key is structuring these definitions to align with the Cerebras API's expectations.
+
+## Core Implementation
+
+### Architecture Components
+
+- **Client for Chat/Completions**: Designed to interact with the Cerebras chat/completions endpoint
+- **Tool Definition**: Structures and helpers to define the embedding tool schema
+- **Prompt Engineering**: Crafting specific prompts for embedding generation
+- **Structured JSON Output**: Using `response_format` with `json_schema` for predictable output
+- **Parsing**: Extracting embedding vectors from JSON responses
+- **Result Formatting**: Properly formatting output for the Cerebras LLM
+
+This approach is more experimental than calling a dedicated embedding API, as it depends on the LLM's ability to follow complex instructions and output structured data.
+
+## Multi-Turn Conversation Flow
+
+### Turn 1: Request with Tool Definition
+
+**Client to LLM:**
+```
+"Please generate embeddings for these texts: ['text A', 'text B'], considering task_type='retrieval', 
+instruction='Focus on semantic meaning for search', and normalize_output=true. 
+Use the advanced_embedding_generator tool."
+```
+
+The API call includes the definition of the `advanced_embedding_generator` tool, specifying its parameters:
+- `input_texts`
+- `task_type`
+- `instruction`
+- `normalize_output`
+
+### Turn 1 Response: Tool Invocation
+
+The LLM, understanding the request and seeing the tool, decides to "call" it.
+
+**Response:**
+```json
+{
+  "id": "call_abc123",
+  "type": "function",
+  "function": {
+    "name": "advanced_embedding_generator",
+    "arguments": "{\"input_texts\": [\"text A\", \"text B\"], \"task_type\": \"retrieval\", \"instruction\": \"Focus on semantic meaning for search\", \"normalize_output\": true}"
+  }
+}
+```
+
+The LLM has essentially confirmed the parameters it will use.
+
+### Turn 2: Execute Tool & Request Structured Output
+
+Our client receives this response. Instead of calling an external API, we instruct the same LLM to perform the actual embedding generation based on the arguments it provided, and to format the output according to a specific JSON schema.
+
+**Client to LLM:**
+```
+"Okay, proceed with the advanced_embedding_generator call (ID: call_abc123). For each input text, 
+generate the embedding. Return the results as a JSON object strictly adhering to this schema: 
+{'results': [{'source_text': '...', 'embedding_vector': [...], 'normalized': true/false}], 
+'model_used': '...', 'usage_info': {'prompt_tokens': ..., 'completion_tokens': ..., 'total_tokens': ...}}."
+```
+
+This API call uses the `response_format` parameter with the detailed JSON schema for the embeddings and usage info.
+
+### Turn 2 Response: Structured Embedding Output
+
+The LLM processes this, generates the embeddings, and formats the output according to the `response_format` schema.
+
+**Response:** A chat message containing the JSON string with embeddings, model info, and usage.
+
+This makes the "tool" a mechanism for the LLM to acknowledge and structure the parameters of a complex internal task, followed by a highly specific prompt that elicits the structured output.
+
+## Technical Implementation Details
+
+### EmbeddingToolParameters
+
+- **InputTexts**: Changed from a single `InputText` to `InputTexts []string` to handle batching
+- **TaskType, Instruction, NormalizeOutput**: Added with defaults to guide the LLM
+
+### EmbeddingToolOutput & EmbeddingResultItem
+
+- Structure demanded from the LLM in Turn 2 using `response_format`
+- **EmbeddingResultItem** includes:
+  - `SourceText`
+  - `EmbeddingVector`
+  - `Normalized` (confirmation of normalization attempt)
+- **EmbeddingToolOutput** wraps results and adds:
+  - `ModelUsed`
+  - `UsageInfo`
+
+### Key Functions
+
+- **getEmbeddingToolDefinition()**: Creates the JSON schema for the tool
+- **getEmbeddingOutputResponseFormat()**: Defines the JSON schema for expected output (with `strict: true`)
+
+### EmbeddingFunction
+
+- Configurable defaults via `EmbeddingFunctionOptions`
+- **EmbedDocuments Orchestration**:
+  - **Turn 1**: Sends initial prompt with texts, parameters, and tool definition
+  - **Turn 2**:
+    - Parses arguments from the LLM's tool call
+    - Constructs a specific prompt for embedding generation
+    - Uses `ResponseFormat` to enforce the output schema
+    - Uses low `Temperature` (e.g., 0.1) for deterministic JSON output
+    - Parses JSON to extract embeddings
+
+### Error Handling and Robustness
+
+- Checks for tool calling issues
+- Success depends on the LLM's ability to follow instructions for both tool use and structured JSON output
+
+## Innovation and Vision Alignment
+
+- **LLM-Powered Structuring**: Using tool-calling to establish parameters for an internal task
+- **Structured Output Enforcement**: Using `response_format` for reliable JSON output
+- **Flexibility**: Nuanced control via natural language instructions
+- **Single LLM Endpoint**: All processing through the chat/completions endpoint
+
+## Challenges and Considerations
+
+### LLM Reliability Requirements
+
+- Understanding when to use the defined tool
+- Correctly populating tool call arguments
+- Following complex instructions for embedding generation
+- Strictly adhering to the JSON schema
+
+### Other Considerations
+
+- **Prompt Engineering**: Critical prompts requiring iteration and testing
+- **Latency**: Two LLM roundtrips introduce more latency than direct API calls
+- **Cost**: Two LLM calls likely more expensive
+- **Normalization**: May require client-side handling if LLM struggles
+- **Token Limits**: JSON output for embeddings can be large
+
+## Conclusion
+
+This sophisticated approach treats the LLM as a flexible processing unit. While experimental, it offers a promising path forward. Thorough testing with the actual Cerebras API and models will be essential to validate this approach.

--- a/pkg/embeddings/cerebras/cerebras.go
+++ b/pkg/embeddings/cerebras/cerebras.go
@@ -1,0 +1,450 @@
+package cerebras
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+// CerebrasModel represents the available LLM models from Cerebras.
+type CerebrasModel string
+
+const (
+	DefaultBaseURL = "https://api.cerebras.ai/v1/chat/completions" // Example, adjust. This should point to the chat/completions endpoint base.
+
+	Llama4Scout17B16EInstruct CerebrasModel = "llama-4-scout-17b-16e-instruct"
+	Llama3_1_8B               CerebrasModel = "llama3.1-8b"
+	Llama3_3_70B              CerebrasModel = "llama-3.3-70b"
+	Qwen3_32B                 CerebrasModel = "qwen-3-32b"
+
+	DefaultChatModel             = Llama3_1_8B // Choose a default model
+	EmbeddingToolName            = "advanced_embedding_generator"
+	DefaultEmbeddingTaskType     = "retrieval_document"
+	DefaultEmbeddingInstruction  = "Generate a dense vector representation of the text suitable for semantic search."
+	DefaultEmbeddingMaxTokens    = 512 // Max tokens for the LLM's response containing the embedding JSON
+)
+
+// Client is the Cerebras API client for chat completions with tool use.
+type Client struct {
+	BaseURL        string
+	APIKey         string
+	DefaultModel   embeddings.EmbeddingModel
+	HTTPClient     *http.Client
+	DefaultHeaders map[string]string
+}
+
+// Option is a function that configures a Client.
+type Option func(*Client) error
+
+// NewClient creates a new Cerebras client.
+func NewClient(apiKey string, opts ...Option) (*Client, error) {
+	c := &Client{
+		APIKey:       apiKey,
+		BaseURL:      DefaultBaseURL,
+		DefaultModel: embeddings.EmbeddingModel(DefaultChatModel),
+		HTTPClient:   &http.Client{},
+	}
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, errors.Wrap(err, "failed to apply Cerebras option")
+		}
+	}
+	if err := c.validate(); err != nil {
+		return nil, errors.Wrap(err, "failed to validate Cerebras client options")
+	}
+	return c, nil
+}
+
+func (c *Client) validate() error { /* ... same as before ... */
+	if c.APIKey == "" {
+		return errors.New("API key is required")
+	}
+	if c.BaseURL == "" {
+		return errors.New("base URL is required")
+	}
+	if _, err := url.ParseRequestURI(c.BaseURL); err != nil {
+		return errors.Wrap(err, "invalid base URL")
+	}
+	return nil
+}
+
+// --- Cerebras API Request/Response Structs (Chat Completions & Tools) ---
+type ChatMessage struct {
+	Role       string      `json:"role"` // "system", "user", "assistant", "tool"
+	Content    string      `json:"content"`
+	ToolCallID string      `json:"tool_call_id,omitempty"` // For role: "tool"
+	Name       string      `json:"name,omitempty"`         // For role: "tool", the name of the tool
+	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`   // For role: "assistant" when it calls tools
+}
+
+type ToolFunctionDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Parameters  any    `json:"parameters,omitempty"` // JSON Schema object
+}
+
+type ToolDefinition struct {
+	Type     string                 `json:"type"` // "function"
+	Function ToolFunctionDefinition `json:"function"`
+}
+
+type ToolCall struct {
+	ID       string              `json:"id"`
+	Type     string              `json:"type"` // "function"
+	Function ToolCallFunction `json:"function"`
+}
+
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string
+}
+
+type JSONSchemaDefinition struct { /* ... same as before ... */
+	Type        string                              `json:"type"`
+	Properties  map[string]JSONSchemaDefinition `json:"properties,omitempty"`
+	Items       *JSONSchemaDefinition               `json:"items,omitempty"`
+	Description string                              `json:"description,omitempty"`
+	Required    []string                            `json:"required,omitempty"`
+}
+type JSONSchemaEnvelope struct { /* ... same as before ... */
+	Name   string               `json:"name"`
+	Strict bool                 `json:"strict"`
+	Schema JSONSchemaDefinition `json:"schema"`
+}
+type ResponseFormat struct { /* ... same as before ... */
+	Type       string             `json:"type"`
+	JSONSchema JSONSchemaEnvelope `json:"json_schema"`
+}
+
+type ChatCompletionRequest struct {
+	Model           string           `json:"model"`
+	Messages        []ChatMessage    `json:"messages"`
+	Tools           []ToolDefinition `json:"tools,omitempty"`
+	ToolChoice      any              `json:"tool_choice,omitempty"` // string ("none", "auto", "required") or object
+	ResponseFormat  *ResponseFormat  `json:"response_format,omitempty"`
+	Temperature     *float32         `json:"temperature,omitempty"`
+	MaxTokens       *int             `json:"max_completion_tokens,omitempty"`
+	// ... other parameters
+}
+
+type ChatCompletionChoice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"` // e.g., "stop", "tool_calls"
+}
+
+type ChatCompletionResponse struct { /* ... same as before ... */
+	ID      string                 `json:"id"`
+	Object  string                 `json:"object"`
+	Created int64                  `json:"created"`
+	Model   string                 `json:"model"`
+	Choices []ChatCompletionChoice `json:"choices"`
+}
+
+// --- Embedding Tool Specific Structs ---
+type EmbeddingToolParameters struct {
+	InputTexts      []string `json:"input_texts"`
+	TaskType        string   `json:"task_type,omitempty"`
+	Instruction     string   `json:"instruction,omitempty"`
+	NormalizeOutput bool     `json:"normalize_output,omitempty"`
+}
+
+type EmbeddingResultItem struct {
+	SourceText      string    `json:"source_text"`
+	EmbeddingVector []float32 `json:"embedding_vector"`
+	Normalized      bool      `json:"normalized"` // Indicates if the LLM claims to have normalized it
+}
+
+type EmbeddingToolOutput struct {
+	Results    []EmbeddingResultItem `json:"results"`
+	ModelUsed  string                `json:"model_used"` // Model reported by LLM for the embedding task
+	UsageInfo  map[string]int        `json:"usage_info,omitempty"` // e.g., {"prompt_tokens": N, "completion_tokens": M, "total_tokens": P}
+}
+
+func getEmbeddingToolDefinition() ToolDefinition {
+	return ToolDefinition{
+		Type: "function",
+		Function: ToolFunctionDefinition{
+			Name:        EmbeddingToolName,
+			Description: "Generates dense vector embeddings for a list of input texts based on specified parameters.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"input_texts": map[string]any{
+						"type":        "array",
+						"description": "A list of text strings to embed.",
+						"items":       map[string]any{"type": "string"},
+					},
+					"task_type": map[string]any{
+						"type":        "string",
+						"description": "Type of task for which the embedding is generated (e.g., 'retrieval_document', 'similarity', 'classification'). Defaults to 'retrieval_document'.",
+						"default":     DefaultEmbeddingTaskType,
+					},
+					"instruction": map[string]any{
+						"type":        "string",
+						"description": "Specific instruction to guide the embedding generation process. Defaults to a general semantic search instruction.",
+						"default":     DefaultEmbeddingInstruction,
+					},
+					"normalize_output": map[string]any{
+						"type":        "boolean",
+						"description": "Whether the output embedding vectors should be normalized (L2 norm). Defaults to false.",
+						"default":     false,
+					},
+				},
+				"required": []string{"input_texts"},
+			},
+		},
+	}
+}
+
+func getEmbeddingOutputResponseFormat() *ResponseFormat {
+	return &ResponseFormat{
+		Type: "json_schema",
+		JSONSchema: JSONSchemaEnvelope{
+			Name:   "embedding_tool_output_schema",
+			Strict: true, // Crucial for reliable parsing
+			Schema: JSONSchemaDefinition{
+				Type: "object",
+				Properties: map[string]JSONSchemaDefinition{
+					"results": {
+						Type: "array",
+						Items: &JSONSchemaDefinition{
+							Type: "object",
+							Properties: map[string]JSONSchemaDefinition{
+								"source_text":      {Type: "string"},
+								"embedding_vector": {Type: "array", Items: &JSONSchemaDefinition{Type: "number"}},
+								"normalized":       {Type: "boolean"},
+							},
+							Required: []string{"source_text", "embedding_vector", "normalized"},
+						},
+					},
+					"model_used": {Type: "string"},
+					"usage_info": {
+						Type: "object",
+						Properties: map[string]JSONSchemaDefinition{
+							"prompt_tokens":     {Type: "integer"},
+							"completion_tokens": {Type: "integer"},
+							"total_tokens":      {Type: "integer"},
+						},
+						// Not strictly required as LLM might not always provide it
+					},
+				},
+				Required: []string{"results", "model_used"},
+			},
+		},
+	}
+}
+
+func (c *Client) CreateChatCompletion(ctx context.Context, req *ChatCompletionRequest) (*ChatCompletionResponse, error) { /* ... same as before ... */
+	if req.Model == "" {
+		req.Model = string(c.DefaultModel)
+	}
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal chat completion request")
+	}
+	endpoint, err := url.JoinPath(c.BaseURL, "chat/completions")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to join URL path for chat/completions")
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create HTTP request")
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+	for k, v := range c.DefaultHeaders {
+		httpReq.Header.Set(k, v)
+	}
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to send request to Cerebras chat API")
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response body")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("Cerebras chat API request failed with status %s: %s", resp.Status, string(bodyBytes))
+	}
+	var chatResp ChatCompletionResponse
+	if err := json.Unmarshal(bodyBytes, &chatResp); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal Cerebras chat response")
+	}
+	return &chatResp, nil
+}
+
+// --- EmbeddingFunction Implementation ---
+var _ embeddings.EmbeddingFunction = (*EmbeddingFunction)(nil)
+
+type EmbeddingFunction struct {
+	client          *Client
+	taskType        string // Default task type for this function instance
+	instruction     string // Default instruction
+	normalizeOutput bool   // Default normalization
+}
+
+type EmbeddingFunctionOption func(*EmbeddingFunction)
+
+func WithTaskType(taskType string) EmbeddingFunctionOption {
+	return func(ef *EmbeddingFunction) { ef.taskType = taskType }
+}
+func WithInstruction(instruction string) EmbeddingFunctionOption {
+	return func(ef *EmbeddingFunction) { ef.instruction = instruction }
+}
+func WithNormalizeOutput(normalize bool) EmbeddingFunctionOption {
+	return func(ef *EmbeddingFunction) { ef.normalizeOutput = normalize }
+}
+
+func NewEmbeddingFunction(apiKey string, clientOpts []Option, efOpts ...EmbeddingFunctionOption) (*EmbeddingFunction, error) {
+	client, err := NewClient(apiKey, clientOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Cerebras client for embedding function")
+	}
+	ef := &EmbeddingFunction{
+		client:          client,
+		taskType:        DefaultEmbeddingTaskType,
+		instruction:     DefaultEmbeddingInstruction,
+		normalizeOutput: false,
+	}
+	for _, opt := range efOpts {
+		opt(ef)
+	}
+	return ef, nil
+}
+
+func (ef *EmbeddingFunction) EmbedDocuments(ctx context.Context, documents []string) ([]embeddings.Embedding, error) {
+	if len(documents) == 0 {
+		return embeddings.NewEmptyEmbeddings(), nil
+	}
+
+	// Turn 1: Ask LLM to use the tool
+	initialPrompt := fmt.Sprintf("Please generate embeddings for the following %d texts using the '%s' tool. Texts: %s. TaskType: '%s', Instruction: '%s', NormalizeOutput: %v.",
+		len(documents), EmbeddingToolName, "[\""+strings.Join(documents, "\", \"")+"\"]", ef.taskType, ef.instruction, ef.normalizeOutput)
+
+	initialMessages := []ChatMessage{
+		{Role: "system", Content: "You are an assistant that can use tools to perform tasks, including generating text embeddings."},
+		{Role: "user", Content: initialPrompt},
+	}
+
+	toolDef := getEmbeddingToolDefinition()
+	maxTokensForToolCall := 100 // Usually small for tool call confirmation
+	reqTurn1 := &ChatCompletionRequest{
+		Model:      string(ef.client.DefaultModel),
+		Messages:   initialMessages,
+		Tools:      []ToolDefinition{toolDef},
+		ToolChoice: "auto", // or `map[string]any{"type": "function", "function": map[string]string{"name": EmbeddingToolName}}` to force
+		MaxTokens:  &maxTokensForToolCall,
+	}
+
+	respTurn1, err := ef.client.CreateChatCompletion(ctx, reqTurn1)
+	if err != nil {
+		return nil, errors.Wrap(err, "turn 1: failed to request tool use from LLM")
+	}
+
+	if len(respTurn1.Choices) == 0 || respTurn1.Choices[0].FinishReason != "tool_calls" || len(respTurn1.Choices[0].Message.ToolCalls) == 0 {
+		return nil, errors.Errorf("turn 1: LLM did not call the embedding tool as expected. Finish reason: %s, Response: %+v", respTurn1.Choices[0].FinishReason, respTurn1.Choices[0].Message)
+	}
+
+	toolCall := respTurn1.Choices[0].Message.ToolCalls[0]
+	if toolCall.Function.Name != EmbeddingToolName {
+		return nil, errors.Errorf("turn 1: LLM called an unexpected tool: %s", toolCall.Function.Name)
+	}
+
+	var toolParams EmbeddingToolParameters
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &toolParams); err != nil {
+		return nil, errors.Wrapf(err, "turn 1: failed to unmarshal tool arguments: %s", toolCall.Function.Arguments)
+	}
+
+	// Turn 2: Instruct LLM to "execute" the tool call and provide structured JSON output
+	// We use the parameters confirmed by the LLM in toolParams.
+	// The prompt for turn 2 needs to be carefully crafted.
+	textsForEmbeddingJson, _ := json.Marshal(toolParams.InputTexts)
+	promptTurn2 := fmt.Sprintf(
+		"You have decided to call the '%s' tool with ID '%s' and the following arguments: TaskType='%s', Instruction='%s', NormalizeOutput=%v, InputTexts=%s. "+
+			"Now, please execute this and provide the results. "+
+			"Generate the embeddings for each input text. "+
+			"Your response MUST be a single JSON object strictly adhering to the schema provided in the 'response_format'. "+
+			"The JSON object must contain 'results' (an array of objects, each with 'source_text', 'embedding_vector', and 'normalized' boolean), "+
+			"'model_used' (string, the name of the model you used for this embedding generation), and optionally 'usage_info' (object with token counts).",
+		EmbeddingToolName, toolCall.ID, toolParams.TaskType, toolParams.Instruction, toolParams.NormalizeOutput, string(textsForEmbeddingJson))
+
+	messagesTurn2 := []ChatMessage{
+		// It's good to include the conversation history that led to the tool call
+		{Role: "system", Content: "You are an assistant that can use tools to perform tasks, including generating text embeddings."},
+		{Role: "user", Content: initialPrompt}, // Original user request
+		respTurn1.Choices[0].Message,          // Assistant's response calling the tool
+		// Now, the message that "simulates" the tool execution result, but is actually a new instruction
+		// This is a bit of a conceptual leap. The Cerebras API expects a `role: "tool"` message here.
+		// However, the *content* of that tool message is what we're debating.
+		// Instead of providing the *actual* embedding (which we don't have yet),
+		// we're using this turn to *request* the embedding in a structured way.
+		// A more direct approach for Turn 2 might be a new User message.
+		// Let's try a new User message for Turn 2 for clarity of instruction to the LLM.
+		{Role: "user", Content: promptTurn2},
+	}
+
+	maxTokensForResult := DefaultEmbeddingMaxTokens * len(documents) // Estimate, adjust based on embedding size
+	if maxTokensForResult == 0 { maxTokensForResult = 2048 } // Fallback
+
+	reqTurn2 := &ChatCompletionRequest{
+		Model:          string(ef.client.DefaultModel),
+		Messages:       messagesTurn2,
+		ResponseFormat: getEmbeddingOutputResponseFormat(), // CRITICAL for getting structured JSON
+		MaxTokens:      &maxTokensForResult,
+		Temperature:    ptrFloat32(0.1), // Low temperature for deterministic JSON output
+	}
+
+	respTurn2, err := ef.client.CreateChatCompletion(ctx, reqTurn2)
+	if err != nil {
+		return nil, errors.Wrap(err, "turn 2: failed to get structured embedding output from LLM")
+	}
+
+	if len(respTurn2.Choices) == 0 {
+		return nil, errors.New("turn 2: no response choices from LLM for embedding generation")
+	}
+
+	var embeddingOutput EmbeddingToolOutput
+	llmResponseContent := respTurn2.Choices[0].Message.Content
+	if err := json.Unmarshal([]byte(llmResponseContent), &embeddingOutput); err != nil {
+		return nil, errors.Wrapf(err, "turn 2: failed to unmarshal LLM response into EmbeddingToolOutput. Content: %s", llmResponseContent)
+	}
+
+	// Convert to standard embeddings.Embedding type
+	finalEmbeddings := make([]embeddings.Embedding, len(embeddingOutput.Results))
+	for i, item := range embeddingOutput.Results {
+		// Sanity check
+		// if i < len(documents) && item.SourceText != documents[i] {
+		// log.Printf("Warning: Source text mismatch in LLM output. Expected '%s', got '%s'", documents[i], item.SourceText)
+		// }
+		finalEmbeddings[i] = embeddings.NewEmbeddingFromFloat32(item.EmbeddingVector)
+	}
+
+	return finalEmbeddings, nil
+}
+
+func (ef *EmbeddingFunction) EmbedQuery(ctx context.Context, document string) (embeddings.Embedding, error) {
+	results, err := ef.EmbedDocuments(ctx, []string{document})
+	if err != nil {
+		return nil, errors.Wrap(err, "EmbedQuery failed")
+	}
+	if len(results) == 0 {
+		return nil, errors.New("EmbedQuery returned no results")
+	}
+	return results[0], nil
+}
+
+func ptrFloat32(f float32) *float32 { return &f }
+

--- a/pkg/embeddings/cerebras/cerebras.go
+++ b/pkg/embeddings/cerebras/cerebras.go
@@ -1,4 +1,5 @@
 package cerebras
+
 import (
 	"bytes"
 	"context"
@@ -11,8 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // CerebrasModel represents the available LLM models from Cerebras.

--- a/pkg/embeddings/cerebras/cerebras.go
+++ b/pkg/embeddings/cerebras/cerebras.go
@@ -46,6 +46,14 @@ type Client struct {
 // Option is a function that configures a Client.
 type Option func(*Client) error
 
+// WithAPIKey sets the API key for the client.
+func WithAPIKey(apiKey string) Option {
+	return func(c *Client) error {
+		c.APIKey = apiKey
+		return nil
+	}
+}
+
 // NewClient creates a new Cerebras client.
 func NewClient(apiKey string, opts ...Option) (*Client, error) {
 	c := &Client{

--- a/pkg/embeddings/cerebras/cerebras_test.go
+++ b/pkg/embeddings/cerebras/cerebras_test.go
@@ -1,0 +1,260 @@
+//go:build ef
+
+package cerebras
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCerebrasAPI is a helper to create a mock HTTP server for Cerebras API calls.
+func mockCerebrasAPI(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+func TestCerebrasEmbeddingFunction_EmbedDocuments_Success(t *testing.T) {
+	var turn1Request ChatCompletionRequest
+	var turn2Request ChatCompletionRequest
+	requestCount := 0
+
+	doc1 := "First test document"
+	doc2 := "Second test document"
+	expectedDocs := []string{doc1, doc2}
+	expectedTaskType := "test_retrieval_doc"
+	expectedInstruction := "Generate test embeddings for semantic search."
+	expectedNormalize := true
+
+	expectedEmbedding1 := []float32{0.11, 0.22, 0.33}
+	expectedEmbedding2 := []float32{0.44, 0.55, 0.66}
+
+	server := mockCerebrasAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		bodyBytes, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		defer r.Body.Close()
+
+		if requestCount == 1 { // Turn 1: Tool call request
+			t.Logf("Mock Server: Received Turn 1 request (Tool Call)")
+			err = json.Unmarshal(bodyBytes, &turn1Request)
+			require.NoError(t, err)
+
+			assert.Len(t, turn1Request.Messages, 2)
+			assert.Equal(t, "system", turn1Request.Messages[0].Role)
+			assert.Equal(t, "user", turn1Request.Messages[1].Role)
+			assert.Contains(t, turn1Request.Messages[1].Content, fmt.Sprintf("TaskType: '%s'", expectedTaskType))
+			assert.Contains(t, turn1Request.Messages[1].Content, fmt.Sprintf("Instruction: '%s'", expectedInstruction))
+			assert.Contains(t, turn1Request.Messages[1].Content, fmt.Sprintf("NormalizeOutput: %v", expectedNormalize))
+			assert.Contains(t, turn1Request.Messages[1].Content, doc1)
+			assert.Contains(t, turn1Request.Messages[1].Content, doc2)
+
+			require.NotNil(t, turn1Request.Tools)
+			require.Len(t, turn1Request.Tools, 1)
+			assert.Equal(t, EmbeddingToolName, turn1Request.Tools[0].Function.Name)
+
+			toolCallArgs := EmbeddingToolParameters{
+				InputTexts:      expectedDocs,
+				TaskType:        expectedTaskType,
+				Instruction:     expectedInstruction,
+				NormalizeOutput: expectedNormalize,
+			}
+			argsBytes, _ := json.Marshal(toolCallArgs)
+
+			resp := ChatCompletionResponse{
+				ID: "chatcmpl-turn1-success",
+				Choices: []ChatCompletionChoice{{
+					Message: ChatMessage{Role: "assistant", ToolCalls: []ToolCall{{
+						ID: "call_success123", Type: "function", Function: ToolCallFunction{Name: EmbeddingToolName, Arguments: string(argsBytes)},
+					}}},
+					FinishReason: "tool_calls",
+				}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		} else if requestCount == 2 { // Turn 2: Embedding generation request
+			t.Logf("Mock Server: Received Turn 2 request (Embedding Generation)")
+			err = json.Unmarshal(bodyBytes, &turn2Request)
+			require.NoError(t, err)
+
+			assert.Len(t, turn2Request.Messages, 4) // system, user(orig), assistant(tool_call), user(new_instr)
+			assert.Equal(t, "user", turn2Request.Messages[3].Role)
+			assert.Contains(t, turn2Request.Messages[3].Content, "You have decided to call the 'advanced_embedding_generator' tool")
+			assert.Contains(t, turn2Request.Messages[3].Content, fmt.Sprintf("TaskType='%s'", expectedTaskType))
+
+			require.NotNil(t, turn2Request.ResponseFormat)
+			assert.Equal(t, "json_schema", turn2Request.ResponseFormat.Type)
+			assert.Equal(t, "embedding_tool_output_schema", turn2Request.ResponseFormat.JSONSchema.Name)
+
+			embeddingOutput := EmbeddingToolOutput{
+				Results: []EmbeddingResultItem{
+					{SourceText: doc1, EmbeddingVector: expectedEmbedding1, Normalized: expectedNormalize},
+					{SourceText: doc2, EmbeddingVector: expectedEmbedding2, Normalized: expectedNormalize},
+				},
+				ModelUsed: string(DefaultChatModel),
+				UsageInfo: map[string]int{"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+			}
+			outputBytes, _ := json.Marshal(embeddingOutput)
+
+			resp := ChatCompletionResponse{
+				ID: "chatcmpl-turn2-success",
+				Choices: []ChatCompletionChoice{{
+					Message:      ChatMessage{Role: "assistant", Content: string(outputBytes)},
+					FinishReason: "stop",
+				}},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		} else {
+			t.Fatalf("Unexpected request count: %d", requestCount)
+		}
+	})
+	defer server.Close()
+
+	// Temporarily set the environment variable for this test
+	// The actual value "env-api-key-for-test" doesn't matter for the mock server,
+	// but it allows us to verify the client would pick it up.
+	t.Setenv(DefaultAPIKeyEnvVarName, "env-api-key-for-test")
+
+	t.Logf("Test: Initializing EmbeddingFunction with BaseURL: %s", server.URL)
+	ef, err := NewEmbeddingFunction(
+		"", // Direct apiKey is now less relevant as WithAPIKeyFromEnv will override
+		[]Option{WithBaseURL(server.URL), WithDefaultModel(DefaultChatModel), WithAPIKeyFromEnv(DefaultAPIKeyEnvVarName)},
+		WithTaskType(expectedTaskType),
+		WithInstruction(expectedInstruction),
+		WithNormalizeOutput(expectedNormalize),
+	)
+	require.NoError(t, err)
+
+	t.Logf("Test: Calling EmbedDocuments with %d documents", len(expectedDocs))
+	embeddingsResult, err := ef.EmbedDocuments(context.Background(), expectedDocs)
+	t.Logf("Test: EmbedDocuments call completed. Error: %v", err)
+	require.NoError(t, err)
+	// You can optionally assert that the client's APIKey was indeed set from the env var
+	assert.Equal(t, "env-api-key-for-test", ef.client.APIKey, "Client APIKey should be set from environment variable")
+
+	require.Equal(t, 2, requestCount, "Expected two API calls")
+
+	require.Len(t, embeddingsResult, 2)
+	t.Logf("Test: Received %d embeddings. First embedding length: %d, Second embedding length: %d", len(embeddingsResult), embeddingsResult[0].Len(), embeddingsResult[1].Len())
+	assert.Equal(t, expectedEmbedding1, embeddingsResult[0].ContentAsFloat32())
+	assert.Equal(t, expectedEmbedding2, embeddingsResult[1].ContentAsFloat32())
+}
+
+func TestCerebrasEmbeddingFunction_EmbedQuery_Success(t *testing.T) {
+	requestCount := 0
+	queryDoc := "Single query document for testing"
+	expectedEmbedding := []float32{0.77, 0.88, 0.99}
+
+	server := mockCerebrasAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		bodyBytes, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+
+		if requestCount == 1 { // Turn 1
+			var req ChatCompletionRequest
+			json.Unmarshal(bodyBytes, &req)
+			assert.Contains(t, req.Messages[1].Content, queryDoc)
+
+			toolCallArgs := EmbeddingToolParameters{InputTexts: []string{queryDoc}} // Simplified for test
+			argsBytes, _ := json.Marshal(toolCallArgs)
+			resp := ChatCompletionResponse{
+				Choices: []ChatCompletionChoice{{
+					Message:      ChatMessage{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_q1", Type: "function", Function: ToolCallFunction{Name: EmbeddingToolName, Arguments: string(argsBytes)}}}},
+					FinishReason: "tool_calls",
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else if requestCount == 2 { // Turn 2
+			embeddingOutput := EmbeddingToolOutput{
+				Results:   []EmbeddingResultItem{{SourceText: queryDoc, EmbeddingVector: expectedEmbedding, Normalized: false}},
+				ModelUsed: string(DefaultChatModel),
+			}
+			outputBytes, _ := json.Marshal(embeddingOutput)
+			resp := ChatCompletionResponse{
+				Choices: []ChatCompletionChoice{{
+					Message:      ChatMessage{Role: "assistant", Content: string(outputBytes)},
+					FinishReason: "stop",
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	})
+	defer server.Close()
+
+	ef, err := NewEmbeddingFunction("dummy-api-key", []Option{WithBaseURL(server.URL)})
+	require.NoError(t, err)
+
+	embeddingResult, err := ef.EmbedQuery(context.Background(), queryDoc)
+	require.NoError(t, err)
+	require.Equal(t, 2, requestCount, "Expected two API calls for EmbedQuery")
+	require.NotNil(t, embeddingResult)
+	assert.Equal(t, expectedEmbedding, embeddingResult.ContentAsFloat32())
+}
+
+func TestCerebrasEmbeddingFunction_EmbedDocuments_EmptyInput(t *testing.T) {
+	ef, err := NewEmbeddingFunction("dummy-key", nil)
+	require.NoError(t, err)
+
+	results, err := ef.EmbedDocuments(context.Background(), []string{})
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	assert.Empty(t, results)
+	assert.Len(t, results, 0)
+}
+
+func TestCerebrasEmbeddingFunction_EmbedDocuments_Turn1_NoToolCall(t *testing.T) {
+	server := mockCerebrasAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		resp := ChatCompletionResponse{
+			Choices: []ChatCompletionChoice{{
+				Message:      ChatMessage{Role: "assistant", Content: "I cannot use tools right now."},
+				FinishReason: "stop",
+			}},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	ef, _ := NewEmbeddingFunction("dummy", []Option{WithBaseURL(server.URL)})
+	_, err := ef.EmbedDocuments(context.Background(), []string{"test doc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM did not call the embedding tool as expected")
+}
+
+func TestCerebrasEmbeddingFunction_EmbedDocuments_Turn2_BadJSONOutput(t *testing.T) {
+	requestCount := 0
+	server := mockCerebrasAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 { // Turn 1 - successful tool call
+			toolCallArgs := EmbeddingToolParameters{InputTexts: []string{"test doc"}}
+			argsBytes, _ := json.Marshal(toolCallArgs)
+			resp := ChatCompletionResponse{
+				Choices: []ChatCompletionChoice{{
+					Message:      ChatMessage{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_badjson", Type: "function", Function: ToolCallFunction{Name: EmbeddingToolName, Arguments: string(argsBytes)}}}},
+					FinishReason: "tool_calls",
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else { // Turn 2 - LLM returns malformed JSON
+			resp := ChatCompletionResponse{
+				Choices: []ChatCompletionChoice{{
+					Message:      ChatMessage{Role: "assistant", Content: "this is not valid json { definitely not"},
+					FinishReason: "stop",
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	})
+	defer server.Close()
+
+	ef, _ := NewEmbeddingFunction("dummy", []Option{WithBaseURL(server.URL)})
+	_, err := ef.EmbedDocuments(context.Background(), []string{"test doc"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "turn 2: failed to unmarshal LLM response into EmbeddingToolOutput")
+}

--- a/pkg/embeddings/cerebras/option.go
+++ b/pkg/embeddings/cerebras/option.go
@@ -1,0 +1,81 @@
+package cerebras
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+// Default environment variable names
+const (
+	DefaultAPIKeyEnvVarName  = "CEREBRAS_API_KEY"
+	DefaultBaseURLEnvVarName = "CEREBRAS_BASE_URL"
+)
+
+// WithBaseURL sets the base URL for the Cerebras API.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) error {
+		if baseURL == "" {
+			return errors.New("base URL cannot be empty")
+		}
+		if _, err := url.ParseRequestURI(baseURL); err != nil {
+			return errors.Wrap(err, "invalid base URL")
+		}
+		c.BaseURL = baseURL
+		return nil
+	}
+}
+
+// WithBaseURLFromEnv sets the base URL for the Cerebras API from an environment variable.
+func WithBaseURLFromEnv(envVarName string) Option {
+	return func(c *Client) error {
+		baseURL := os.Getenv(envVarName)
+		if baseURL == "" {
+			return errors.Errorf("environment variable %s not set or is empty", envVarName)
+		}
+		if _, err := url.ParseRequestURI(baseURL); err != nil {
+			return errors.Wrapf(err, "invalid base URL from environment variable %s", envVarName)
+		}
+		c.BaseURL = baseURL
+		return nil
+	}
+}
+
+// WithDefaultModel sets the default chat model for generating embeddings.
+func WithDefaultModel(model CerebrasModel) Option {
+	return func(c *Client) error {
+		if model == "" {
+			return errors.New("model cannot be empty")
+		}
+		c.DefaultModel = embeddings.EmbeddingModel(model)
+		return nil
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) error {
+		if httpClient == nil {
+			return errors.New("HTTP client cannot be nil")
+		}
+		c.HTTPClient = httpClient
+		return nil
+	}
+}
+
+// WithAPIKeyFromEnv sets the API key from an environment variable.
+// The `envVarName` parameter specifies which environment variable to read.
+func WithAPIKeyFromEnv(envVarName string) Option {
+	return func(c *Client) error {
+		apiKey := os.Getenv(envVarName)
+		if apiKey == "" {
+			return errors.Errorf("environment variable %s not set or is empty", envVarName)
+		}
+		c.APIKey = apiKey
+		return nil
+	}
+}

--- a/pkg/embeddings/cerebras/option.go
+++ b/pkg/embeddings/cerebras/option.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // Default environment variable names

--- a/pkg/embeddings/cloudflare/cloudflare.go
+++ b/pkg/embeddings/cloudflare/cloudflare.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // Docs:  https://developers.cloudflare.com/workers-ai/ (Cloudflare Workers AI) and https://developers.cloudflare.com/workers-ai/models/embedding/ (Embedding API)

--- a/pkg/embeddings/cloudflare/option.go
+++ b/pkg/embeddings/cloudflare/option.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *CloudflareClient) error

--- a/pkg/embeddings/cohere/cohere.go
+++ b/pkg/embeddings/cohere/cohere.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	ccommons "github.com/guiperry/chroma-go_cerebras/pkg/commons/cohere"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 const (

--- a/pkg/embeddings/cohere/cohere_test.go
+++ b/pkg/embeddings/cohere/cohere_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
+	ccommons "github.com/guiperry/chroma-go_cerebras/pkg/commons/cohere"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"

--- a/pkg/embeddings/cohere/option.go
+++ b/pkg/embeddings/cohere/option.go
@@ -3,9 +3,9 @@ package cohere
 import (
 	"github.com/pkg/errors"
 
-	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
-	httpc "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	ccommons "github.com/guiperry/chroma-go_cerebras/pkg/commons/cohere"
+	httpc "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *CohereEmbeddingFunction) ccommons.Option

--- a/pkg/embeddings/default_ef/default_ef.go
+++ b/pkg/embeddings/default_ef/default_ef.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pkg/errors"
 	ort "github.com/yalue/onnxruntime_go"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
-	tokenizers "github.com/amikos-tech/chroma-go/pkg/tokenizers/libtokenizers"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
+	tokenizers "github.com/guiperry/chroma-go_cerebras/pkg/tokenizers/libtokenizers"
 )
 
 type Option func(p *DefaultEmbeddingFunction) error

--- a/pkg/embeddings/gemini/gemini.go
+++ b/pkg/embeddings/gemini/gemini.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/api/option"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 const (

--- a/pkg/embeddings/gemini/option.go
+++ b/pkg/embeddings/gemini/option.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/generative-ai-go/genai"
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *Client) error

--- a/pkg/embeddings/hf/hf.go
+++ b/pkg/embeddings/hf/hf.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type HuggingFaceClient struct {

--- a/pkg/embeddings/jina/jina.go
+++ b/pkg/embeddings/jina/jina.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type EmbeddingType string

--- a/pkg/embeddings/jina/option.go
+++ b/pkg/embeddings/jina/option.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(c *JinaEmbeddingFunction) error

--- a/pkg/embeddings/mistral/mistral.go
+++ b/pkg/embeddings/mistral/mistral.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 const (

--- a/pkg/embeddings/nomic/nomic.go
+++ b/pkg/embeddings/nomic/nomic.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // Docs:  https://docs.nomic.ai/reference/endpoints/nomic-embed-text

--- a/pkg/embeddings/nomic/option.go
+++ b/pkg/embeddings/nomic/option.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *Client) error

--- a/pkg/embeddings/ollama/ollama.go
+++ b/pkg/embeddings/ollama/ollama.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type OllamaClient struct {

--- a/pkg/embeddings/ollama/ollama_test.go
+++ b/pkg/embeddings/ollama/ollama_test.go
@@ -5,13 +5,14 @@ package ollama
 import (
 	"context"
 	"fmt"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
-	"github.com/stretchr/testify/require"
-	tcollama "github.com/testcontainers/testcontainers-go/modules/ollama"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
+	"github.com/stretchr/testify/require"
+	tcollama "github.com/testcontainers/testcontainers-go/modules/ollama"
 )
 
 func Test_ollama(t *testing.T) {

--- a/pkg/embeddings/ollama/option.go
+++ b/pkg/embeddings/ollama/option.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *OllamaClient) error

--- a/pkg/embeddings/openai/openai.go
+++ b/pkg/embeddings/openai/openai.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type EmbeddingModel string

--- a/pkg/embeddings/together/option.go
+++ b/pkg/embeddings/together/option.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *TogetherAIClient) error

--- a/pkg/embeddings/together/together.go
+++ b/pkg/embeddings/together/together.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // Docs:  https://docs.together.ai/docs/embeddings-rest.  Models - https://docs.together.ai/docs/embeddings-models.

--- a/pkg/embeddings/voyage/option.go
+++ b/pkg/embeddings/voyage/option.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 type Option func(p *VoyageAIClient) error

--- a/pkg/embeddings/voyage/voyage.go
+++ b/pkg/embeddings/voyage/voyage.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
 )
 
 // Docs:  https://docs.together.ai/docs/embeddings-rest.  Models - https://docs.together.ai/docs/embeddings-models.

--- a/pkg/rerankings/cohere/cohere.go
+++ b/pkg/rerankings/cohere/cohere.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	ccommons "github.com/guiperry/chroma-go_cerebras/pkg/commons/cohere"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 const (

--- a/pkg/rerankings/cohere/cohere_test.go
+++ b/pkg/rerankings/cohere/cohere_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 func TestRerank(t *testing.T) {

--- a/pkg/rerankings/cohere/option.go
+++ b/pkg/rerankings/cohere/option.go
@@ -1,10 +1,10 @@
 package cohere
 
 import (
-	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
-	httpc "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	ccommons "github.com/guiperry/chroma-go_cerebras/pkg/commons/cohere"
+	httpc "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 type Option func(p *CohereRerankingFunction) ccommons.Option

--- a/pkg/rerankings/hf/huggingface.go
+++ b/pkg/rerankings/hf/huggingface.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 const (

--- a/pkg/rerankings/hf/huggingface_test.go
+++ b/pkg/rerankings/hf/huggingface_test.go
@@ -5,11 +5,12 @@ package huggingface
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
@@ -17,8 +18,8 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 func TestRerankHFEI(t *testing.T) {

--- a/pkg/rerankings/hf/option.go
+++ b/pkg/rerankings/hf/option.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 type Option func(c *HFRerankingFunction) error

--- a/pkg/rerankings/jina/jina.go
+++ b/pkg/rerankings/jina/jina.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"net/http"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
-	"github.com/amikos-tech/chroma-go/types"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	chttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 const (

--- a/pkg/rerankings/jina/jina_test.go
+++ b/pkg/rerankings/jina/jina_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chromago "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	chromago "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/pkg/rerankings"
 )
 
 func TestRerank(t *testing.T) {

--- a/pkg/rerankings/jina/option.go
+++ b/pkg/rerankings/jina/option.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 type Option func(c *JinaRerankingFunction) error

--- a/pkg/rerankings/reranking.go
+++ b/pkg/rerankings/reranking.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	chromago "github.com/amikos-tech/chroma-go"
+	chromago "github.com/guiperry/chroma-go_cerebras"
 )
 
 type RerankingModel string

--- a/pkg/rerankings/reranking_test.go
+++ b/pkg/rerankings/reranking_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chromago "github.com/amikos-tech/chroma-go"
+	chromago "github.com/guiperry/chroma-go_cerebras"
 )
 
 type DummyRerankingFunction struct {

--- a/test/chroma_api_test.go
+++ b/test/chroma_api_test.go
@@ -6,18 +6,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Masterminds/semver"
-	chroma "github.com/amikos-tech/chroma-go"
-	chhttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
-	"github.com/amikos-tech/chroma-go/types"
-	"github.com/stretchr/testify/require"
-	tcchroma "github.com/testcontainers/testcontainers-go/modules/chroma"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Masterminds/semver"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	chhttp "github.com/guiperry/chroma-go_cerebras/pkg/commons/http"
+	"github.com/guiperry/chroma-go_cerebras/types"
+	"github.com/stretchr/testify/require"
+	tcchroma "github.com/testcontainers/testcontainers-go/modules/chroma"
 )
 
 func TestAPIErrorHandling(t *testing.T) {

--- a/test/chroma_client_test.go
+++ b/test/chroma_client_test.go
@@ -11,12 +11,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	defaultef "github.com/amikos-tech/chroma-go/pkg/embeddings/default_ef"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
-	testcontainers "github.com/testcontainers/testcontainers-go"
-	tcchroma "github.com/testcontainers/testcontainers-go/modules/chroma"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -25,15 +19,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	defaultef "github.com/guiperry/chroma-go_cerebras/pkg/embeddings/default_ef"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	tcchroma "github.com/testcontainers/testcontainers-go/modules/chroma"
+	"github.com/testcontainers/testcontainers-go/wait"
+
 	"github.com/Masterminds/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chroma "github.com/amikos-tech/chroma-go"
-	"github.com/amikos-tech/chroma-go/collection"
-	"github.com/amikos-tech/chroma-go/types"
-	"github.com/amikos-tech/chroma-go/where"
-	wheredoc "github.com/amikos-tech/chroma-go/where_document"
+	chroma "github.com/guiperry/chroma-go_cerebras"
+	"github.com/guiperry/chroma-go_cerebras/collection"
+	"github.com/guiperry/chroma-go_cerebras/types"
+	"github.com/guiperry/chroma-go_cerebras/where"
+	wheredoc "github.com/guiperry/chroma-go_cerebras/where_document"
 )
 
 func TestChromaClient(t *testing.T) {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/amikos-tech/chroma-go/types"
+	"github.com/guiperry/chroma-go_cerebras/types"
 )
 
 func Compare(t *testing.T, actual, expected map[string]interface{}) bool {

--- a/types/types.go
+++ b/types/types.go
@@ -16,10 +16,10 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 
-	"github.com/amikos-tech/chroma-go/pkg/embeddings"
-	openapi "github.com/amikos-tech/chroma-go/swagger"
-	"github.com/amikos-tech/chroma-go/where"
-	wheredoc "github.com/amikos-tech/chroma-go/where_document"
+	"github.com/guiperry/chroma-go_cerebras/pkg/embeddings"
+	openapi "github.com/guiperry/chroma-go_cerebras/swagger"
+	"github.com/guiperry/chroma-go_cerebras/where"
+	wheredoc "github.com/guiperry/chroma-go_cerebras/where_document"
 )
 
 type DistanceFunction string

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -4,16 +4,17 @@ package types
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
 	"github.com/oklog/ulid"
 
-	openapi "github.com/amikos-tech/chroma-go/swagger"
-	"github.com/amikos-tech/chroma-go/where"
-	wheredoc "github.com/amikos-tech/chroma-go/where_document"
+	openapi "github.com/guiperry/chroma-go_cerebras/swagger"
+	"github.com/guiperry/chroma-go_cerebras/where"
+	wheredoc "github.com/guiperry/chroma-go_cerebras/where_document"
 )
 
 func TestConsistentHashEmbeddingFunction_EmbedDocuments(t *testing.T) {


### PR DESCRIPTION
This pull request implements an innovative approach to using Cerebras LLM's "tool calling" functionality for embedding generation. Rather than delegating to an external service, we leverage the LLM's inherent capabilities to generate embeddings directly.

Our findings suggest that Cerebras LLM models can generate embeddings effectively, making the concept of an EmbeddingToolExecutor unnecessary for this specific task. Our vision is to allow Cerebras (and its underlying LLM models) to handle embeddings end-to-end.

Please see the [README.md](https://github.com/guiperry/chroma-go_cerebras/tree/main/pkg/embeddings/cerebras) for details.