### PR TITLE
[CHORE] Enable Claude code reviews on PRs and update gitignore

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 on:
-  # pull_request:
-  #   types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
     # Optional: Only run on specific file changes
     # paths:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ _testmain.go
 *.out
 unit*.xml
 *.log
+ISSUE_CONTEXT.md


### PR DESCRIPTION
## Summary
- Enable Claude code review workflow to automatically run on pull request events (opened, synchronize)
- Add ISSUE_CONTEXT.md to gitignore to prevent tracking worktree context files created by /wt command

## Changes
- `.github/workflows/claude-code-review.yml`: Uncommented pull_request triggers
- `.gitignore`: Added ISSUE_CONTEXT.md pattern

## Test plan
- [x] Verify workflow triggers on PR creation
- [x] Confirm ISSUE_CONTEXT.md files are ignored in worktrees