### PR TITLE
[CHORE] Bump tests to use chroma v1.1.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -101,7 +101,7 @@ jobs:
     needs: [lint,paths-filter]
     strategy:
       matrix:
-        chroma-version: ["0.6.3","1.0.20"]
+        chroma-version: ["0.6.3","1.1.0"]
     if: needs.paths-filter.outputs.basev2 == 'true'
     environment: Test
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,5 +123,5 @@ Integration tests use `testcontainers-go` for Docker-based testing against real 
 - **Working with Metadata**: Use `/pkg/api/v2/metadata/` utilities for type conversions
 
 ### Version Compatibility
-The client is tested against Chroma versions 0.4.8 to 1.0.20. Ensure changes maintain compatibility across this range.
+The client is tested against Chroma versions 0.4.8 to 1.1.0. Ensure changes maintain compatibility across this range.
 - Always lint before commiting or pushing code

--- a/pkg/api/v2/client_http_integration_test.go
+++ b/pkg/api/v2/client_http_integration_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestClientHTTPIntegration(t *testing.T) {
 	ctx := context.Background()
-	var chromaVersion = "1.0.20"
+	var chromaVersion = "1.1.0"
 	var chromaImage = "ghcr.io/chroma-core/chroma"
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")
@@ -92,7 +92,7 @@ func TestClientHTTPIntegration(t *testing.T) {
 	t.Run("get version", func(t *testing.T) {
 		v, err := c.GetVersion(ctx)
 		require.NoError(t, err)
-		if strings.HasPrefix(chromaVersion, "1.0") || chromaVersion == "latest" {
+		if strings.HasPrefix(chromaVersion, "1.0") || strings.HasPrefix(chromaVersion, "1.1") || chromaVersion == "latest" {
 			require.Contains(t, v, "1.")
 		} else {
 			require.Equal(t, chromaVersion, v)
@@ -459,7 +459,7 @@ func TestClientHTTPIntegrationWithBasicAuth(t *testing.T) {
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")
 	}
-	if strings.HasPrefix(chromaVersion, "1.0") || chromaVersion == "latest" {
+	if strings.HasPrefix(chromaVersion, "1.0") || strings.HasPrefix(chromaVersion, "1.1") || chromaVersion == "latest" {
 		t.Skip("Not supported by Chroma 1.0.x")
 	}
 	if os.Getenv("CHROMA_IMAGE") != "" {
@@ -542,7 +542,7 @@ func TestClientHTTPIntegrationWithBearerAuthorizationHeaderAuth(t *testing.T) {
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")
 	}
-	if strings.HasPrefix(chromaVersion, "1.0") || chromaVersion == "latest" {
+	if strings.HasPrefix(chromaVersion, "1.0") || strings.HasPrefix(chromaVersion, "1.1") || chromaVersion == "latest" {
 		t.Skip("Not supported by Chroma 1.0.x")
 	}
 	if os.Getenv("CHROMA_IMAGE") != "" {
@@ -607,7 +607,7 @@ func TestClientHTTPIntegrationWithBearerXChromaTokenHeaderAuth(t *testing.T) {
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")
 	}
-	if strings.HasPrefix(chromaVersion, "1.0") || chromaVersion == "latest" {
+	if strings.HasPrefix(chromaVersion, "1.0") || strings.HasPrefix(chromaVersion, "1.1") || chromaVersion == "latest" {
 		t.Skip("Not supported by Chroma 1.0.x")
 	}
 	if os.Getenv("CHROMA_IMAGE") != "" {
@@ -688,7 +688,7 @@ func TestClientHTTPIntegrationWithSSL(t *testing.T) {
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")
 	}
-	if strings.HasPrefix(chromaVersion, "1.0") || chromaVersion == "latest" {
+	if strings.HasPrefix(chromaVersion, "1.0") || strings.HasPrefix(chromaVersion, "1.1") || chromaVersion == "latest" {
 		t.Skip("Not supported by Chroma 1.0.x")
 	}
 

--- a/pkg/api/v2/collection_http_integration_test.go
+++ b/pkg/api/v2/collection_http_integration_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCollectionAddIntegration(t *testing.T) {
 	ctx := context.Background()
-	var chromaVersion = "1.0.20"
+	var chromaVersion = "1.1.0"
 	var chromaImage = "ghcr.io/chroma-core/chroma"
 	if os.Getenv("CHROMA_VERSION") != "" {
 		chromaVersion = os.Getenv("CHROMA_VERSION")


### PR DESCRIPTION
## Summary
- Bump Chroma test version from v1.0.20 to v1.1.0 to ensure compatibility with the latest release
- Update GitHub workflow test matrix to use the new version
- Add support for v1.1 version prefix checks in integration tests

## Changes
- Update `.github/workflows/go.yml` test matrix
- Update default test versions in integration test files
- Add v1.1 prefix handling alongside v1.0 in version checks
- Update CLAUDE.md documentation

## Test plan
- [x] Run `make test-v2` - All tests pass
- [x] Run `make lint` - No linting issues
- [ ] GitHub Actions CI should pass with the new version

Closes #260

🤖 Generated with [Claude Code](https://claude.ai/code)