### PR TITLE
fix(jina): adapt to API response format change

### DIFF
--- a/pkg/rerankings/jina/jina.go
+++ b/pkg/rerankings/jina/jina.go
@@ -37,9 +37,7 @@ type RerankingResponse struct {
 	Results []struct {
 		Index          int     `json:"index"`
 		RelevanceScore float32 `json:"relevance_score"`
-		Document       struct {
-			Text string `json:"text"`
-		} `json:"document,omitempty"`
+		Document       string  `json:"document,omitempty"`
 	} `json:"results"`
 }
 
@@ -149,8 +147,8 @@ func (r *JinaRerankingFunction) Rerank(ctx context.Context, query string, result
 		if err != nil {
 			return nil, err
 		}
-		if rr.Document.Text != "" {
-			originalDoc = rr.Document.Text
+		if rr.Document != "" {
+			originalDoc = rr.Document
 		}
 		rankedResults[r.ID()][i] = rerankings.RankedResult{
 			String: originalDoc,


### PR DESCRIPTION
## Summary
- Fix JSON unmarshaling error caused by Jina API response format change
- Change `Document` field from nested object to plain string

## Details
Jina changed their reranker API response format:
- **Before:** `"document": {"text": "..."}`
- **After:** `"document": "..."`

**Changes:**
- Update struct definition (jina.go:40): `Document` from nested struct to `string`
- Update usage (jina.go:150-152): Access `rr.Document` directly instead of `rr.Document.Text`

## Test Results
All previously failing Jina reranker tests now pass:
- ✅ `TestRerank/Test_Rerank_basic`
- ✅ `TestRerank/Test_Rerank_With_Env_Key`
- ✅ `TestRerank/Test_Rerank_With_TopN`
- ✅ `TestRerank/Test_Rerank_With_Different_Model`
- ✅ `TestRerankChromaResults/Test_Rerank_basic`

Closes #282