### PR TITLE
fix(test): pin TEI container image version for reproducibility

### DIFF
--- a/pkg/embeddings/hf/hf_test.go
+++ b/pkg/embeddings/hf/hf_test.go
@@ -4,6 +4,7 @@ package hf
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -112,9 +113,17 @@ func Test_Huggingface_client_with_options(t *testing.T) {
 	})
 
 	t.Run("Test with huggingface embedding inference", func(t *testing.T) {
+		teiVersion := "1.8.3"
+		teiImage := "ghcr.io/huggingface/text-embeddings-inference"
+		if v := os.Getenv("TEI_VERSION"); v != "" {
+			teiVersion = v
+		}
+		if img := os.Getenv("TEI_IMAGE"); img != "" {
+			teiImage = img
+		}
 		ctx := context.Background()
 		req := testcontainers.ContainerRequest{
-			Image:         "ghcr.io/huggingface/text-embeddings-inference:cpu-latest",
+			Image:         fmt.Sprintf("%s:cpu-%s", teiImage, teiVersion),
 			ExposedPorts:  []string{"80/tcp"},
 			WaitingFor:    wait.ForLog("Ready"),
 			ImagePlatform: "linux/amd64",

--- a/pkg/rerankings/hf/huggingface_test.go
+++ b/pkg/rerankings/hf/huggingface_test.go
@@ -22,6 +22,18 @@ import (
 	"github.com/amikos-tech/chroma-go/pkg/rerankings"
 )
 
+func getTEIImage() string {
+	teiVersion := "1.8.3"
+	teiImage := "ghcr.io/huggingface/text-embeddings-inference"
+	if v := os.Getenv("TEI_VERSION"); v != "" {
+		teiVersion = v
+	}
+	if img := os.Getenv("TEI_IMAGE"); img != "" {
+		teiImage = img
+	}
+	return fmt.Sprintf("%s:cpu-%s", teiImage, teiVersion)
+}
+
 func TestRerankHFEI(t *testing.T) {
 	apiKey := os.Getenv("HF_API_KEY")
 	if apiKey == "" {
@@ -34,7 +46,7 @@ func TestRerankHFEI(t *testing.T) {
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:         "ghcr.io/huggingface/text-embeddings-inference:cpu-latest",
+		Image:         getTEIImage(),
 		ExposedPorts:  []string{"80/tcp"},
 		WaitingFor:    wait.ForHTTP("/health").WithPort("80/tcp").WithStartupTimeout(5 * time.Minute),
 		ImagePlatform: "linux/amd64",
@@ -148,7 +160,7 @@ func TestRerankChromaResults(t *testing.T) {
 
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:         "ghcr.io/huggingface/text-embeddings-inference:cpu-latest",
+		Image:         getTEIImage(),
 		ExposedPorts:  []string{"80/tcp"},
 		WaitingFor:    wait.ForHTTP("/health").WithPort("80/tcp").WithStartupTimeout(5 * time.Minute),
 		ImagePlatform: "linux/amd64",


### PR DESCRIPTION
## Summary
- Pins HuggingFace Text Embeddings Inference (TEI) container image to version `1.8.3` instead of using the rolling `:cpu-latest` tag
- Adds `TEI_VERSION` and `TEI_IMAGE` environment variable support for override flexibility
- Follows existing Chroma version pinning pattern used in other test files

## Changes
- `pkg/embeddings/hf/hf_test.go`: Added version variables with env var override
- `pkg/rerankings/hf/huggingface_test.go`: Added `getTEIImage()` helper function, updated 2 test functions

## Test plan
- [ ] Run `make test-ef` to verify HF embedding tests
- [ ] Run `make test-rf` to verify HF reranking tests
- [ ] Verify env var override: `TEI_VERSION=1.7 make test-rf`

Fixes #290