### PR TITLE
feat(embeddings): add Chroma Cloud embedding function

### DIFF
--- a/pkg/embeddings/chromacloud/chromacloud_test.go
+++ b/pkg/embeddings/chromacloud/chromacloud_test.go
@@ -64,6 +64,19 @@ func TestClient_Validation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid task")
 	})
+
+	t.Run("fails with HTTP base URL without WithInsecure", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithBaseURL("http://example.com"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base URL must use HTTPS")
+	})
+
+	t.Run("succeeds with HTTP base URL when WithInsecure is set", func(t *testing.T) {
+		client, err := NewClient(WithAPIKey("test-key"), WithBaseURL("http://example.com"), WithInsecure())
+		require.NoError(t, err)
+		require.Equal(t, "http://example.com", client.BaseURL)
+		require.True(t, client.Insecure)
+	})
 }
 
 func TestClient_Options(t *testing.T) {

--- a/pkg/embeddings/chromacloud/option.go
+++ b/pkg/embeddings/chromacloud/option.go
@@ -74,3 +74,10 @@ func WithBaseURL(baseURL string) Option {
 		return nil
 	}
 }
+
+func WithInsecure() Option {
+	return func(c *Client) error {
+		c.Insecure = true
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Adds new embedding function for Chroma Cloud embedding API (`embed.trychroma.com`)
- Supports `Qwen/Qwen3-Embedding-0.6B` model with task-based instructions
- Implements `EmbedDocuments` and `EmbedQuery` with different instructions for document vs query embedding
- Follows existing embedding function patterns (functional options, client struct)

## Test plan
- [x] Unit tests for client validation and options
- [x] Integration tests against real Chroma Cloud API
- [x] Lint, vet, govulncheck pass
- [x] V2 API test suite passes

Closes #300