### PR TITLE
fix: Renamed Cloud client constructor for naming consistency

### DIFF
--- a/examples/v2/auth/main.go
+++ b/examples/v2/auth/main.go
@@ -304,7 +304,7 @@ func runCloudAuth() {
 	}
 
 	// Create Chroma Cloud client
-	client, err := v2.NewCloudAPIClient(
+	client, err := v2.NewCloudClient(
 		v2.WithCloudAPIKey(apiKey),
 		v2.WithDatabaseAndTenant(database, tenant),
 	)

--- a/pkg/api/v2/client_cloud.go
+++ b/pkg/api/v2/client_cloud.go
@@ -13,7 +13,7 @@ type CloudAPIClient struct {
 	*APIClientV2
 }
 
-func NewCloudAPIClient(options ...ClientOption) (*CloudAPIClient, error) {
+func NewCloudClient(options ...ClientOption) (*CloudAPIClient, error) {
 	bc, err := newBaseAPIClient()
 	if err != nil {
 		return nil, err
@@ -52,6 +52,11 @@ func NewCloudAPIClient(options ...ClientOption) (*CloudAPIClient, error) {
 		c.authProvider = NewTokenAuthCredentialsProvider(os.Getenv("CHROMA_API_KEY"), XChromaTokenHeader)
 	}
 	return c, nil
+}
+
+// Deprecated: use NewCloudClient instead
+func NewCloudAPIClient(options ...ClientOption) (*CloudAPIClient, error) {
+	return NewCloudClient(options...)
 }
 
 // WithCloudAPIKey sets the API key for the cloud client. It will automatically set a new TokenAuthCredentialsProvider.

--- a/pkg/api/v2/client_cloud_test.go
+++ b/pkg/api/v2/client_cloud_test.go
@@ -24,7 +24,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		err := godotenv.Load("../../../.env")
 		require.NoError(t, err)
 	}
-	client, err := NewCloudAPIClient(
+	client, err := NewCloudClient(
 		WithDebug(),
 		WithDatabaseAndTenant(os.Getenv("CHROMA_DATABASE"), os.Getenv("CHROMA_TENANT")),
 		WithCloudAPIKey(os.Getenv("CHROMA_API_KEY")),
@@ -204,7 +204,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 
 	t.Run("Without API Key", func(t *testing.T) {
 		t.Setenv("CHROMA_API_KEY", "")
-		client, err := NewCloudAPIClient(
+		client, err := NewCloudClient(
 			WithDebug(),
 			WithDatabaseAndTenant("test_database", "test_tenant"),
 		)
@@ -216,7 +216,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 	t.Run("Without Tenant and DB", func(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "")
 		t.Setenv("CHROMA_DATABASE", "")
-		client, err := NewCloudAPIClient(
+		client, err := NewCloudClient(
 			WithDebug(),
 			WithCloudAPIKey("test"),
 		)
@@ -227,7 +227,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 	t.Run("With env tenant and DB", func(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "test_tenant")
 		t.Setenv("CHROMA_DATABASE", "test_database")
-		client, err := NewCloudAPIClient(
+		client, err := NewCloudClient(
 			WithDebug(),
 			WithCloudAPIKey("test"),
 		)
@@ -241,7 +241,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "test_tenant")
 		t.Setenv("CHROMA_DATABASE", "test_database")
 		t.Setenv("CHROMA_API_KEY", "test")
-		client, err := NewCloudAPIClient(
+		client, err := NewCloudClient(
 			WithDebug(),
 		)
 		require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "test_tenant")
 		t.Setenv("CHROMA_DATABASE", "test_database")
 		t.Setenv("CHROMA_API_KEY", "test")
-		client, err := NewCloudAPIClient(
+		client, err := NewCloudClient(
 			WithDebug(),
 			WithCloudAPIKey("different_test_key"),
 			WithDatabaseAndTenant("other_db", "other_tenant"),


### PR DESCRIPTION
leaving NewCloudAPIClient for backward compatibility but making it deprecated
Closes #257

