### PR TITLE
[DOC] Add V1 API deprecation notice for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Chroma Go
 
+> [!WARNING]
+> **V1 API Deprecation Notice**: The V1 API will be removed in the upcoming v0.3.0 release.
+> Users currently using the V1 API (root package import) should migrate to the V2 API (`github.com/amikos-tech/chroma-go/pkg/api/v2`).
+> The V2 API offers feature parity with V1 plus additional capabilities.
+> For continued V1 support, please use v0.2.x releases.
+
 A simple Chroma Vector Database client written in Go
 
 Works with Chroma Version: v0.4.3 - v1.0.x


### PR DESCRIPTION
## Summary
- Add deprecation warning at the top of README for V1 API
- Inform users that V1 will be removed in v0.3.0
- Direct users to migrate to V2 API

## Context
Following our discussion about cleaning up the codebase, this PR adds a deprecation notice to warn users that the V1 API will be removed in the upcoming v0.3.0 release. Users who need continued V1 support should use v0.2.x releases.

## Test plan
[x] Visual inspection - warning notice appears prominently at the top of README
[x] Links to V2 API package path are correct

🤖 Generated with [Claude Code](https://claude.ai/code)