### PR TITLE
[BUG] Fix flaky HFEI reranker tests - replace log wait with HTTP health check

### DIFF
--- a/pkg/rerankings/hf/huggingface_test.go
+++ b/pkg/rerankings/hf/huggingface_test.go
@@ -5,12 +5,13 @@ package huggingface
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,7 @@ func TestRerankHFEI(t *testing.T) {
 	req := testcontainers.ContainerRequest{
 		Image:         "ghcr.io/huggingface/text-embeddings-inference:cpu-latest",
 		ExposedPorts:  []string{"80/tcp"},
-		WaitingFor:    wait.ForLog("Ready"),
+		WaitingFor:    wait.ForHTTP("/health").WithPort("80/tcp").WithStartupTimeout(5 * time.Minute),
 		ImagePlatform: "linux/amd64",
 		Cmd:           []string{"--model-id", "BAAI/bge-reranker-base"},
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
@@ -153,7 +154,7 @@ func TestRerankChromaResults(t *testing.T) {
 	req := testcontainers.ContainerRequest{
 		Image:         "ghcr.io/huggingface/text-embeddings-inference:cpu-latest",
 		ExposedPorts:  []string{"80/tcp"},
-		WaitingFor:    wait.ForLog("Ready"),
+		WaitingFor:    wait.ForHTTP("/health").WithPort("80/tcp").WithStartupTimeout(5 * time.Minute),
 		ImagePlatform: "linux/amd64",
 		Cmd:           []string{"--model-id", "BAAI/bge-reranker-base"},
 		HostConfigModifier: func(hostConfig *container.HostConfig) {


### PR DESCRIPTION
## Summary
Fixes flaky HFEI reranker tests that were timing out due to unreliable log-based container wait strategy.

## Problem
The tests `TestRerankHFEI` and `TestRerankChromaResults` were intermittently failing with timeout errors. Investigation revealed:
- Container logs weren't consistently captured during model warmup phase
- `wait.ForLog("Ready")` was unreliable for detecting container readiness
- Model warmup takes ~3-3.5 minutes on CPU, but default timeout was only 60s

## Solution
- **Replaced** log-based waiting with HTTP health check: `wait.ForHTTP("/health")`
- **Increased** timeout from 60s to 5 minutes to accommodate model warmup
- TEI exposes reliable `/health` endpoint that returns 200 when fully ready

## Test Results
Both tests now pass consistently:
- `TestRerankHFEI`: PASSED (232s total, 20s execution)
- `TestRerankChromaResults`: PASSED (206s total, 11s execution)

## Changes
- `pkg/rerankings/hf/huggingface_test.go`:
  - Added `time` import
  - Updated wait strategy in both test functions
  - Increased startup timeout to 5 minutes

Fixes #283