### PR TITLE
allow customization of onnx runtime version with env variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ The codebase heavily relies on environment variables for configuration:
 - `CHROMA_CLOUD_HOST` - Cloud host
 - `CHROMA_CLOUD_TENANT` - Cloud tenant ID
 - `CHROMA_CLOUD_DATABASE` - Cloud database ID
+- `CHROMAGO_ONNX_RUNTIME_PATH` - Absolute path to ONNX Runtime library file (overrides auto-download)
+- `CHROMAGO_ONNX_RUNTIME_VERSION` - ONNX Runtime version for auto-download (default: 1.22.0)
 
 ## Architecture
 

--- a/docs/docs/embeddings.md
+++ b/docs/docs/embeddings.md
@@ -63,6 +63,22 @@ func main() {
 }
 ```
 
+### ONNX Runtime Configuration
+
+The ONNX Runtime library can be customized using environment variables:
+
+- `CHROMAGO_ONNX_RUNTIME_PATH` - Absolute path to a custom ONNX Runtime library file (e.g., `/usr/local/lib/libonnxruntime.1.23.2.dylib`). When set, skips auto-download.
+- `CHROMAGO_ONNX_RUNTIME_VERSION` - Version of ONNX Runtime to download (default: `1.22.0`). Only used when `CHROMAGO_ONNX_RUNTIME_PATH` is not set.
+
+Example:
+```bash
+# Use a specific version
+export CHROMAGO_ONNX_RUNTIME_VERSION=1.23.0
+
+# Or point to a manually downloaded library
+export CHROMAGO_ONNX_RUNTIME_PATH=/usr/local/lib/libonnxruntime.1.23.2.dylib
+```
+
 ## OpenAI
 
 Supported Embedding Function Options:

--- a/examples/v2/auth/go.mod
+++ b/examples/v2/auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/amikos-tech/chroma-go/examples/v2/auth
 
-go 1.23.0
+go 1.24
 
 require github.com/amikos-tech/chroma-go v0.2.4
 
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/yalue/onnxruntime_go v1.19.0 // indirect
+	github.com/yalue/onnxruntime_go v1.22.0 // indirect
 )
 
 replace github.com/amikos-tech/chroma-go => ../../../

--- a/examples/v2/auth/go.sum
+++ b/examples/v2/auth/go.sum
@@ -92,6 +92,7 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
 github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/examples/v2/basic/go.mod
+++ b/examples/v2/basic/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/yalue/onnxruntime_go v1.19.0 // indirect
+	github.com/yalue/onnxruntime_go v1.22.0 // indirect
 )

--- a/examples/v2/basic/go.sum
+++ b/examples/v2/basic/go.sum
@@ -92,6 +92,7 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
 github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/examples/v2/embedding_function_basic/go.mod
+++ b/examples/v2/embedding_function_basic/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/yalue/onnxruntime_go v1.19.0 // indirect
+	github.com/yalue/onnxruntime_go v1.22.0 // indirect
 )

--- a/examples/v2/embedding_function_basic/go.sum
+++ b/examples/v2/embedding_function_basic/go.sum
@@ -92,6 +92,7 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
 github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/examples/v2/metadata_filters/go.mod
+++ b/examples/v2/metadata_filters/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/yalue/onnxruntime_go v1.19.0 // indirect
+	github.com/yalue/onnxruntime_go v1.22.0 // indirect
 )

--- a/examples/v2/metadata_filters/go.sum
+++ b/examples/v2/metadata_filters/go.sum
@@ -92,6 +92,7 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
 github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/examples/v2/tenant_and_db/go.mod
+++ b/examples/v2/tenant_and_db/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/yalue/onnxruntime_go v1.19.0 // indirect
+	github.com/yalue/onnxruntime_go v1.22.0 // indirect
 )

--- a/examples/v2/tenant_and_db/go.sum
+++ b/examples/v2/tenant_and_db/go.sum
@@ -92,6 +92,7 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
 github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/amikos-tech/pure-tokenizers v0.1.1
 	github.com/docker/docker v28.0.1+incompatible
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
@@ -17,7 +18,8 @@ require (
 	github.com/testcontainers/testcontainers-go v0.36.0
 	github.com/testcontainers/testcontainers-go/modules/chroma v0.36.0
 	github.com/testcontainers/testcontainers-go/modules/ollama v0.36.0
-	github.com/yalue/onnxruntime_go v1.19.0
+	github.com/yalue/onnxruntime_go v1.22.0
+	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.186.0
 )
 
@@ -32,7 +34,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.1 // indirect
@@ -86,7 +87,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
-github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -384,8 +382,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/tmc/langchaingo v0.1.5 h1:PNPFu54wn5uVPRt9GS/quRwdFZW4omSab9/dcFAsGmU=
 github.com/tmc/langchaingo v0.1.5/go.mod h1:RLtnUED/hH2v765vdjS9Z6gonErZAXURuJHph0BttqM=
-github.com/yalue/onnxruntime_go v1.19.0 h1:+qCu7/Nzrr/TY7B3sMy9sOATegP2qbtXn4b7q90fDOo=
-github.com/yalue/onnxruntime_go v1.19.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+github.com/yalue/onnxruntime_go v1.22.0 h1:SzqOfFRRrLRRAFR5VoSxABjTiQSAi8Y4ETYKrMFK1jk=
+github.com/yalue/onnxruntime_go v1.22.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -427,6 +425,8 @@ go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
@@ -606,8 +606,6 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
-golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/api/v2/auth_security_test.go
+++ b/pkg/api/v2/auth_security_test.go
@@ -1,5 +1,4 @@
 //go:build basicv2
-// +build basicv2
 
 package v2
 

--- a/pkg/api/v2/client_logger_test.go
+++ b/pkg/api/v2/client_logger_test.go
@@ -1,4 +1,4 @@
-// +build basicv2
+//go:build basicv2
 
 package v2
 

--- a/pkg/embeddings/default_ef/constants.go
+++ b/pkg/embeddings/default_ef/constants.go
@@ -3,39 +3,114 @@ package defaultef
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 )
 
 const (
-	defaultLibOnnxRuntimeVersion = "1.21.0"
+	defaultLibOnnxRuntimeVersion = "1.22.0"
 	onnxModelDownloadEndpoint    = "https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz"
 	ChromaCacheDir               = ".cache/chroma/"
 )
 
-var (
-	libOnnxRuntimeVersion string
-	libCacheDir           string
-	onnxCacheDir          string
-	onnxLibPath           string
+// Config holds all computed configuration paths for ONNX Runtime
+type Config struct {
+	LibOnnxRuntimeVersion string
+	LibCacheDir           string
+	OnnxCacheDir          string
+	OnnxLibPath           string
 
-	onnxModelsCachePath          string
-	onnxModelCachePath           string
-	onnxModelPath                string
-	onnxModelTokenizerConfigPath string
+	OnnxModelsCachePath          string
+	OnnxModelCachePath           string
+	OnnxModelPath                string
+	OnnxModelTokenizerConfigPath string
+}
+
+var (
+	configOnce sync.Once
+	config     *Config
 )
 
-func init() {
-	if v, ok := os.LookupEnv("CHROMAGO_ONNX_RUNTIME_VERSION"); ok {
-		libOnnxRuntimeVersion = v
-	} else {
-		libOnnxRuntimeVersion = defaultLibOnnxRuntimeVersion
+// getConfig returns the singleton configuration instance,
+// initializing it on first call using environment variables
+func getConfig() *Config {
+	configOnce.Do(func() {
+		config = initializeConfig()
+	})
+	return config
+}
+
+// initializeConfig creates a new Config by reading environment variables
+// and computing all derived paths
+func initializeConfig() *Config {
+	// Priority 1: Check for explicit path to ONNX Runtime library
+	if customPath := os.Getenv("CHROMAGO_ONNX_RUNTIME_PATH"); customPath != "" {
+		// User provided explicit path to library file
+		// We still need to compute model paths, but use custom lib path
+		libCacheDir := filepath.Join(os.Getenv("HOME"), ChromaCacheDir)
+		onnxModelsCachePath := filepath.Join(libCacheDir, "onnx_models")
+		onnxModelCachePath := filepath.Join(onnxModelsCachePath, "all-MiniLM-L6-v2/onnx")
+		onnxModelPath := filepath.Join(onnxModelCachePath, "model.onnx")
+		onnxModelTokenizerConfigPath := filepath.Join(onnxModelCachePath, "tokenizer.json")
+
+		return &Config{
+			LibOnnxRuntimeVersion:        "custom", // marker for custom path
+			LibCacheDir:                  libCacheDir,
+			OnnxCacheDir:                 filepath.Dir(customPath), // not used for custom path
+			OnnxLibPath:                  customPath,
+			OnnxModelsCachePath:          onnxModelsCachePath,
+			OnnxModelCachePath:           onnxModelCachePath,
+			OnnxModelPath:                onnxModelPath,
+			OnnxModelTokenizerConfigPath: onnxModelTokenizerConfigPath,
+		}
 	}
 
-	libCacheDir = filepath.Join(os.Getenv("HOME"), ChromaCacheDir)
-	onnxCacheDir = filepath.Join(libCacheDir, "shared", "onnxruntime")
-	onnxLibPath = filepath.Join(onnxCacheDir, "libonnxruntime."+libOnnxRuntimeVersion+"."+getExtensionForOs())
+	// Priority 2: Use version-based auto-download
+	version := defaultLibOnnxRuntimeVersion
+	if v := os.Getenv("CHROMAGO_ONNX_RUNTIME_VERSION"); v != "" {
+		// Basic validation: non-empty and reasonable length
+		if len(v) > 0 && len(v) < 100 {
+			version = v
+		}
+	}
 
-	onnxModelsCachePath = filepath.Join(libCacheDir, "onnx_models")
-	onnxModelCachePath = filepath.Join(onnxModelsCachePath, "all-MiniLM-L6-v2/onnx")
-	onnxModelPath = filepath.Join(onnxModelCachePath, "model.onnx")
-	onnxModelTokenizerConfigPath = filepath.Join(onnxModelCachePath, "tokenizer.json")
+	// Compute all paths based on the version
+	libCacheDir := filepath.Join(os.Getenv("HOME"), ChromaCacheDir)
+	onnxCacheDir := filepath.Join(libCacheDir, "shared", "onnxruntime")
+	onnxLibPath := filepath.Join(onnxCacheDir, "libonnxruntime."+version+"."+getExtensionForOs())
+
+	onnxModelsCachePath := filepath.Join(libCacheDir, "onnx_models")
+	onnxModelCachePath := filepath.Join(onnxModelsCachePath, "all-MiniLM-L6-v2/onnx")
+	onnxModelPath := filepath.Join(onnxModelCachePath, "model.onnx")
+	onnxModelTokenizerConfigPath := filepath.Join(onnxModelCachePath, "tokenizer.json")
+
+	return &Config{
+		LibOnnxRuntimeVersion:        version,
+		LibCacheDir:                  libCacheDir,
+		OnnxCacheDir:                 onnxCacheDir,
+		OnnxLibPath:                  onnxLibPath,
+		OnnxModelsCachePath:          onnxModelsCachePath,
+		OnnxModelCachePath:           onnxModelCachePath,
+		OnnxModelPath:                onnxModelPath,
+		OnnxModelTokenizerConfigPath: onnxModelTokenizerConfigPath,
+	}
+}
+
+// getExtensionForOs returns the shared library extension for the current OS
+func getExtensionForOs() string {
+	cos := runtime.GOOS
+	if cos == "darwin" {
+		return "dylib"
+	}
+	if cos == "windows" {
+		return "dll"
+	}
+	return "so" // assume Linux default
+}
+
+// resetConfigForTesting resets the configuration singleton for testing purposes
+// This should only be called from test code
+func resetConfigForTesting() {
+	config = nil
+	configOnce = sync.Once{}
 }

--- a/pkg/embeddings/default_ef/default_ef_test.go
+++ b/pkg/embeddings/default_ef/default_ef_test.go
@@ -2,6 +2,7 @@ package defaultef
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,4 +41,118 @@ func TestCloseClosed(t *testing.T) {
 	ef := &DefaultEmbeddingFunction{}
 	err := ef.Close()
 	require.NoError(t, err)
+}
+
+func TestCustomOnnxRuntimeVersion(t *testing.T) {
+	// Test that CHROMAGO_ONNX_RUNTIME_VERSION env var correctly sets the version
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	// Test with custom version
+	customVersion := "1.21.0"
+	t.Setenv("CHROMAGO_ONNX_RUNTIME_VERSION", customVersion)
+
+	// Reset config to pick up the new env var
+	resetConfigForTesting()
+
+	cfg := getConfig()
+	require.NotNil(t, cfg)
+	require.Equal(t, customVersion, cfg.LibOnnxRuntimeVersion, "Config should use custom ONNX Runtime version from env var")
+
+	// Verify the library path contains the version
+	require.Contains(t, cfg.OnnxLibPath, customVersion, "Library path should contain the custom version")
+}
+
+func TestCustomOnnxRuntimePath(t *testing.T) {
+	// This test downloads a specific ONNX Runtime version from GitHub
+	// and tests using CHROMAGO_ONNX_RUNTIME_PATH
+	// Set RUN_SLOW_TESTS=1 to enable this test
+	if os.Getenv("RUN_SLOW_TESTS") != "1" {
+		t.Skip("This test requires downloading ~33MB from GitHub and takes time - set RUN_SLOW_TESTS=1 to run")
+	}
+
+	// Set up temp directory
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	// Get platform info
+	cos, carch := getOSAndArch()
+	if carch == "amd64" {
+		carch = "x64"
+	}
+	if cos == "darwin" {
+		cos = "osx"
+		if carch == "x64" {
+			carch = "x86_64"
+		}
+	}
+
+	// Download ONNX Runtime 1.23.0 (different from default 1.22.0)
+	version := "1.23.0"
+	url := "https://github.com/microsoft/onnxruntime/releases/download/v" + version + "/onnxruntime-" + cos + "-" + carch + "-" + version + ".tgz"
+
+	t.Logf("Downloading ONNX Runtime %s for %s-%s from GitHub", version, cos, carch)
+	targetArchive := tempDir + "/onnxruntime-" + version + ".tgz"
+	err := downloadFile(targetArchive, url)
+	require.NoError(t, err, "Failed to download ONNX Runtime from GitHub")
+
+	// Extract the library file
+	extractDir := tempDir + "/extracted"
+	err = os.MkdirAll(extractDir, 0755)
+	require.NoError(t, err)
+
+	// Determine the library filename pattern in the archive
+	// Note: tar archives have a leading "./" in the path
+	var targetFile string
+	if cos == "linux" {
+		targetFile = "./onnxruntime-" + cos + "-" + carch + "-" + version + "/lib/libonnxruntime." + getExtensionForOs() + "." + version
+	} else {
+		targetFile = "./onnxruntime-" + cos + "-" + carch + "-" + version + "/lib/libonnxruntime." + version + "." + getExtensionForOs()
+	}
+
+	t.Logf("Extracting %s from archive", targetFile)
+	err = extractSpecificFile(targetArchive, targetFile, extractDir)
+	require.NoError(t, err, "Failed to extract library from archive")
+
+	// Get the extracted library path - extractSpecificFile uses filepath.Base
+	// so we need to construct the path with just the filename
+	libFilename := ""
+	if cos == "linux" {
+		libFilename = "libonnxruntime." + getExtensionForOs() + "." + version
+	} else {
+		libFilename = "libonnxruntime." + version + "." + getExtensionForOs()
+	}
+	libPath := extractDir + "/" + libFilename
+
+	// Verify the library file exists
+	_, err = os.Stat(libPath)
+	require.NoError(t, err, "Extracted library not found at %s", libPath)
+
+	t.Logf("Using custom ONNX Runtime library at: %s", libPath)
+
+	// Set the custom path environment variable
+	t.Setenv("CHROMAGO_ONNX_RUNTIME_PATH", libPath)
+
+	// Reset config to pick up the new environment variable
+	resetConfigForTesting()
+
+	// Create embedding function - should use the custom library
+	ef, closeEf, err := NewDefaultEmbeddingFunction()
+	require.NoError(t, err, "Failed to create embedding function with custom ONNX Runtime path")
+	t.Cleanup(func() {
+		err := closeEf()
+		if err != nil {
+			t.Logf("error while closing embedding function: %v", err)
+		}
+	})
+	require.NotNil(t, ef)
+
+	// Test that embeddings work with the custom library
+	embeddings, err := ef.EmbedDocuments(context.TODO(), []string{"Testing custom ONNX Runtime path"})
+	require.NoError(t, err, "Failed to generate embeddings with custom library")
+	require.NotNil(t, embeddings)
+	require.Len(t, embeddings, 1)
+	require.Equal(t, 384, embeddings[0].Len(), "Expected 384-dimensional embeddings")
+
+	t.Logf("✓ Successfully used ONNX Runtime %s from custom path", version)
 }

--- a/pkg/embeddings/default_ef/download_utils.go
+++ b/pkg/embeddings/default_ef/download_utils.go
@@ -244,9 +244,19 @@ var (
 )
 
 func EnsureOnnxRuntimeSharedLibrary() error {
+	cfg := getConfig()
+
+	// If using custom path, just verify the file exists
+	if cfg.LibOnnxRuntimeVersion == "custom" {
+		if _, err := os.Stat(cfg.OnnxLibPath); err != nil {
+			return errors.Wrapf(err, "custom ONNX Runtime library not found at: %s", cfg.OnnxLibPath)
+		}
+		return nil
+	}
+
 	onnxMu.Lock()
 	defer onnxMu.Unlock()
-	lockFile, err := lockFile(onnxCacheDir)
+	lockFile, err := lockFile(cfg.OnnxCacheDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to acquire lock for onnx download")
 	}
@@ -266,9 +276,9 @@ func EnsureOnnxRuntimeSharedLibrary() error {
 	}
 
 	downloadAndExtractNeeded := false
-	if _, onnxInitErr = os.Stat(onnxLibPath); os.IsNotExist(onnxInitErr) {
+	if _, onnxInitErr = os.Stat(cfg.OnnxLibPath); os.IsNotExist(onnxInitErr) {
 		downloadAndExtractNeeded = true
-		onnxInitErr = os.MkdirAll(onnxCacheDir, 0755)
+		onnxInitErr = os.MkdirAll(cfg.OnnxCacheDir, 0755)
 		if onnxInitErr != nil {
 			return errors.Wrap(onnxInitErr, "failed to create onnx cache")
 		}
@@ -276,10 +286,10 @@ func EnsureOnnxRuntimeSharedLibrary() error {
 	if !downloadAndExtractNeeded {
 		return nil
 	}
-	targetArchive := filepath.Join(onnxCacheDir, "onnxruntime-"+cos+"-"+carch+"-"+libOnnxRuntimeVersion+".tgz")
-	if _, onnxInitErr = os.Stat(onnxLibPath); os.IsNotExist(onnxInitErr) {
+	targetArchive := filepath.Join(cfg.OnnxCacheDir, "onnxruntime-"+cos+"-"+carch+"-"+cfg.LibOnnxRuntimeVersion+".tgz")
+	if _, onnxInitErr = os.Stat(cfg.OnnxLibPath); os.IsNotExist(onnxInitErr) {
 		// Download the library
-		url := "https://github.com/microsoft/onnxruntime/releases/download/v" + libOnnxRuntimeVersion + "/onnxruntime-" + cos + "-" + carch + "-" + libOnnxRuntimeVersion + ".tgz"
+		url := "https://github.com/microsoft/onnxruntime/releases/download/v" + cfg.LibOnnxRuntimeVersion + "/onnxruntime-" + cos + "-" + carch + "-" + cfg.LibOnnxRuntimeVersion + ".tgz"
 		// TODO integrity check
 		if _, onnxInitErr = os.Stat(targetArchive); os.IsNotExist(onnxInitErr) {
 			onnxInitErr = downloadFile(targetArchive, url)
@@ -294,25 +304,24 @@ func EnsureOnnxRuntimeSharedLibrary() error {
 			}
 		}
 	}
-	targetFile := "onnxruntime-" + cos + "-" + carch + "-" + libOnnxRuntimeVersion + "/lib/libonnxruntime." + libOnnxRuntimeVersion + "." + getExtensionForOs()
+	targetFile := "onnxruntime-" + cos + "-" + carch + "-" + cfg.LibOnnxRuntimeVersion + "/lib/libonnxruntime." + cfg.LibOnnxRuntimeVersion + "." + getExtensionForOs()
 	if cos == "linux" {
-		targetFile = "onnxruntime-" + cos + "-" + carch + "-" + libOnnxRuntimeVersion + "/lib/libonnxruntime." + getExtensionForOs() + "." + libOnnxRuntimeVersion
+		targetFile = "onnxruntime-" + cos + "-" + carch + "-" + cfg.LibOnnxRuntimeVersion + "/lib/libonnxruntime." + getExtensionForOs() + "." + cfg.LibOnnxRuntimeVersion
 	}
-	onnxInitErr = extractSpecificFile(targetArchive, targetFile, onnxCacheDir)
+	onnxInitErr = extractSpecificFile(targetArchive, targetFile, cfg.OnnxCacheDir)
 	if onnxInitErr != nil {
 		return errors.Wrapf(onnxInitErr, "could not extract onnxruntime shared library")
 	}
 
 	if cos == "linux" {
-		// wantedTargetFile := filepath.Join(onnxCacheDir, "libonnxruntime."+LibOnnxRuntimeVersion+"."+getExtensionForOs())
-		onnxInitErr = os.Rename(filepath.Join(onnxCacheDir, "libonnxruntime."+getExtensionForOs()+"."+libOnnxRuntimeVersion), onnxLibPath)
+		onnxInitErr = os.Rename(filepath.Join(cfg.OnnxCacheDir, "libonnxruntime."+getExtensionForOs()+"."+cfg.LibOnnxRuntimeVersion), cfg.OnnxLibPath)
 		if onnxInitErr != nil {
-			return errors.Wrapf(onnxInitErr, "could not rename extracted file to %s", onnxLibPath)
+			return errors.Wrapf(onnxInitErr, "could not rename extracted file to %s", cfg.OnnxLibPath)
 		}
 	}
 
-	if _, err := os.Stat(onnxLibPath); err != nil {
-		return errors.Wrapf(err, "extracted file not found at expected location: %s", onnxLibPath)
+	if _, err := os.Stat(cfg.OnnxLibPath); err != nil {
+		return errors.Wrapf(err, "extracted file not found at expected location: %s", cfg.OnnxLibPath)
 	}
 
 	onnxInitErr = os.RemoveAll(targetArchive)
@@ -324,8 +333,9 @@ func EnsureOnnxRuntimeSharedLibrary() error {
 }
 
 func EnsureDefaultEmbeddingFunctionModel() error {
+	cfg := getConfig()
 
-	lockFile, err := lockFile(onnxModelsCachePath)
+	lockFile, err := lockFile(cfg.OnnxModelsCachePath)
 	if err != nil {
 		return errors.Wrap(err, "failed to acquire lock for onnx download")
 	}
@@ -334,23 +344,23 @@ func EnsureDefaultEmbeddingFunctionModel() error {
 	}()
 
 	downloadAndExtractNeeded := false
-	if _, err := os.Stat(onnxModelCachePath); os.IsNotExist(err) {
+	if _, err := os.Stat(cfg.OnnxModelCachePath); os.IsNotExist(err) {
 		downloadAndExtractNeeded = true
-		if err := os.MkdirAll(onnxModelCachePath, 0755); err != nil {
+		if err := os.MkdirAll(cfg.OnnxModelCachePath, 0755); err != nil {
 			return errors.Wrap(err, "failed to create onnx model cache")
 		}
 	}
 	if !downloadAndExtractNeeded {
 		return nil
 	}
-	targetArchive := filepath.Join(onnxModelsCachePath, "onnx.tar.gz")
+	targetArchive := filepath.Join(cfg.OnnxModelsCachePath, "onnx.tar.gz")
 	if _, err := os.Stat(targetArchive); os.IsNotExist(err) {
 		// TODO integrity check
 		if err := downloadFile(targetArchive, onnxModelDownloadEndpoint); err != nil {
 			return errors.Wrap(err, "failed to download onnx model")
 		}
 	}
-	if err := extractSpecificFile(targetArchive, "", onnxModelCachePath); err != nil {
+	if err := extractSpecificFile(targetArchive, "", cfg.OnnxModelCachePath); err != nil {
 		return errors.Wrapf(err, "could not extract onnx model")
 	}
 
@@ -359,16 +369,4 @@ func EnsureDefaultEmbeddingFunctionModel() error {
 	//	return err
 	//}
 	return nil
-}
-
-// LibOnnxRuntimeVersion is the version of the ONNX Runtime library to download
-func getExtensionForOs() string {
-	cos := runtime.GOOS
-	if cos == "darwin" {
-		return "dylib"
-	}
-	if cos == "windows" {
-		return "dll"
-	}
-	return "so" // assume Linux default
 }

--- a/pkg/embeddings/default_ef/download_utils_test.go
+++ b/pkg/embeddings/default_ef/download_utils_test.go
@@ -3,7 +3,6 @@ package defaultef
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,16 +10,30 @@ import (
 
 func TestDownload(t *testing.T) {
 	t.Run("Download", func(t *testing.T) {
-		libCacheDir = filepath.Join(t.TempDir(), "lib_cache")
-		fmt.Println(onnxLibPath)
-		err := os.RemoveAll(onnxLibPath)
+		// Set up test environment with temp directory
+		tempDir := t.TempDir()
+		t.Setenv("HOME", tempDir)
+
+		// Reset config to pick up new HOME
+		resetConfigForTesting()
+
+		cfg := getConfig()
+		fmt.Println(cfg.OnnxLibPath)
+		err := os.RemoveAll(cfg.OnnxLibPath)
 		require.NoError(t, err)
 		err = EnsureOnnxRuntimeSharedLibrary()
 		require.NoError(t, err)
 	})
 	t.Run("Download Model", func(t *testing.T) {
-		libCacheDir = filepath.Join(t.TempDir(), "lib_cache")
-		err := os.RemoveAll(onnxModelCachePath)
+		// Set up test environment with temp directory
+		tempDir := t.TempDir()
+		t.Setenv("HOME", tempDir)
+
+		// Reset config to pick up new HOME
+		resetConfigForTesting()
+
+		cfg := getConfig()
+		err := os.RemoveAll(cfg.OnnxModelCachePath)
 		require.NoError(t, err)
 		err = EnsureDefaultEmbeddingFunctionModel()
 		require.NoError(t, err)


### PR DESCRIPTION
the library depends on the version of onnx runtime installed on the device. However, some devices might have a higher version installed already. The version was hardcoded in the code making it hard for anyone to choose the version they already have. With this fix, we allow the customization of the onnx runtime version by setting it with an env variable called CHROMAGO_ONNX_RUNTIME_VERSION. All dependent variables are also derived from it.