### PR TITLE
feat(embeddings): add Chroma Cloud Splade sparse embedding function

### DIFF
--- a/pkg/api/v2/schema.go
+++ b/pkg/api/v2/schema.go
@@ -306,9 +306,9 @@ type FtsIndexConfig struct{}
 
 // SparseVectorIndexConfig represents configuration for sparse vector indexing
 type SparseVectorIndexConfig struct {
-	EmbeddingFunction embeddings.EmbeddingFunction `json:"-"`
-	SourceKey         string                       `json:"source_key,omitempty"`
-	BM25              bool                         `json:"bm25,omitempty"`
+	EmbeddingFunction embeddings.SparseEmbeddingFunction `json:"-"`
+	SourceKey         string                             `json:"source_key,omitempty"`
+	BM25              bool                               `json:"bm25,omitempty"`
 }
 
 // SparseVectorIndexOption configures a SparseVectorIndexConfig
@@ -323,7 +323,7 @@ func NewSparseVectorIndexConfig(opts ...SparseVectorIndexOption) *SparseVectorIn
 	return cfg
 }
 
-func WithSparseEmbeddingFunction(ef embeddings.EmbeddingFunction) SparseVectorIndexOption {
+func WithSparseEmbeddingFunction(ef embeddings.SparseEmbeddingFunction) SparseVectorIndexOption {
 	return func(c *SparseVectorIndexConfig) {
 		c.EmbeddingFunction = ef
 	}

--- a/pkg/embeddings/chromacloudsplade/chromacloudsplade.go
+++ b/pkg/embeddings/chromacloudsplade/chromacloudsplade.go
@@ -1,0 +1,184 @@
+package chromacloudsplade
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+const (
+	defaultBaseURL = "https://embed.trychroma.com/embed_sparse"
+	defaultModel   = "prithivida/Splade_PP_en_v1"
+	defaultTimeout = 60 * time.Second
+	APIKeyEnvVar   = "CHROMA_API_KEY"
+)
+
+type Client struct {
+	BaseURL    string
+	APIKey     string
+	Model      embeddings.EmbeddingModel
+	HTTPClient *http.Client
+	Insecure   bool
+}
+
+type embeddingRequest struct {
+	Texts  []string `json:"texts"`
+	Task   string   `json:"task"`
+	Target string   `json:"target"`
+}
+
+type sparseEmbedding struct {
+	Indices []int     `json:"indices"`
+	Values  []float32 `json:"values"`
+}
+
+type embeddingResponse struct {
+	Embeddings []sparseEmbedding `json:"embeddings,omitempty"`
+	Error      string            `json:"error,omitempty"`
+}
+
+func applyDefaults(c *Client) {
+	if c.HTTPClient == nil {
+		c.HTTPClient = &http.Client{Timeout: defaultTimeout}
+	}
+	if c.BaseURL == "" {
+		c.BaseURL = defaultBaseURL
+	}
+	if c.Model == "" {
+		c.Model = defaultModel
+	}
+}
+
+func validate(c *Client) error {
+	if c.APIKey == "" {
+		return errors.New("API key is required")
+	}
+	if !c.Insecure && !strings.HasPrefix(c.BaseURL, "https://") {
+		return errors.New("base URL must use HTTPS scheme for secure API key transmission; use WithInsecure() to override")
+	}
+	return nil
+}
+
+func NewClient(opts ...Option) (*Client, error) {
+	client := &Client{}
+	for _, opt := range opts {
+		if err := opt(client); err != nil {
+			return nil, errors.Wrap(err, "failed to apply option")
+		}
+	}
+	applyDefaults(client)
+	if err := validate(client); err != nil {
+		return nil, errors.Wrap(err, "failed to validate client")
+	}
+	return client, nil
+}
+
+func (c *Client) embed(ctx context.Context, texts []string) ([]*embeddings.SparseVector, error) {
+	if len(texts) == 0 {
+		return make([]*embeddings.SparseVector, 0), nil
+	}
+
+	reqBody := embeddingRequest{
+		Texts:  texts,
+		Task:   "",
+		Target: "",
+	}
+	reqData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal request")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL, bytes.NewReader(reqData))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+	req.Header.Set("Cache-Control", "no-store")
+	req.Header.Set("x-chroma-token", c.APIKey)
+	req.Header.Set("x-chroma-embedding-model", string(c.Model))
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to send request")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var embResp embeddingResponse
+	if err := json.Unmarshal(body, &embResp); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal response")
+	}
+
+	if embResp.Error != "" {
+		return nil, errors.Errorf("API error [status %d]: %s", resp.StatusCode, embResp.Error)
+	}
+
+	result := make([]*embeddings.SparseVector, len(embResp.Embeddings))
+	for i, emb := range embResp.Embeddings {
+		sv, err := embeddings.NewSparseVector(emb.Indices, emb.Values)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create sparse vector at index %d", i)
+		}
+		result[i] = sv
+	}
+
+	return result, nil
+}
+
+var _ embeddings.SparseEmbeddingFunction = (*EmbeddingFunction)(nil)
+
+type EmbeddingFunction struct {
+	client *Client
+}
+
+func NewEmbeddingFunction(opts ...Option) (*EmbeddingFunction, error) {
+	client, err := NewClient(opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create client")
+	}
+	return &EmbeddingFunction{client: client}, nil
+}
+
+func (e *EmbeddingFunction) EmbedDocumentsSparse(ctx context.Context, documents []string) ([]*embeddings.SparseVector, error) {
+	if len(documents) == 0 {
+		return make([]*embeddings.SparseVector, 0), nil
+	}
+
+	vectors, err := e.client.embed(ctx, documents)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to embed documents")
+	}
+
+	return vectors, nil
+}
+
+func (e *EmbeddingFunction) EmbedQuerySparse(ctx context.Context, query string) (*embeddings.SparseVector, error) {
+	vectors, err := e.client.embed(ctx, []string{query})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to embed query")
+	}
+	if len(vectors) == 0 {
+		return nil, errors.New("no embedding returned")
+	}
+	return vectors[0], nil
+}

