### PR TITLE
fix(rerankings): update Jina default model to v2

### DIFF
--- a/pkg/rerankings/jina/jina.go
+++ b/pkg/rerankings/jina/jina.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	DefaultBaseAPIEndpoint                      = "https://api.jina.ai/v1/rerank"
-	DefaultRerankingModel  types.RerankingModel = "jina-reranker-v1-base-en"
+	DefaultRerankingModel  types.RerankingModel = "jina-reranker-v2-base-multilingual"
 )
 
 type RerankingRequest struct {

--- a/pkg/rerankings/jina/jina_test.go
+++ b/pkg/rerankings/jina/jina_test.go
@@ -123,7 +123,7 @@ func TestRerank(t *testing.T) {
 		{
 			name: "Test Rerank With Different Model",
 			rankingFunction: func() *JinaRerankingFunction {
-				rf, err := NewJinaRerankingFunction(WithEnvAPIKey(), WithModel("jina-reranker-v1-turbo-en"))
+				rf, err := NewJinaRerankingFunction(WithEnvAPIKey(), WithModel("jina-reranker-v2-base-multilingual"))
 				require.NoError(t, err, "Failed to create JinaRerankingFunction")
 				return rf
 			},


### PR DESCRIPTION
## Summary

- Update default Jina reranker model from `jina-reranker-v1-base-en` to `jina-reranker-v2-base-multilingual`
- Update test model from `jina-reranker-v1-turbo-en` to `jina-reranker-v2-base-multilingual`

Jina v1 reranker models are deprecated and return 500 Internal Server errors, breaking CI.

## Test plan

- [ ] CI passes with `make test-rf` (reranking function tests)
- [ ] Verify no 500 errors from Jina API

Fixes #324