### PR TITLE
[CLN] Remove duplicate test assertions in reranking tests

### DIFF
--- a/pkg/rerankings/cohere/cohere_test.go
+++ b/pkg/rerankings/cohere/cohere_test.go
@@ -227,14 +227,10 @@ func TestRerank(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
-			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
 
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+				maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+			}
 		})
 	}
 }
@@ -300,13 +296,10 @@ func TestRerankChromaResults(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
+
+				maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 		})
 	}
 }

--- a/pkg/rerankings/hf/huggingface_test.go
+++ b/pkg/rerankings/hf/huggingface_test.go
@@ -128,14 +128,10 @@ func TestRerankHFEI(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
-			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
 
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+				maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+			}
 		})
 	}
 }
@@ -241,13 +237,10 @@ func TestRerankChromaResults(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
+
+				maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 		})
 	}
 }

--- a/pkg/rerankings/jina/jina_test.go
+++ b/pkg/rerankings/jina/jina_test.go
@@ -169,14 +169,10 @@ func TestRerank(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
-			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
 
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+				maxIdx, _ := getMaxIDAndRank(res[rf.ID()])
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
+			}
 		})
 	}
 }
@@ -242,13 +238,10 @@ func TestRerankChromaResults(t *testing.T) {
 				require.NotNil(t, res, "Rerank result is nil")
 				require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
 				tt.validate(t, rf, res)
+
+				maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
+				require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 			}
-			require.NoError(t, err, "Failed to rerank")
-			require.NotNil(t, res, "Rerank result is nil")
-			require.Contains(t, res.Ranks, rf.ID(), "Rerank result does not contain the ID of the reranking function")
-			tt.validate(t, rf, res)
-			maxIdx := getIDForMaxRank(res.Ranks[rf.ID()][0]) // we have only one query
-			require.Equal(t, 3, maxIdx, "The most relevant result is not the expected one")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Removes duplicate test assertions that were incorrectly placed after if/else blocks in HuggingFace, Jina, and Cohere reranking tests.

## Changes
Cleaned up duplicate assertions in 6 test functions across 3 files:
- `pkg/rerankings/hf/huggingface_test.go` (TestRerankHFEI, TestRerankChromaResults)
- `pkg/rerankings/jina/jina_test.go` (TestRerank, TestRerankChromaResults)  
- `pkg/rerankings/cohere/cohere_test.go` (TestRerank, TestRerankChromaResults)

## Details
The following assertions were duplicated after if/else blocks:
```go
require.NoError(t, err, "Failed to rerank")
require.NotNil(t, res, "Rerank result is nil")
require.Contains(t, res, rf.ID(), ...)
tt.validate(t, rf, res)
```

These assertions were already present in the else block, making the duplicates unreachable dead code.

## Impact
- **Current state**: No impact - these duplicates are dormant because no test cases populate `expectedErrorStrings`
- **Future safety**: Prevents incorrect test failures if error test cases are added later
- **Code quality**: Removes 24 lines of confusing dead code

## Testing
The test suite behavior is unchanged - all reranking tests pass with identical behavior before and after this change.

Fixes #289