--- a/pkg/embeddings/chromacloudsplade/chromacloudsplade_test.go
+++ b/pkg/embeddings/chromacloudsplade/chromacloudsplade_test.go
@@ -1,0 +1,144 @@
+//go:build ef && cloud
+
+package chromacloudsplade
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadEnv(t *testing.T) {
+	if os.Getenv(APIKeyEnvVar) == "" {
+		err := godotenv.Load("../../../.env")
+		if err != nil {
+			assert.Failf(t, "Error loading .env file", "%s", err)
+		}
+	}
+}
+
+func TestClient_Validation(t *testing.T) {
+	t.Run("fails without API key", func(t *testing.T) {
+		_, err := NewClient()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "API key is required")
+	})
+
+	t.Run("fails with empty API key option", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey(""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "API key cannot be empty")
+	})
+
+	t.Run("fails with nil HTTP client", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithHTTPClient(nil))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "HTTP client cannot be nil")
+	})
+
+	t.Run("fails with empty model", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithModel(""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "model cannot be empty")
+	})
+
+	t.Run("fails with empty base URL", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithBaseURL(""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base URL cannot be empty")
+	})
+
+	t.Run("fails with invalid base URL", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithBaseURL("not a valid url"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid base URL")
+	})
+
+	t.Run("fails with HTTP base URL without WithInsecure", func(t *testing.T) {
+		_, err := NewClient(WithAPIKey("test-key"), WithBaseURL("http://example.com"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "base URL must use HTTPS")
+	})
+
+	t.Run("succeeds with HTTP base URL when WithInsecure is set", func(t *testing.T) {
+		client, err := NewClient(WithAPIKey("test-key"), WithBaseURL("http://example.com"), WithInsecure())
+		require.NoError(t, err)
+		require.Equal(t, "http://example.com", client.BaseURL)
+		require.True(t, client.Insecure)
+	})
+}
+
+func TestClient_Options(t *testing.T) {
+	t.Run("creates client with API key", func(t *testing.T) {
+		client, err := NewClient(WithAPIKey("test-key"))
+		require.NoError(t, err)
+		require.Equal(t, "test-key", client.APIKey)
+		require.Equal(t, defaultBaseURL, client.BaseURL)
+		require.Equal(t, defaultModel, string(client.Model))
+	})
+
+	t.Run("creates client with custom model", func(t *testing.T) {
+		client, err := NewClient(WithAPIKey("test-key"), WithModel("custom-model"))
+		require.NoError(t, err)
+		require.Equal(t, "custom-model", string(client.Model))
+	})
+
+	t.Run("creates client with custom HTTP client", func(t *testing.T) {
+		httpClient := &http.Client{}
+		client, err := NewClient(WithAPIKey("test-key"), WithHTTPClient(httpClient))
+		require.NoError(t, err)
+		require.Same(t, httpClient, client.HTTPClient)
+	})
+
+	t.Run("creates client with custom base URL", func(t *testing.T) {
+		client, err := NewClient(WithAPIKey("test-key"), WithBaseURL("https://custom.example.com"))
+		require.NoError(t, err)
+		require.Equal(t, "https://custom.example.com", client.BaseURL)
+	})
+}
+
+func TestEmbeddingFunction(t *testing.T) {
+	loadEnv(t)
+
+	t.Run("EmbedDocumentsSparse with default options", func(t *testing.T) {
+		ef, err := NewEmbeddingFunction(WithEnvAPIKey())
+		require.NoError(t, err)
+
+		documents := []string{
+			"The quick brown fox jumps over the lazy dog while the sun sets behind the mountains.",
+			"Machine learning models can process natural language to extract meaningful representations from text.",
+		}
+		embeddings, err := ef.EmbedDocumentsSparse(context.Background(), documents)
+		require.NoError(t, err)
+		require.Len(t, embeddings, 2)
+		require.Greater(t, embeddings[0].Len(), 0)
+		require.Greater(t, embeddings[1].Len(), 0)
+		require.Equal(t, len(embeddings[0].Indices), len(embeddings[0].Values))
+		require.Equal(t, len(embeddings[1].Indices), len(embeddings[1].Values))
+	})
+
+	t.Run("EmbedDocumentsSparse with empty list", func(t *testing.T) {
+		ef, err := NewEmbeddingFunction(WithEnvAPIKey())
+		require.NoError(t, err)
+
+		embeddings, err := ef.EmbedDocumentsSparse(context.Background(), []string{})
+		require.NoError(t, err)
+		require.Len(t, embeddings, 0)
+	})
+
+	t.Run("EmbedQuerySparse", func(t *testing.T) {
+		ef, err := NewEmbeddingFunction(WithEnvAPIKey())
+		require.NoError(t, err)
+
+		query := "How do neural networks learn to recognize patterns in images and text data?"
+		embedding, err := ef.EmbedQuerySparse(context.Background(), query)
+		require.NoError(t, err)
+		require.Greater(t, embedding.Len(), 0)
+		require.Equal(t, len(embedding.Indices), len(embedding.Values))
+	})
+}

--- a/pkg/embeddings/chromacloudsplade/option.go
+++ b/pkg/embeddings/chromacloudsplade/option.go
@@ -1,0 +1,73 @@
+package chromacloudsplade
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+type Option func(c *Client) error
+
+func WithModel(model embeddings.EmbeddingModel) Option {
+	return func(c *Client) error {
+		if model == "" {
+			return errors.New("model cannot be empty")
+		}
+		c.Model = model
+		return nil
+	}
+}
+
+func WithAPIKey(apiKey string) Option {
+	return func(c *Client) error {
+		if apiKey == "" {
+			return errors.New("API key cannot be empty")
+		}
+		c.APIKey = apiKey
+		return nil
+	}
+}
+
+func WithEnvAPIKey() Option {
+	return func(c *Client) error {
+		if apiKey := os.Getenv(APIKeyEnvVar); apiKey != "" {
+			c.APIKey = apiKey
+			return nil
+		}
+		return errors.Errorf("%s not set", APIKeyEnvVar)
+	}
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) error {
+		if client == nil {
+			return errors.New("HTTP client cannot be nil")
+		}
+		c.HTTPClient = client
+		return nil
+	}
+}
+
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) error {
+		if baseURL == "" {
+			return errors.New("base URL cannot be empty")
+		}
+		if _, err := url.ParseRequestURI(baseURL); err != nil {
+			return errors.Wrap(err, "invalid base URL")
+		}
+		c.BaseURL = baseURL
+		return nil
+	}
+}
+
+func WithInsecure() Option {
+	return func(c *Client) error {
+		c.Insecure = true
+		return nil
+	}
+}

--- a/pkg/embeddings/embedding.go
+++ b/pkg/embeddings/embedding.go
@@ -219,8 +219,13 @@ type EmbeddingFunction interface {
 	EmbedDocuments(ctx context.Context, texts []string) ([]Embedding, error)
 	// EmbedQuery embeds a single text.
 	EmbedQuery(ctx context.Context, text string) (Embedding, error)
-	//// EmbedRecords embeds a list of records.
-	// EmbedRecords(ctx context.Context, records []v2.Record, force bool) error
+}
+
+type SparseEmbeddingFunction interface {
+	// EmbedDocumentsSparse returns a sparse vector for each text.
+	EmbedDocumentsSparse(ctx context.Context, texts []string) ([]*SparseVector, error)
+	// EmbedQuerySparse embeds a single text as a sparse vector.
+	EmbedQuerySparse(ctx context.Context, text string) (*SparseVector, error)
 }
 
 func NewEmbeddingFromFloat32(embedding []float32) Embedding {


### PR DESCRIPTION
## Summary
- Add `SparseEmbeddingFunction` interface for sparse vector embeddings
- Create `chromacloudsplade` package calling `/embed_sparse` endpoint
- Update `SparseVectorIndexConfig` to use new `SparseEmbeddingFunction` interface
- Default model: `prithivida/Splade_PP_en_v1`

## Usage
```go
ef, err := chromacloudsplade.NewEmbeddingFunction(
    chromacloudsplade.WithEnvAPIKey(),
)
vectors, err := ef.EmbedDocumentsSparse(ctx, []string{"hello world"})
// vectors[0].Indices, vectors[0].Values
```

Closes #301

## Test plan
- [x] Unit tests for client validation and options
- [x] Integration tests with `//go:build ef && cloud` tag
- [x] Lint, vet, govulncheck pass
- [x] V2 API tests pass