### PR TITLE
[DOC] Add Go code examples documentation

### DIFF
--- a/docs/go-examples/README.md
+++ b/docs/go-examples/README.md
@@ -1,0 +1,243 @@
+# Chroma Go Examples
+
+Go code examples for the [Chroma](https://trychroma.com/) vector database, using the [chroma-go](https://github.com/amikos-tech/chroma-go) client library.
+
+Each document provides side-by-side Python and Go examples, referencing the [official Chroma documentation](https://docs.trychroma.com/).
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect to Chroma server
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create or get a collection
+	collection, _ := client.GetOrCreateCollection(ctx, "my_collection")
+
+	// Add documents
+	collection.Add(ctx,
+		v2.WithIDs("doc1", "doc2"),
+		v2.WithDocuments("Hello world", "Goodbye world"),
+	)
+
+	// Query
+	results, _ := collection.Query(ctx,
+		v2.WithQueryTexts("Hello"),
+		v2.WithNResults(1),
+	)
+
+	// Iterate using Rows() for ergonomic access
+	for _, row := range results.Rows() {
+		log.Printf("Found: %s", row.ID)
+	}
+}
+```
+
+## Documentation Index
+
+### Getting Started
+
+| Topic | Description |
+|-------|-------------|
+| [Getting Started](docs/overview/getting-started.md) | Quick introduction to chroma-go |
+| [Client-Server Mode](docs/run-chroma/client-server.md) | Connect to a Chroma server via HTTP |
+| [Cloud Client](docs/run-chroma/cloud-client.md) | Connect to Chroma Cloud |
+| [Persistent Client](docs/run-chroma/persistent-client.md) | Working with persistent data |
+| [Ephemeral Client](docs/run-chroma/ephemeral-client.md) | Testing and experimentation |
+| [Running a Server](docs/cli/run.md) | Start and connect to Chroma |
+
+### Collections
+
+| Topic | Description |
+|-------|-------------|
+| [Manage Collections](docs/collections/manage-collections.md) | Create, get, list, delete collections |
+| [Add Data](docs/collections/add-data.md) | Add documents and embeddings |
+| [Update Data](docs/collections/update-data.md) | Update and upsert documents |
+| [Delete Data](docs/collections/delete-data.md) | Delete documents by ID or filter |
+| [Configure Collections](docs/collections/configure.md) | HNSW parameters and distance metrics |
+
+### Querying
+
+| Topic | Description |
+|-------|-------------|
+| [Query and Get](docs/querying-collections/query-and-get.md) | Query by text/embedding, get by ID |
+| [Metadata Filtering](docs/querying-collections/metadata-filtering.md) | Filter with $eq, $gt, $in, $and, $or |
+| [Full-Text Search](docs/querying-collections/full-text-search.md) | Search document content with $contains |
+
+### Embedding Functions
+
+| Topic | Description |
+|-------|-------------|
+| [Embedding Functions](docs/embeddings/embedding-functions.md) | OpenAI, Cohere, HuggingFace, and more |
+| [Multimodal Embeddings](docs/embeddings/multimodal.md) | Image embedding support |
+
+### Cloud Search API
+
+| Topic | Description |
+|-------|-------------|
+| [Search Basics](cloud/search-api/search-basics.md) | Introduction to the Search API |
+| [Filtering](cloud/search-api/filtering.md) | Metadata filtering in search |
+| [Ranking](cloud/search-api/ranking.md) | KNN ranking and arithmetic operations |
+| [Hybrid Search](cloud/search-api/hybrid-search.md) | RRF with dense and sparse vectors |
+| [Pagination & Selection](cloud/search-api/pagination-selection.md) | Limit, offset, and field selection |
+| [Group By](cloud/search-api/group-by.md) | Group results by metadata |
+| [Batch Operations](cloud/search-api/batch-operations.md) | Multiple searches in one request |
+| [Examples](cloud/search-api/examples.md) | E-commerce, recommendations, multi-category |
+
+### Schema & Advanced Features
+
+| Topic | Description |
+|-------|-------------|
+| [Schema Basics](cloud/schema/schema-basics.md) | Configure collection indexes |
+| [Sparse Vector Search](cloud/schema/sparse-vector-search.md) | SPLADE and hybrid search setup |
+| [Collection Forking](cloud/features/collection-forking.md) | Copy-on-write collection cloning |
+
+### Reference
+
+| Topic | Description |
+|-------|-------------|
+| [Migration](docs/overview/migration.md) | Version migration guide |
+| [Telemetry](docs/overview/telemetry.md) | Anonymous usage tracking |
+| [Troubleshooting](docs/overview/troubleshooting.md) | Common issues and solutions |
+
+## API Quick Reference
+
+### Client Creation
+
+```go
+// HTTP client (default: localhost:8000)
+client, _ := v2.NewHTTPClient()
+
+// HTTP client with options
+client, _ := v2.NewHTTPClient(
+    v2.WithBaseURL("http://localhost:8000"),
+    v2.WithAuth(v2.NewTokenAuthCredentialsProvider("token", v2.AuthorizationTokenHeader)),
+)
+
+// Cloud client
+client, _ := v2.NewCloudClient(
+    v2.WithCloudAPIKey("api-key"),
+    v2.WithDatabaseAndTenant("database", "tenant"),
+)
+```
+
+### Collection Operations
+
+```go
+// Create/Get
+col, _ := client.CreateCollection(ctx, "name")
+col, _ := client.GetCollection(ctx, "name")
+col, _ := client.GetOrCreateCollection(ctx, "name")
+
+// List/Delete
+cols, _ := client.ListCollections(ctx)
+client.DeleteCollection(ctx, "name")
+```
+
+### Data Operations
+
+```go
+// Add
+col.Add(ctx,
+    v2.WithIDs("id1", "id2"),
+    v2.WithDocuments("doc1", "doc2"),
+    v2.WithMetadatas(map[string]any{"key": "value"}),
+)
+
+// Query
+results, _ := col.Query(ctx,
+    v2.WithQueryTexts("search text"),
+    v2.WithNResults(10),
+    v2.WithWhere(v2.EqString("key", "value")),
+)
+
+// Get
+results, _ := col.Get(ctx,
+    v2.WithGetIDs("id1", "id2"),
+)
+
+// Update/Upsert
+col.Update(ctx, v2.WithIDs("id1"), v2.WithDocuments("new doc"))
+col.Upsert(ctx, v2.WithIDs("id1"), v2.WithDocuments("doc"))
+
+// Delete
+col.Delete(ctx, v2.WithDeleteIDs("id1", "id2"))
+col.Delete(ctx, v2.WithDeleteWhere(v2.EqString("key", "value")))
+```
+
+### Search API (Cloud)
+
+```go
+// Basic search
+result, _ := col.Search(ctx,
+    v2.NewSearchRequest(
+        v2.WithKnnRank(v2.KnnQueryText("query")),
+        v2.WithPage(v2.WithLimit(10)),
+        v2.WithSelect(v2.KDocument, v2.KScore),
+    ),
+)
+
+// Hybrid search with RRF
+denseKnn, _ := v2.NewKnnRank(v2.KnnQueryText("query"), v2.WithKnnReturnRank())
+sparseKnn, _ := v2.NewKnnRank(v2.KnnQueryText("query"), v2.WithKnnKey(v2.K("sparse")), v2.WithKnnReturnRank())
+
+result, _ := col.Search(ctx,
+    v2.NewSearchRequest(
+        v2.WithRffRank(
+            v2.WithRffRanks(denseKnn.WithWeight(0.7), sparseKnn.WithWeight(0.3)),
+        ),
+        v2.WithPage(v2.WithLimit(10)),
+    ),
+)
+```
+
+### Where Filters
+
+```go
+// Comparison
+v2.EqString("key", "value")
+v2.GtInt("count", 10)
+v2.LteFloat("score", 0.95)
+
+// Logical
+v2.And(v2.EqString("a", "b"), v2.GtInt("c", 5))
+v2.Or(v2.EqString("x", "1"), v2.EqString("x", "2"))
+
+// In/Not In
+v2.InString("category", "a", "b", "c")
+v2.NinInt("status", 0, -1)
+```
+
+## Requirements
+
+- Go 1.21+
+- Chroma server (local or Chroma Cloud)
+- chroma-go v2 (`github.com/amikos-tech/chroma-go/pkg/api/v2`)
+
+## Installation
+
+```bash
+go get github.com/amikos-tech/chroma-go
+```
+
+## Links
+
+- [chroma-go GitHub](https://github.com/amikos-tech/chroma-go)
+- [Chroma Documentation](https://docs.trychroma.com/)
+- [Chroma Cloud](https://trychroma.com/)
+

--- a/docs/go-examples/cloud/features/collection-forking.md
+++ b/docs/go-examples/cloud/features/collection-forking.md
@@ -1,0 +1,429 @@
+# Collection Forking - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/features/collection-forking)
+
+## Overview
+
+Forking lets you create a new collection from an existing one instantly, using copy-on-write under the hood. The forked collection initially shares its data with the source and only incurs additional storage for incremental changes you make afterward.
+
+> **Note**: Forking is available in Chroma Cloud only. The storage engine on single-node Chroma does not support forking.
+
+## Go Examples
+
+### Basic Collection Fork
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+source_collection = client.get_collection(name="main-repo-index")
+
+# Create a forked collection. Name must be unique within the database.
+forked_collection = source_collection.fork(name="main-repo-index-pr-1234")
+
+# Forked collection is immediately queryable; changes are isolated
+forked_collection.add(documents=["new content"], ids=["doc-pr-1"])  # billed as incremental storage
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get the source collection
+	sourceCollection, err := client.GetCollection(ctx, "main-repo-index")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create a forked collection. Name must be unique within the database.
+	forkedCollection, err := sourceCollection.Fork(ctx, "main-repo-index-pr-1234")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Forked collection is immediately queryable; changes are isolated
+	err = forkedCollection.Add(ctx,
+		v2.WithIDs("doc-pr-1"),
+		v2.WithDocuments("new content"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Forked collection '%s' created from '%s'",
+		forkedCollection.Name(), sourceCollection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Git-like Workflow Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+client = chromadb.CloudClient(
+    tenant="your-tenant",
+    database="your-database",
+    api_key="your-api-key"
+)
+
+# Get the main branch collection
+main_collection = client.get_collection(name="codebase-index")
+
+# Fork for a feature branch
+feature_collection = main_collection.fork(name="codebase-index-feature-xyz")
+
+# Add new files from the feature branch
+feature_collection.add(
+    ids=["file1", "file2"],
+    documents=["new feature code", "updated tests"]
+)
+
+# Query the fork - includes both original and new data
+results = feature_collection.query(query_texts=["feature implementation"])
+
+# Original collection remains unchanged
+original_count = main_collection.count()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("your-database", "your-tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get the main branch collection
+	mainCollection, err := client.GetCollection(ctx, "codebase-index")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Fork for a feature branch
+	featureCollection, err := mainCollection.Fork(ctx, "codebase-index-feature-xyz")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Add new files from the feature branch
+	err = featureCollection.Add(ctx,
+		v2.WithIDs("file1", "file2"),
+		v2.WithDocuments("new feature code", "updated tests"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Query the fork - includes both original and new data
+	results, err := featureCollection.Query(ctx,
+		v2.WithQueryTexts("feature implementation"),
+		v2.WithNResults(10),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	fmt.Printf("Found %d results in forked collection\n", len(results.IDs[0]))
+
+	// Original collection remains unchanged
+	originalCount, err := mainCollection.Count(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	fmt.Printf("Original collection still has %d documents\n", originalCount)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Data Versioning / Checkpointing
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+from datetime import datetime
+
+client = chromadb.CloudClient(
+    tenant="your-tenant",
+    database="your-database",
+    api_key="your-api-key"
+)
+
+# Get the production collection
+prod_collection = client.get_collection(name="knowledge-base")
+
+# Create a checkpoint before major update
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+checkpoint = prod_collection.fork(name=f"knowledge-base-checkpoint-{timestamp}")
+
+# Now safe to update production
+prod_collection.update(
+    ids=["doc1"],
+    documents=["updated content"]
+)
+
+# If something goes wrong, checkpoint has the original data
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("your-database", "your-tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get the production collection
+	prodCollection, err := client.GetCollection(ctx, "knowledge-base")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create a checkpoint before major update
+	timestamp := time.Now().Format("20060102_150405")
+	checkpointName := fmt.Sprintf("knowledge-base-checkpoint-%s", timestamp)
+
+	checkpoint, err := prodCollection.Fork(ctx, checkpointName)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Checkpoint created: %s", checkpoint.Name())
+
+	// Now safe to update production
+	err = prodCollection.Update(ctx,
+		v2.WithIDs("doc1"),
+		v2.WithDocuments("updated content"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Println("Production collection updated")
+
+	// If something goes wrong, checkpoint has the original data
+	// You can query it or use it to restore
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### A/B Testing with Forks
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+client = chromadb.CloudClient(
+    tenant="your-tenant",
+    database="your-database",
+    api_key="your-api-key"
+)
+
+# Get baseline collection
+baseline = client.get_collection(name="search-index")
+
+# Create variant A - different embedding model
+variant_a = baseline.fork(name="search-index-variant-a")
+
+# Create variant B - different chunking strategy
+variant_b = baseline.fork(name="search-index-variant-b")
+
+# Modify variant A with new embeddings
+variant_a.update(
+    ids=["doc1", "doc2"],
+    embeddings=[new_embeddings_a]
+)
+
+# Modify variant B with different data
+variant_b.delete(ids=["doc1"])
+variant_b.add(ids=["doc1a", "doc1b"], documents=["chunk1", "chunk2"])
+
+# Run queries against all three for comparison
+query = "search query"
+baseline_results = baseline.query(query_texts=[query])
+variant_a_results = variant_a.query(query_texts=[query])
+variant_b_results = variant_b.query(query_texts=[query])
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("your-database", "your-tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get baseline collection
+	baseline, err := client.GetCollection(ctx, "search-index")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create variant A - different embedding model
+	variantA, err := baseline.Fork(ctx, "search-index-variant-a")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create variant B - different chunking strategy
+	variantB, err := baseline.Fork(ctx, "search-index-variant-b")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Modify variant A with new embeddings
+	err = variantA.Update(ctx,
+		v2.WithIDs("doc1", "doc2"),
+		v2.WithEmbeddings([][]float32{{0.1, 0.2}, {0.3, 0.4}}),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Modify variant B with different chunking
+	err = variantB.Delete(ctx, v2.WithDeleteIDs("doc1"))
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	err = variantB.Add(ctx,
+		v2.WithIDs("doc1a", "doc1b"),
+		v2.WithDocuments("chunk1", "chunk2"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Run queries against all three for comparison
+	query := "search query"
+
+	baselineResults, err := baseline.Query(ctx,
+		v2.WithQueryTexts(query),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	variantAResults, err := variantA.Query(ctx,
+		v2.WithQueryTexts(query),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	variantBResults, err := variantB.Query(ctx,
+		v2.WithQueryTexts(query),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Compare results
+	fmt.Printf("Baseline results: %d\n", len(baselineResults.IDs[0]))
+	fmt.Printf("Variant A results: %d\n", len(variantAResults.IDs[0]))
+	fmt.Printf("Variant B results: %d\n", len(variantBResults.IDs[0]))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Fork API Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `collection.fork(name="new-name")` | `collection.Fork(ctx, "new-name")` | Create fork of collection |
+
+## Notes
+
+- **Copy-on-write**: Forks share data blocks with the source collection. New writes to either branch allocate new blocks; unchanged data remains shared.
+- **Instant**: Forking a collection of any size completes quickly.
+- **Isolation**: Changes to a fork do not affect the source, and vice versa.
+- **Pricing**: $0.03 per fork call, plus storage for incremental blocks written after the fork.
+- **Quota**: Default limit is 4,096 fork edges per tree. Deleted collections still count toward this limit.
+- **Database scope**: Forked collections belong to the same database as the source collection.
+
+## Use Cases
+
+1. **Data versioning/checkpointing**: Maintain consistent snapshots as your data evolves
+2. **Git-like workflows**: Index a branch by forking from its divergence point, then apply the diff
+3. **A/B testing**: Compare different embedding strategies or data configurations
+4. **Safe experimentation**: Test changes without affecting production data
+

--- a/docs/go-examples/cloud/schema/schema-basics.md
+++ b/docs/go-examples/cloud/schema/schema-basics.md
@@ -1,0 +1,514 @@
+# Schema Basics - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/schema/schema-basics)
+
+## Overview
+
+Learn how to create and use Schema to configure indexes on your Chroma collections. A Schema controls which fields are indexed and how, with support for vector indexes, full-text search, sparse vectors, and metadata inverted indexes.
+
+## Go Examples
+
+### Creating a Schema
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema
+
+# Create an empty schema (starts with defaults)
+schema = Schema()
+
+# The schema is now ready to be configured
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create schema with defaults (L2 vector index with HNSW)
+	schema, err := v2.NewSchemaWithDefaults()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Or create an empty schema with specific options
+	customSchema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v, %v", schema, customSchema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Configuring Vector Index
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, VectorIndexConfig
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+schema = Schema()
+
+# Configure vector index with custom embedding function
+embedding_function = OpenAIEmbeddingFunction(
+    api_key="your-api-key",
+    model_name="text-embedding-3-small"
+)
+
+schema.create_index(config=VectorIndexConfig(
+    space="cosine",
+    embedding_function=embedding_function
+))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	// Create embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		openai.WithAPIKey("your-api-key"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with custom vector index configuration
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+			v2.WithVectorEmbeddingFunction(ef),
+			v2.WithHnsw(v2.NewHnswConfig(
+				v2.WithEfConstruction(100),
+				v2.WithMaxNeighbors(16),
+				v2.WithEfSearch(10),
+			)),
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v", schema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Configuring Sparse Vector Index
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, SparseVectorIndexConfig, K
+from chromadb.utils.embedding_functions import ChromaCloudSpladeEmbeddingFunction
+
+schema = Schema()
+
+# Add sparse vector index for a specific key (required for hybrid search)
+sparse_ef = ChromaCloudSpladeEmbeddingFunction()
+schema.create_index(
+    config=SparseVectorIndexConfig(
+        source_key=K.DOCUMENT,
+        embedding_function=sparse_ef
+    ),
+    key="sparse_embedding"
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade"
+)
+
+func main() {
+	// Create sparse embedding function
+	sparseEF, err := splade.NewChromaCloudSpladeEmbeddingFunction(
+		splade.WithAPIKey(os.Getenv("CHROMA_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with sparse vector index on a specific key
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+		)),
+		v2.WithSparseVectorIndex("sparse_embedding", v2.NewSparseVectorIndexConfig(
+			v2.WithSparseEmbeddingFunction(sparseEF),
+			v2.WithSparseSourceKey(v2.DocumentKey), // "#document"
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v", schema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Configuring Metadata Indexes
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, StringInvertedIndexConfig, IntInvertedIndexConfig
+
+schema = Schema()
+
+# Disable string inverted index globally
+schema.delete_index(config=StringInvertedIndexConfig())
+
+# Disable int inverted index for a specific key
+schema.delete_index(config=IntInvertedIndexConfig(), key="unimportant_count")
+
+# Disable all indexes for a specific key
+schema.delete_index(key="temporary_field")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create schema with custom metadata index configuration
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceL2),
+		)),
+		// Disable string inverted index globally
+		v2.DisableDefaultStringIndex(),
+		// Disable int inverted index for a specific key
+		v2.DisableIntIndex("unimportant_count"),
+		// Enable string index for specific keys
+		v2.WithStringIndex("category"),
+		v2.WithStringIndex("tags"),
+		// Enable other indexes for specific keys
+		v2.WithIntIndex("year"),
+		v2.WithFloatIndex("score"),
+		v2.WithBoolIndex("published"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v", schema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Method Chaining vs Functional Options
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, StringInvertedIndexConfig, IntInvertedIndexConfig
+
+schema = (Schema()
+    .delete_index(config=StringInvertedIndexConfig())  # Disable globally
+    .create_index(config=StringInvertedIndexConfig(), key="category")  # Enable for category
+    .create_index(config=StringInvertedIndexConfig(), key="tags")  # Enable for tags
+    .delete_index(config=IntInvertedIndexConfig()))  # Disable int indexing
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Go uses functional options instead of method chaining
+	// All configuration is passed to NewSchema at creation time
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceL2),
+		)),
+		// Disable string indexing globally
+		v2.DisableDefaultStringIndex(),
+		// Enable for specific keys
+		v2.WithStringIndex("category"),
+		v2.WithStringIndex("tags"),
+		// Disable int indexing globally
+		v2.DisableDefaultIntIndex(),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v", schema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Using Schema with Collections
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Create collection with schema
+collection = client.create_collection(
+    name="my_collection",
+    schema=schema
+)
+
+# Or use get_or_create_collection
+collection = client.get_or_create_collection(
+    name="my_collection",
+    schema=schema
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create schema with configuration
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+		)),
+		v2.WithStringIndex("category"),
+		v2.WithIntIndex("year"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create collection with schema
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Or use GetOrCreateCollection
+	collection, err = client.GetOrCreateCollection(ctx, "my_collection",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection created: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Schema Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, VectorIndexConfig, SparseVectorIndexConfig, StringInvertedIndexConfig, K
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction, ChromaCloudSpladeEmbeddingFunction
+
+# Create embedding functions
+dense_ef = OpenAIEmbeddingFunction(api_key="your-api-key", model_name="text-embedding-3-small")
+sparse_ef = ChromaCloudSpladeEmbeddingFunction()
+
+# Create schema with full configuration
+schema = (Schema()
+    .create_index(config=VectorIndexConfig(
+        space="cosine",
+        embedding_function=dense_ef
+    ))
+    .create_index(config=SparseVectorIndexConfig(
+        source_key=K.DOCUMENT,
+        embedding_function=sparse_ef
+    ), key="sparse_embedding")
+    .delete_index(config=StringInvertedIndexConfig())  # Disable globally
+    .create_index(config=StringInvertedIndexConfig(), key="category")
+    .create_index(config=StringInvertedIndexConfig(), key="author"))
+
+collection = client.create_collection(name="articles", schema=schema)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create embedding functions
+	denseEF, err := openai.NewOpenAIEmbeddingFunction(
+		openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	sparseEF, err := splade.NewChromaCloudSpladeEmbeddingFunction(
+		splade.WithAPIKey(os.Getenv("CHROMA_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with full configuration
+	schema, err := v2.NewSchema(
+		// Configure vector index with embedding function
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+			v2.WithVectorEmbeddingFunction(denseEF),
+			v2.WithHnsw(v2.NewHnswConfig(
+				v2.WithEfConstruction(100),
+				v2.WithMaxNeighbors(16),
+			)),
+		)),
+		// Configure sparse vector index for hybrid search
+		v2.WithSparseVectorIndex("sparse_embedding", v2.NewSparseVectorIndexConfig(
+			v2.WithSparseEmbeddingFunction(sparseEF),
+			v2.WithSparseSourceKey(v2.DocumentKey),
+		)),
+		// Disable string indexing globally
+		v2.DisableDefaultStringIndex(),
+		// Enable for specific keys
+		v2.WithStringIndex("category"),
+		v2.WithStringIndex("author"),
+		// Enable other metadata indexes
+		v2.WithIntIndex("year"),
+		v2.WithFloatIndex("rating"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create collection with schema
+	collection, err := client.CreateCollection(ctx, "articles",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection created: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Schema API Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `Schema()` | `v2.NewSchema(opts...)` | Create new schema |
+| `Schema()` (with defaults) | `v2.NewSchemaWithDefaults()` | Create schema with L2 defaults |
+| `VectorIndexConfig(space=...)` | `v2.NewVectorIndexConfig(v2.WithSpace(...))` | Configure vector index |
+| `SparseVectorIndexConfig(...)` | `v2.NewSparseVectorIndexConfig(...)` | Configure sparse vector index |
+| `.create_index(config=..., key=...)` | `v2.WithVectorIndex(key, cfg)` | Add index to key |
+| `.delete_index(config=..., key=...)` | `v2.DisableStringIndex(key)` | Disable index on key |
+| `.delete_index(config=StringInvertedIndexConfig())` | `v2.DisableDefaultStringIndex()` | Disable string index globally |
+
+### Space Constants
+
+| Python | Go Constant | Description |
+|--------|-------------|-------------|
+| `"l2"` | `v2.SpaceL2` | Euclidean distance |
+| `"cosine"` | `v2.SpaceCosine` | Cosine similarity |
+| `"ip"` | `v2.SpaceIP` | Inner product |
+
+### Reserved Keys
+
+| Python | Go Constant | Description |
+|--------|-------------|-------------|
+| `K.DOCUMENT` | `v2.DocumentKey` (`"#document"`) | Document text content |
+| `K.EMBEDDING` | `v2.EmbeddingKey` (`"#embedding"`) | Dense vector embeddings |
+
+## Notes
+
+- Go uses functional options pattern instead of method chaining
+- All schema configuration is passed at creation time via `NewSchema(opts...)`
+- HNSW configuration is available via `WithHnsw()` for fine-tuning
+- SPANN configuration is available via `WithSpann()` for cloud-scale workloads
+- Schema is automatically persisted with the collection
+- Embedding functions are serialized/deserialized automatically when supported
+

--- a/docs/go-examples/cloud/schema/sparse-vector-search.md
+++ b/docs/go-examples/cloud/schema/sparse-vector-search.md
@@ -1,0 +1,574 @@
+# Sparse Vector Search Setup - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/schema/sparse-vector-search)
+
+## Overview
+
+Learn how to configure and use sparse vectors for keyword-based search, and combine them with dense embeddings for powerful hybrid search capabilities.
+
+## Go Examples
+
+### Enabling Sparse Vector Index
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Schema, SparseVectorIndexConfig, K
+from chromadb.utils.embedding_functions import ChromaCloudSpladeEmbeddingFunction
+
+schema = Schema()
+
+# Add sparse vector index for keyword-based search
+# "sparse_embedding" is just a metadata key name - use any name you prefer
+sparse_ef = ChromaCloudSpladeEmbeddingFunction()
+schema.create_index(
+    config=SparseVectorIndexConfig(
+        source_key=K.DOCUMENT,
+        embedding_function=sparse_ef
+    ),
+    key="sparse_embedding"
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade"
+)
+
+func main() {
+	// Create sparse embedding function
+	sparseEF, err := splade.NewChromaCloudSpladeEmbeddingFunction(
+		splade.WithAPIKey(os.Getenv("CHROMA_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with sparse vector index
+	// "sparse_embedding" is the metadata key name where sparse vectors are stored
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+		)),
+		v2.WithSparseVectorIndex("sparse_embedding", v2.NewSparseVectorIndexConfig(
+			v2.WithSparseEmbeddingFunction(sparseEF),
+			v2.WithSparseSourceKey(v2.DocumentKey), // Generate from document text
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Schema created: %v", schema)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Create Collection with Schema
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+client = chromadb.CloudClient(
+    tenant="your-tenant",
+    database="your-database",
+    api_key="your-api-key"
+)
+
+collection = client.create_collection(
+    name="hybrid_search_collection",
+    schema=schema
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey(os.Getenv("CHROMA_API_KEY")),
+		v2.WithDatabaseAndTenant("your-database", "your-tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create sparse embedding function
+	sparseEF, err := splade.NewChromaCloudSpladeEmbeddingFunction(
+		splade.WithAPIKey(os.Getenv("CHROMA_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with sparse vector index
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+		)),
+		v2.WithSparseVectorIndex("sparse_embedding", v2.NewSparseVectorIndexConfig(
+			v2.WithSparseEmbeddingFunction(sparseEF),
+			v2.WithSparseSourceKey(v2.DocumentKey),
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create collection with schema
+	collection, err := client.CreateCollection(ctx, "hybrid_search_collection",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection created: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Add Data
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.add(
+    ids=["doc1", "doc2", "doc3"],
+    documents=[
+        "The quick brown fox jumps over the lazy dog",
+        "A fast auburn fox leaps over a sleepy canine",
+        "Machine learning is a subset of artificial intelligence"
+    ],
+    metadatas=[
+        {"category": "animals"},
+        {"category": "animals"},
+        {"category": "technology"}
+    ]
+)
+
+# Sparse embeddings for "sparse_embedding" are generated automatically
+# from the documents (source_key=K.DOCUMENT)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Assuming collection is already created with sparse vector schema
+	ctx := context.Background()
+
+	// Add documents - sparse embeddings are generated automatically
+	// from the documents based on the schema configuration
+	err := collection.Add(ctx,
+		v2.WithIDs("doc1", "doc2", "doc3"),
+		v2.WithDocuments(
+			"The quick brown fox jumps over the lazy dog",
+			"A fast auburn fox leaps over a sleepy canine",
+			"Machine learning is a subset of artificial intelligence",
+		),
+		v2.WithMetadatas(
+			map[string]interface{}{"category": "animals"},
+			map[string]interface{}{"category": "animals"},
+			map[string]interface{}{"category": "technology"},
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Println("Documents added with auto-generated sparse embeddings")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Sparse Vector Search
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+# Search using sparse embeddings only
+sparse_rank = Knn(query="fox animal", key="sparse_embedding")
+
+# Build and execute search
+search = (Search()
+    .rank(sparse_rank)
+    .limit(10)
+    .select(K.DOCUMENT, K.SCORE))
+
+results = collection.search(search)
+
+# Process results
+for row in results.rows()[0]:
+    print(f"Score: {row['score']:.3f} - {row['document']}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Search using sparse embeddings only
+	// The query text will be converted to sparse vector using the configured embedding function
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(
+				v2.KnnQueryText("fox animal"),
+				v2.WithKnnKey(v2.K("sparse_embedding")), // Search on sparse index
+				v2.WithKnnLimit(50),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Process results using Rows()
+	for _, row := range result.Rows() {
+		fmt.Printf("Score: %.3f - %s\n", row.Score, row.Document)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Hybrid Search with RRF
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, Rrf
+
+# Create RRF ranking combining dense and sparse embeddings
+hybrid_rank = Rrf(
+    ranks=[
+        Knn(query="fox animal", return_rank=True),           # Dense semantic search
+        Knn(query="fox animal", key="sparse_embedding", return_rank=True)  # Sparse keyword search
+    ],
+    weights=[0.7, 0.3],  # 70% semantic, 30% keyword
+    k=60
+)
+
+# Build and execute search
+search = (Search()
+    .rank(hybrid_rank)
+    .limit(10)
+    .select(K.DOCUMENT, K.SCORE))
+
+results = collection.search(search)
+
+# Process results
+for row in results.rows()[0]:
+    print(f"Score: {row['score']:.3f} - {row['document']}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Create KNN ranks for dense and sparse search
+	denseKnn, err := v2.NewKnnRank(
+		v2.KnnQueryText("fox animal"),
+		v2.WithKnnReturnRank(), // Required for RRF
+		v2.WithKnnLimit(100),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	sparseKnn, err := v2.NewKnnRank(
+		v2.KnnQueryText("fox animal"),
+		v2.WithKnnKey(v2.K("sparse_embedding")), // Search on sparse index
+		v2.WithKnnReturnRank(),                   // Required for RRF
+		v2.WithKnnLimit(100),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create RRF ranking combining dense and sparse
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(0.7),  // 70% semantic
+					sparseKnn.WithWeight(0.3), // 30% keyword
+				),
+				v2.WithRffK(60),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Process results using Rows()
+	for _, row := range result.Rows() {
+		fmt.Printf("Score: %.3f - %s\n", row.Score, row.Document)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Hybrid Search Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+from chromadb import Schema, SparseVectorIndexConfig, VectorIndexConfig, K, Search, Knn, Rrf
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction, ChromaCloudSpladeEmbeddingFunction
+
+# Create client
+client = chromadb.CloudClient(
+    tenant="your-tenant",
+    database="your-database",
+    api_key="your-api-key"
+)
+
+# Create embedding functions
+dense_ef = OpenAIEmbeddingFunction(api_key="your-openai-key")
+sparse_ef = ChromaCloudSpladeEmbeddingFunction()
+
+# Create schema
+schema = (Schema()
+    .create_index(config=VectorIndexConfig(space="cosine", embedding_function=dense_ef))
+    .create_index(config=SparseVectorIndexConfig(
+        source_key=K.DOCUMENT,
+        embedding_function=sparse_ef
+    ), key="sparse_embedding"))
+
+# Create collection
+collection = client.create_collection(name="hybrid_demo", schema=schema)
+
+# Add data
+collection.add(
+    ids=["1", "2", "3"],
+    documents=[
+        "Python is a programming language",
+        "Machine learning uses algorithms",
+        "Deep learning is a subset of ML"
+    ]
+)
+
+# Hybrid search
+results = collection.search(Search()
+    .rank(Rrf(
+        ranks=[
+            Knn(query="programming", return_rank=True),
+            Knn(query="programming", key="sparse_embedding", return_rank=True)
+        ],
+        weights=[0.6, 0.4]
+    ))
+    .limit(10)
+    .select(K.DOCUMENT, K.SCORE))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	// Create client
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey(os.Getenv("CHROMA_API_KEY")),
+		v2.WithDatabaseAndTenant("your-database", "your-tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create embedding functions
+	denseEF, err := openai.NewOpenAIEmbeddingFunction(
+		openai.WithAPIKey(os.Getenv("OPENAI_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	sparseEF, err := splade.NewChromaCloudSpladeEmbeddingFunction(
+		splade.WithAPIKey(os.Getenv("CHROMA_API_KEY")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create schema with both dense and sparse indexes
+	schema, err := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+			v2.WithVectorEmbeddingFunction(denseEF),
+		)),
+		v2.WithSparseVectorIndex("sparse_embedding", v2.NewSparseVectorIndexConfig(
+			v2.WithSparseEmbeddingFunction(sparseEF),
+			v2.WithSparseSourceKey(v2.DocumentKey),
+		)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create collection
+	collection, err := client.CreateCollection(ctx, "hybrid_demo",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Add data - embeddings generated automatically
+	err = collection.Add(ctx,
+		v2.WithIDs("1", "2", "3"),
+		v2.WithDocuments(
+			"Python is a programming language",
+			"Machine learning uses algorithms",
+			"Deep learning is a subset of ML",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create KNN ranks for hybrid search
+	denseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("programming"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	sparseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("programming"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	// Execute hybrid search
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(0.6),
+					sparseKnn.WithWeight(0.4),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Print results using Rows()
+	fmt.Println("Hybrid Search Results:")
+	for _, row := range result.Rows() {
+		fmt.Printf("  %.3f: %s\n", row.Score, row.Document)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Sparse Vector Configuration Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `SparseVectorIndexConfig(...)` | `v2.NewSparseVectorIndexConfig(...)` | Create sparse vector config |
+| `source_key=K.DOCUMENT` | `v2.WithSparseSourceKey(v2.DocumentKey)` | Set source field for text |
+| `embedding_function=ef` | `v2.WithSparseEmbeddingFunction(ef)` | Set sparse embedding function |
+| `schema.create_index(..., key="name")` | `v2.WithSparseVectorIndex("name", cfg)` | Add sparse index to schema |
+
+## Available Sparse Embedding Functions
+
+| Provider | Go Package | Description |
+|----------|------------|-------------|
+| Chroma Cloud SPLADE | `github.com/amikos-tech/chroma-go/pkg/embeddings/chroma_cloud_splade` | Cloud-hosted SPLADE |
+| HuggingFace | `github.com/amikos-tech/chroma-go/pkg/embeddings/hf` | Hugging Face sparse models |
+
+## Notes
+
+- Sparse vectors excel at exact keyword matching and domain-specific terms
+- Dense vectors capture semantic meaning - use both for best results
+- The `source_key` specifies which field generates sparse embeddings (usually `#document`)
+- Sparse embeddings are auto-generated when adding documents with a schema
+- Use RRF to combine dense and sparse search for hybrid retrieval
+- Weight tuning depends on your use case - start with 0.7/0.3 and adjust
+- Use `Rows()` for ergonomic iteration over results
+- Use `At(group, index)` for safe indexed access with bounds checking
+

--- a/docs/go-examples/cloud/search-api/batch-operations.md
+++ b/docs/go-examples/cloud/search-api/batch-operations.md
@@ -1,0 +1,494 @@
+# Batch Operations - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/batch-operations)
+
+## Overview
+
+Execute multiple searches in a single API call for better performance and easier comparison of results.
+
+## Go Examples
+
+### Running Multiple Searches
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+searches = [
+    # Search 1: Recent articles
+    (Search()
+        .where((K("type") == "article") & (K("year") >= 2024))
+        .rank(Knn(query="machine learning applications"))
+        .limit(5)
+        .select(K.DOCUMENT, K.SCORE, "title")),
+
+    # Search 2: Papers by specific authors
+    (Search()
+        .where(K("author").is_in(["Smith", "Jones"]))
+        .rank(Knn(query="neural network research"))
+        .limit(10)
+        .select(K.DOCUMENT, K.SCORE, "title", "author")),
+
+    # Search 3: Featured content
+    Search()
+        .where(K("status") == "featured")
+        .limit(20)
+        .select("title", "date")
+]
+
+# Execute all searches in one request
+results = collection.search(searches)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Execute multiple searches in one call
+	results, err := collection.Search(ctx,
+		// Search 1: Recent articles
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString("type", "article"),
+					v2.GteInt("year", 2024),
+				),
+			),
+			v2.WithKnnRank(
+				v2.KnnQueryText("machine learning applications"),
+				v2.WithKnnLimit(50),
+			),
+			v2.WithPage(v2.WithLimit(5)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title")),
+		),
+		// Search 2: Papers by specific authors
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.InString("author", "Smith", "Jones")),
+			v2.WithKnnRank(
+				v2.KnnQueryText("neural network research"),
+				v2.WithKnnLimit(50),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("author")),
+		),
+		// Search 3: Featured content (no ranking)
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("status", "featured")),
+			v2.WithPage(v2.WithLimit(20)),
+			v2.WithSelect(v2.K("title"), v2.K("date")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Access results by index
+	log.Printf("Search 1 results: %d", len(results.IDs[0]))
+	log.Printf("Search 2 results: %d", len(results.IDs[1]))
+	log.Printf("Search 3 results: %d", len(results.IDs[2]))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Accessing Batch Results
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Batch search returns multiple result sets
+results = collection.search([search1, search2, search3])
+
+# Access results by index
+ids_1 = results.ids[0]    # IDs from search1
+ids_2 = results.ids[1]    # IDs from search2
+ids_3 = results.ids[2]    # IDs from search3
+
+# Process each search's results
+for search_index, ids in enumerate(results.ids):
+    print(f"Results from search {search_index + 1}:")
+    for i, id in enumerate(ids):
+        print(f"  - {id}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Execute batch searches
+	results, err := collection.Search(ctx,
+		v2.NewSearchRequest(v2.WithPage(v2.WithLimit(5))),
+		v2.NewSearchRequest(v2.WithPage(v2.WithLimit(10))),
+		v2.NewSearchRequest(v2.WithPage(v2.WithLimit(20))),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Access results by index
+	ids1 := results.IDs[0] // IDs from search 1
+	ids2 := results.IDs[1] // IDs from search 2
+	ids3 := results.IDs[2] // IDs from search 3
+
+	// Process each search's results
+	for searchIndex, ids := range results.IDs {
+		fmt.Printf("Results from search %d:\n", searchIndex+1)
+		for _, id := range ids {
+			fmt.Printf("  - %s\n", id)
+		}
+	}
+
+	log.Printf("Total searches: %d (%d, %d, %d)",
+		len(results.IDs), len(ids1), len(ids2), len(ids3))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Comparing Different Queries
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Compare different query variations
+query_variations = [
+    "machine learning",
+    "machine learning algorithms and applications",
+    "modern machine learning techniques"
+]
+
+searches = [
+    Search()
+        .rank(Knn(query=q))
+        .limit(10)
+        .select(K.DOCUMENT, K.SCORE, "title")
+    for q in query_variations
+]
+
+results = collection.search(searches)
+
+# Compare top results from each variation
+for i, query_name in enumerate(["Original", "Expanded", "Refined"]):
+    print(f"{query_name} Query Top Result:")
+    if results.scores[i]:
+        print(f"  Score: {results.scores[i][0]:.3f}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Compare different query variations
+	queryVariations := []string{
+		"machine learning",
+		"machine learning algorithms and applications",
+		"modern machine learning techniques",
+	}
+
+	// Build search options for each query
+	searchOpts := make([]v2.SearchCollectionOption, len(queryVariations))
+	for i, q := range queryVariations {
+		searchOpts[i] = v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText(q), v2.WithKnnLimit(50)),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title")),
+		)
+	}
+
+	// Execute all at once
+	results, err := collection.Search(ctx, searchOpts...)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Compare top results from each variation
+	queryNames := []string{"Original", "Expanded", "Refined"}
+	for i, queryName := range queryNames {
+		fmt.Printf("%s Query Top Result:\n", queryName)
+		if results.Scores != nil && len(results.Scores[i]) > 0 {
+			fmt.Printf("  Score: %.3f\n", results.Scores[i][0])
+		}
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Searching Across Categories
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Different category filters
+categories = ["technology", "science", "business"]
+
+searches = [
+    Search()
+        .where(K("category") == category)
+        .rank(Knn(query="artificial intelligence"))
+        .limit(5)
+        .select("title", "category", K.SCORE)
+    for category in categories
+]
+
+results = collection.search(searches)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Different category filters
+	categories := []string{"technology", "science", "business"}
+
+	// Build search options for each category
+	searchOpts := make([]v2.SearchCollectionOption, len(categories))
+	for i, category := range categories {
+		searchOpts[i] = v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("category", category)),
+			v2.WithKnnRank(
+				v2.KnnQueryText("artificial intelligence"),
+				v2.WithKnnLimit(50),
+			),
+			v2.WithPage(v2.WithLimit(5)),
+			v2.WithSelect(v2.K("title"), v2.K("category"), v2.KScore),
+		)
+	}
+
+	// Execute all at once
+	results, err := collection.Search(ctx, searchOpts...)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Process results by category using RowGroups()
+	rowGroups := results.RowGroups()
+	for i, category := range categories {
+		fmt.Printf("\nCategory: %s\n", category)
+		if i >= len(rowGroups) || len(rowGroups[i]) == 0 {
+			fmt.Println("  No results found")
+			continue
+		}
+		for j, row := range rowGroups[i] {
+			title := ""
+			if row.Metadata != nil {
+				if t, ok := row.Metadata.Get("title"); ok {
+					title = fmt.Sprintf("%v", t)
+				}
+			}
+			fmt.Printf("  %d. %s (Score: %.3f, ID: %s)\n", j+1, title, row.Score, row.ID)
+		}
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Performance: Batch vs Sequential
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Sequential execution (slow) - multiple API calls
+results = []
+for search in searches:
+    result = collection.search(search)
+    results.append(result)
+
+# Batch execution (fast) - single API call
+results = collection.search(searches)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	queries := []string{"query1", "query2", "query3"}
+
+	// Sequential execution (slow) - multiple API calls
+	sequentialResults := make([]*v2.SearchResultImpl, len(queries))
+	for i, q := range queries {
+		result, _ := collection.Search(ctx,
+			v2.NewSearchRequest(
+				v2.WithKnnRank(v2.KnnQueryText(q)),
+				v2.WithPage(v2.WithLimit(10)),
+			),
+		)
+		sequentialResults[i] = result
+	}
+
+	// Batch execution (fast) - single API call
+	searchOpts := make([]v2.SearchCollectionOption, len(queries))
+	for i, q := range queries {
+		searchOpts[i] = v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText(q)),
+			v2.WithPage(v2.WithLimit(10)),
+		)
+	}
+	batchResult, _ := collection.Search(ctx, searchOpts...)
+
+	log.Printf("Sequential: %d searches, Batch: %d result sets",
+		len(sequentialResults), len(batchResult.IDs))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Iterating Over Batch Results
+
+Use the `RowGroups()` method for ergonomic iteration over batch results:
+
+```go
+results, err := collection.Search(ctx, search1, search2, search3)
+if err != nil {
+    log.Fatalf("Error: %v", err)
+}
+
+// Iterate using RowGroups() - each group corresponds to a search request
+for i, rows := range results.RowGroups() {
+    fmt.Printf("Search %d results:\n", i+1)
+    for j, row := range rows {
+        fmt.Printf("  %d. ID: %s, Score: %.3f\n", j+1, row.ID, row.Score)
+        if row.Metadata != nil {
+            if title, ok := row.Metadata.Get("title"); ok {
+                fmt.Printf("      Title: %v\n", title)
+            }
+        }
+    }
+}
+
+// Or use At(group, index) for safe indexed access
+if row, ok := results.At(0, 0); ok {
+    fmt.Printf("First result of first search: %s\n", row.ID)
+}
+```
+
+## Notes
+
+- Batch operations reduce network overhead with a single API call
+- Results maintain the same order as input searches
+- Each search can have different filters, rankings, and field selections
+- Use batch operations for 3-10x speedup compared to sequential execution
+- Mixed field selection is supported - each search returns only its requested fields
+- Use `RowGroups()` for easy iteration over all search result groups
+- Use `At(group, index)` for safe indexed access with bounds checking
+

--- a/docs/go-examples/cloud/search-api/examples.md
+++ b/docs/go-examples/cloud/search-api/examples.md
@@ -1,0 +1,583 @@
+# Examples & Patterns - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/examples)
+
+## Overview
+
+Complete end-to-end examples demonstrating real-world use cases of the Search API.
+
+## E-commerce Product Search
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, And
+
+def search_products(collection, user_query, min_price=None, max_price=None,
+                   category=None, in_stock_only=True, page=0, page_size=20):
+    # Build filter conditions
+    combined_filter = And([])
+
+    if in_stock_only:
+        combined_filter &= K("in_stock") == True
+
+    if category:
+        combined_filter &= K("category") == category
+
+    if min_price is not None:
+        combined_filter &= K("price") >= min_price
+
+    if max_price is not None:
+        combined_filter &= K("price") <= max_price
+
+    # Build search
+    search = (Search()
+        .where(combined_filter)
+        .rank(Knn(query=user_query))
+        .limit(page_size, offset=page * page_size)
+        .select(K.DOCUMENT, K.SCORE, "name", "price", "category", "rating"))
+
+    results = collection.search(search)
+    return results.rows()[0]
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+type ProductSearchOptions struct {
+	UserQuery   string
+	MinPrice    *float64
+	MaxPrice    *float64
+	Category    string
+	InStockOnly bool
+	Page        int
+	PageSize    int
+}
+
+func searchProducts(
+	ctx context.Context,
+	collection v2.CollectionAPI,
+	opts ProductSearchOptions,
+) (*v2.SearchResultImpl, error) {
+	// Build filter conditions
+	var filters []v2.WhereClause
+
+	if opts.InStockOnly {
+		filters = append(filters, v2.EqBool("in_stock", true))
+	}
+
+	if opts.Category != "" {
+		filters = append(filters, v2.EqString("category", opts.Category))
+	}
+
+	if opts.MinPrice != nil {
+		filters = append(filters, v2.GteFloat("price", *opts.MinPrice))
+	}
+
+	if opts.MaxPrice != nil {
+		filters = append(filters, v2.LteFloat("price", *opts.MaxPrice))
+	}
+
+	// Build search options
+	searchOpts := []v2.SearchOption{
+		v2.WithKnnRank(
+			v2.KnnQueryText(opts.UserQuery),
+			v2.WithKnnLimit(100),
+		),
+		v2.WithPage(
+			v2.WithLimit(opts.PageSize),
+			v2.WithOffset(opts.Page*opts.PageSize),
+		),
+		v2.WithSelect(v2.KDocument, v2.KScore, v2.K("name"), v2.K("price"), v2.K("category"), v2.K("rating")),
+	}
+
+	// Add combined filter if we have conditions
+	if len(filters) > 0 {
+		searchOpts = append([]v2.SearchOption{v2.WithFilter(v2.And(filters...))}, searchOpts...)
+	}
+
+	return collection.Search(ctx, v2.NewSearchRequest(searchOpts...))
+}
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "products")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Search for products
+	minPrice := 50.0
+	maxPrice := 300.0
+	results, err := searchProducts(ctx, collection, ProductSearchOptions{
+		UserQuery:   "noise cancelling headphones for travel",
+		MinPrice:    &minPrice,
+		MaxPrice:    &maxPrice,
+		Category:    "electronics",
+		InStockOnly: true,
+		Page:        0,
+		PageSize:    20,
+	})
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Display results using the ergonomic Rows() API
+	for i, row := range results.Rows() {
+		name := ""
+		price := 0.0
+		rating := 0.0
+		if row.Metadata != nil {
+			if n, ok := row.Metadata.Get("name"); ok {
+				name = fmt.Sprintf("%v", n)
+			}
+			if p, ok := row.Metadata.Get("price"); ok {
+				price = p.(float64)
+			}
+			if r, ok := row.Metadata.Get("rating"); ok {
+				rating = r.(float64)
+			}
+		}
+
+		fmt.Printf("%d. %s\n", i+1, name)
+		fmt.Printf("   Price: $%.2f | Rating: %.1f/5\n", price, rating)
+		fmt.Printf("   Relevance: %.3f\n\n", row.Score)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Content Recommendation System
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, Rrf
+
+def get_recommendations(collection, user_preferences, seen_content_ids, num_recommendations=10):
+    # Build filter to exclude seen content
+    combined_filter = K.ID.not_in(seen_content_ids)
+
+    # Filter by preferred categories
+    if user_preferences.get("categories"):
+        combined_filter &= K("category").is_in(user_preferences["categories"])
+
+    # Filter by minimum rating
+    min_rating = user_preferences.get("min_rating", 3.5)
+    combined_filter &= K("rating") >= min_rating
+
+    # Create hybrid search with multiple signals
+    user_interest_query = " ".join(user_preferences.get("interests", ["general"]))
+    favorite_topics_query = " ".join(user_preferences.get("favorite_topics", []))
+
+    hybrid_rank = Rrf(
+        ranks=[
+            Knn(query=user_interest_query, return_rank=True, limit=200),
+            Knn(query=favorite_topics_query, return_rank=True, limit=200)
+        ],
+        weights=[0.6, 0.4],
+        k=60
+    )
+
+    search = (Search()
+        .where(combined_filter)
+        .rank(hybrid_rank)
+        .limit(num_recommendations)
+        .select(K.DOCUMENT, K.SCORE, "title", "category", "author", "rating"))
+
+    return collection.search(search)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+type UserPreferences struct {
+	Interests      []string
+	FavoriteTopics []string
+	Categories     []string
+	MinRating      float64
+}
+
+func getRecommendations(
+	ctx context.Context,
+	collection v2.CollectionAPI,
+	prefs UserPreferences,
+	seenContentIDs []string,
+	numRecommendations int,
+) (*v2.SearchResultImpl, error) {
+	// Build filter conditions
+	var filters []v2.WhereClause
+
+	// Filter by preferred categories
+	if len(prefs.Categories) > 0 {
+		filters = append(filters, v2.InString("category", prefs.Categories...))
+	}
+
+	// Filter by minimum rating
+	minRating := prefs.MinRating
+	if minRating == 0 {
+		minRating = 3.5
+	}
+	filters = append(filters, v2.GteFloat("rating", minRating))
+
+	// Create hybrid search with multiple signals
+	interests := prefs.Interests
+	if len(interests) == 0 {
+		interests = []string{"general"}
+	}
+	userInterestQuery := strings.Join(interests, " ")
+	favoriteTopicsQuery := strings.Join(prefs.FavoriteTopics, " ")
+
+	// Create KNN ranks for RRF
+	interestKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText(userInterestQuery),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(200),
+	)
+
+	topicsKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText(favoriteTopicsQuery),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(200),
+	)
+
+	// Build search
+	searchOpts := []v2.SearchOption{
+		v2.WithRffRank(
+			v2.WithRffRanks(
+				interestKnn.WithWeight(0.6),
+				topicsKnn.WithWeight(0.4),
+			),
+			v2.WithRffK(60),
+		),
+		v2.WithPage(v2.WithLimit(numRecommendations)),
+		v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("category"), v2.K("author"), v2.K("rating")),
+	}
+
+	if len(filters) > 0 {
+		searchOpts = append([]v2.SearchOption{v2.WithFilter(v2.And(filters...))}, searchOpts...)
+	}
+
+	// Add ID filter for seen content (using FilterIDs is for inclusion, so we handle exclusion differently)
+	// Note: ID exclusion might need to be handled at the filter level if supported
+
+	return collection.Search(ctx, v2.NewSearchRequest(searchOpts...))
+}
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "content")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	prefs := UserPreferences{
+		Interests:      []string{"machine learning", "artificial intelligence", "data science"},
+		FavoriteTopics: []string{"neural networks", "deep learning", "transformers"},
+		Categories:     []string{"technology", "science", "research"},
+		MinRating:      4.0,
+	}
+
+	seenContent := []string{"content_001", "content_045", "content_123"}
+
+	results, err := getRecommendations(ctx, collection, prefs, seenContent, 10)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	fmt.Println("Personalized Recommendations:")
+	for i, row := range results.Rows() {
+		title := ""
+		category := ""
+		author := ""
+		rating := 0.0
+		if row.Metadata != nil {
+			if t, ok := row.Metadata.Get("title"); ok {
+				title = fmt.Sprintf("%v", t)
+			}
+			if c, ok := row.Metadata.Get("category"); ok {
+				category = fmt.Sprintf("%v", c)
+			}
+			if a, ok := row.Metadata.Get("author"); ok {
+				author = fmt.Sprintf("%v", a)
+			}
+			if r, ok := row.Metadata.Get("rating"); ok {
+				rating = r.(float64)
+			}
+		}
+
+		fmt.Printf("\n%d. %s\n", i+1, title)
+		fmt.Printf("   Category: %s | Author: %s\n", category, author)
+		fmt.Printf("   Rating: %.1f/5 | Match Score: %.3f\n", rating, row.Score)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Multi-Category Search with Batch Operations
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+def search_across_categories(collection, user_query, categories, results_per_category=5):
+    # Build a search for each category
+    searches = [
+        (Search()
+            .where(K("category") == category)
+            .rank(Knn(query=user_query))
+            .limit(results_per_category)
+            .select(K.DOCUMENT, K.SCORE, "title", "category", "date"))
+        for category in categories
+    ]
+
+    # Execute all searches in one batch
+    results = collection.search(searches)
+
+    # Process results by category
+    category_results = {}
+    for i, category in enumerate(categories):
+        rows = results.rows()[i]
+        category_results[category] = rows
+
+    return category_results
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+type CategoryResult struct {
+	Title string
+	Date  string
+	Score float64
+}
+
+func searchAcrossCategories(
+	ctx context.Context,
+	collection v2.CollectionAPI,
+	userQuery string,
+	categories []string,
+	resultsPerCategory int,
+) (map[string][]CategoryResult, error) {
+	// Build a search for each category
+	searchOpts := make([]v2.SearchCollectionOption, len(categories))
+	for i, category := range categories {
+		searchOpts[i] = v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("category", category)),
+			v2.WithKnnRank(
+				v2.KnnQueryText(userQuery),
+				v2.WithKnnLimit(50),
+			),
+			v2.WithPage(v2.WithLimit(resultsPerCategory)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("category"), v2.K("date")),
+		)
+	}
+
+	// Execute all searches in one batch
+	results, err := collection.Search(ctx, searchOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process results by category using RowGroups() for batch operations
+	categoryResults := make(map[string][]CategoryResult)
+	rowGroups := results.RowGroups()
+	for i, category := range categories {
+		var items []CategoryResult
+		for _, row := range rowGroups[i] {
+			title := ""
+			date := ""
+			if row.Metadata != nil {
+				if t, ok := row.Metadata.Get("title"); ok {
+					title = fmt.Sprintf("%v", t)
+				}
+				if d, ok := row.Metadata.Get("date"); ok {
+					date = fmt.Sprintf("%v", d)
+				}
+			}
+			items = append(items, CategoryResult{
+				Title: title,
+				Date:  date,
+				Score: row.Score,
+			})
+		}
+		categoryResults[category] = items
+	}
+
+	return categoryResults, nil
+}
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "articles")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	query := "latest developments in renewable energy"
+	categories := []string{"technology", "science", "news", "research"}
+
+	results, err := searchAcrossCategories(ctx, collection, query, categories, 3)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Display results
+	for category, items := range results {
+		fmt.Printf("\n%s\n", strings.Repeat("=", 60))
+		fmt.Printf("Category: %s\n", strings.ToUpper(category))
+		fmt.Printf("%s\n", strings.Repeat("=", 60))
+
+		if len(items) == 0 {
+			fmt.Println("  No results found")
+			continue
+		}
+
+		for i, item := range items {
+			fmt.Printf("\n  %d. %s\n", i+1, item.Title)
+			fmt.Printf("     Date: %s\n", item.Date)
+			fmt.Printf("     Relevance: %.3f\n", item.Score)
+		}
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Ergonomic Result Handling
+
+The Go client provides `Rows()` and `RowGroups()` methods for ergonomic result iteration, eliminating manual index tracking.
+
+### ResultRow Structure
+
+```go
+type ResultRow struct {
+    ID        DocumentID       // Document ID
+    Document  string           // Document text (if included)
+    Metadata  DocumentMetadata // Metadata map (if included)
+    Embedding []float32        // Embedding vector (if included)
+    Score     float64          // Relevance score
+}
+```
+
+### Single Search: Rows()
+
+```go
+// For a single search request, use Rows()
+results, _ := collection.Search(ctx, v2.NewSearchRequest(...))
+
+for i, row := range results.Rows() {
+    fmt.Printf("ID: %s, Score: %.3f\n", row.ID, row.Score)
+    if row.Metadata != nil {
+        if title, ok := row.Metadata.Get("title"); ok {
+            fmt.Printf("Title: %v\n", title)
+        }
+    }
+}
+```
+
+### Batch Search: RowGroups()
+
+```go
+// For batch operations with multiple search requests, use RowGroups()
+results, _ := collection.Search(ctx,
+    v2.NewSearchRequest(...), // First search
+    v2.NewSearchRequest(...), // Second search
+)
+
+for groupIdx, rows := range results.RowGroups() {
+    fmt.Printf("Search %d results:\n", groupIdx+1)
+    for _, row := range rows {
+        fmt.Printf("  ID: %s, Score: %.3f\n", row.ID, row.Score)
+    }
+}
+```
+
+### Safe Index Access: At()
+
+```go
+// For safe indexed access with bounds checking
+if row, ok := results.At(0, 5); ok {
+    fmt.Printf("Row 5 of search 0: %s\n", row.ID)
+}
+```
+
+## Best Practices
+
+Based on these examples:
+
+1. **Use Rows() for iteration** - The `Rows()` method provides clean iteration without manual index tracking
+2. **Use RowGroups() for batch results** - When using multiple search requests, `RowGroups()` returns results grouped by search
+3. **Build filters incrementally** - Construct complex filters by combining simpler conditions
+4. **Use batch operations** - When searching multiple variations, use batch operations for better performance
+5. **Select only needed fields** - Reduce data transfer by selecting only the fields you'll use
+6. **Handle empty results gracefully** - Always check if results exist before processing
+7. **Use hybrid search for personalization** - Combine multiple ranking signals with RRF for better recommendations
+8. **Paginate large result sets** - Use limit and offset for efficient pagination
+
+## Notes
+
+- Go uses functional options pattern for building search requests
+- Use `Rows()` for single search results, `RowGroups()` for batch operations
+- Use `At(group, index)` for safe indexed access with bounds checking
+- Error handling is explicit in Go - always check returned errors
+- Batch operations significantly reduce API call overhead
+

--- a/docs/go-examples/cloud/search-api/filtering.md
+++ b/docs/go-examples/cloud/search-api/filtering.md
@@ -1,0 +1,568 @@
+# Filtering with Where - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/filtering)
+
+## Overview
+
+Filter search results using Where expressions to narrow down your search to specific documents, IDs, or metadata values.
+
+## Go Examples
+
+### Basic Metadata Filtering
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import K
+
+# Filter by metadata field
+K("status") == "active"
+
+# Filter by document content
+K.DOCUMENT.contains("machine learning")
+
+# Filter by document IDs (include only these)
+K.ID.is_in(["doc1", "doc2", "doc3"])
+
+# Filter by document IDs (exclude these)
+K.ID.not_in(["excluded1", "excluded2"])
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Filter by metadata field: K("status") == "active"
+	result1, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString(v2.K("status"), "active")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Filter by document content: K.DOCUMENT.contains(...)
+	result2, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.DocumentContains("machine learning")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Filter by specific document IDs: K.ID.is_in([...])
+	// Option 1: Using WithFilterIDs convenience function
+	result3, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilterIDs("doc1", "doc2", "doc3"),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Option 2: Using IDIn within WithFilter
+	result4, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.IDIn("doc1", "doc2", "doc3")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Exclude specific document IDs: K.ID.not_in([...])
+	result5, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.IDNotIn("excluded1", "excluded2")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v, %v, %v, %v, %v", result1, result2, result3, result4, result5)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Comparison Operators
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Equality and inequality (all types)
+K("status") == "published"     # String equality
+K("views") != 0                # Numeric inequality
+K("featured") == True          # Boolean equality
+
+# Numeric comparisons (numbers only)
+K("price") > 100               # Greater than
+K("rating") >= 4.5             # Greater than or equal
+K("stock") < 10                # Less than
+K("discount") <= 0.25          # Less than or equal
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// String equality: K("status") == "published"
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString(v2.K("status"), "published")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Numeric inequality: K("views") != 0
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.NeInt(v2.K("views"), 0)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Boolean equality: K("featured") == True
+	result3, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqBool(v2.K("featured"), true)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Greater than: K("price") > 100
+	result4, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.GtFloat(v2.K("price"), 100)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Greater than or equal: K("rating") >= 4.5
+	result5, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.GteFloat(v2.K("rating"), 4.5)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Less than: K("stock") < 10
+	result6, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.LtInt(v2.K("stock"), 10)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Less than or equal: K("discount") <= 0.25
+	result7, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.LteFloat(v2.K("discount"), 0.25)),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v, %v, %v, %v, %v, %v",
+		result1, result2, result3, result4, result5, result6, result7)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Set Membership Operators
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Set membership operators (works on all fields)
+K.ID.is_in(["doc1", "doc2", "doc3"])           # Match any ID in list
+K.ID.not_in(["excluded1", "excluded2"])        # Exclude specific IDs
+K("category").is_in(["tech", "science"])       # Match any category
+K("status").not_in(["draft", "deleted"])       # Exclude specific values
+
+# String content operators (currently K.DOCUMENT only)
+K.DOCUMENT.contains("machine learning")        # Substring search in document
+K.DOCUMENT.not_contains("deprecated")          # Exclude documents with text
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// K.ID.is_in([...])
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.IDIn("doc1", "doc2", "doc3")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// K.ID.not_in([...])
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.IDNotIn("excluded1", "excluded2")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// K("category").is_in(["tech", "science"])
+	result3, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.InString(v2.K("category"), "tech", "science")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// K("status").not_in(["draft", "deleted"])
+	result4, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.NinString(v2.K("status"), "draft", "deleted")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// K.DOCUMENT.contains(...)
+	result5, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.DocumentContains("machine learning")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// K.DOCUMENT.not_contains(...)
+	result6, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.DocumentNotContains("deprecated")),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v, %v, %v, %v, %v",
+		result1, result2, result3, result4, result5, result6)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Logical Operators (AND/OR)
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# AND operator (&) - all conditions must match
+(K("status") == "published") & (K("year") >= 2020)
+
+# OR operator (|) - any condition can match
+(K("category") == "tech") | (K("category") == "science")
+
+# Complex nesting - use parentheses for clarity
+(
+    (K("status") == "published") &
+    ((K("category") == "tech") | (K("category") == "science")) &
+    (K("rating") >= 4.0)
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// AND operator - all conditions must match
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString(v2.K("status"), "published"),
+					v2.GteInt(v2.K("year"), 2020),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// OR operator - any condition can match
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.Or(
+					v2.EqString(v2.K("category"), "tech"),
+					v2.EqString(v2.K("category"), "science"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Complex nesting with AND and OR
+	result3, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString(v2.K("status"), "published"),
+					v2.Or(
+						v2.EqString(v2.K("category"), "tech"),
+						v2.EqString(v2.K("category"), "science"),
+					),
+					v2.GteFloat(v2.K("rating"), 4.0),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v, %v", result1, result2, result3)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Filter Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+# Complex filter combining IDs, document content, and metadata
+search = (Search()
+    .where(
+        # Exclude specific documents
+        K.ID.not_in(["excluded_001", "excluded_002"]) &
+
+        # Must contain specific content
+        K.DOCUMENT.contains("artificial intelligence") &
+
+        # Metadata conditions
+        (K("status") == "published") &
+        (K("quality_score") >= 0.75) &
+        (
+            (K("category") == "research") |
+            (K("category") == "tutorial")
+        ) &
+        (K("year") >= 2023)
+    )
+    .rank(Knn(query="latest AI research developments"))
+    .limit(10)
+    .select(K.DOCUMENT, "title", "author", "year")
+)
+
+results = collection.search(search)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Complex filter combining IDs, document content, and metadata
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					// K.ID.not_in([...])
+					v2.IDNotIn("excluded_001", "excluded_002"),
+					// K.DOCUMENT.contains(...)
+					v2.DocumentContains("artificial intelligence"),
+					// K("status") == "published"
+					v2.EqString(v2.K("status"), "published"),
+					// K("quality_score") >= 0.75
+					v2.GteFloat(v2.K("quality_score"), 0.75),
+					// (K("category") == "research") | (K("category") == "tutorial")
+					v2.Or(
+						v2.EqString(v2.K("category"), "research"),
+						v2.EqString(v2.K("category"), "tutorial"),
+					),
+					// K("year") >= 2023
+					v2.GteInt(v2.K("year"), 2023),
+				),
+			),
+			v2.WithKnnRank(
+				v2.KnnQueryText("latest AI research developments"),
+				v2.WithKnnLimit(100),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.K("title"), v2.K("author"), v2.K("year")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Filter Functions Reference
+
+| Python Operator | Go Function | Description |
+|----------------|-------------|-------------|
+| `K("field") == value` | `v2.EqString(v2.K("field"), value)` | Equality |
+| `K("field") != value` | `v2.NeString(v2.K("field"), value)` | Inequality |
+| `K("field") > value` | `v2.GtInt(v2.K("field"), value)` | Greater than |
+| `K("field") >= value` | `v2.GteInt(v2.K("field"), value)` | Greater than or equal |
+| `K("field") < value` | `v2.LtInt(v2.K("field"), value)` | Less than |
+| `K("field") <= value` | `v2.LteInt(v2.K("field"), value)` | Less than or equal |
+| `K("field").is_in([...])` | `v2.InString(v2.K("field"), ...)` | Value in list |
+| `K("field").not_in([...])` | `v2.NinString(v2.K("field"), ...)` | Value not in list |
+| `K.ID.is_in([...])` | `v2.IDIn(...)` | Include specific document IDs |
+| `K.ID.not_in([...])` | `v2.IDNotIn(...)` | Exclude specific document IDs |
+| `K.DOCUMENT.contains("text")` | `v2.DocumentContains(...)` | Document contains text |
+| `K.DOCUMENT.not_contains("text")` | `v2.DocumentNotContains(...)` | Document doesn't contain |
+| `... & ...` | `v2.And(...)` | Logical AND |
+| `... \| ...` | `v2.Or(...)` | Logical OR |
+
+## Notes
+
+- Use `v2.K("field")` to clearly mark metadata field names in filter expressions
+- String comparisons are case-sensitive
+- All filter clauses can be combined using `v2.And()` and `v2.Or()` within `WithFilter()`
+- Use `WithFilterIDs()` as a convenience shortcut to restrict search to specific document IDs
+- Standard keys are available as constants: `v2.KID`, `v2.KDocument`, `v2.KScore`, `v2.KMetadata`, `v2.KEmbedding`
+
+### Go vs Python Syntax
+
+Python uses `K("field")` for metadata filtering:
+```python
+K("status") == "active"
+K("category").is_in(["tech", "ai"])
+```
+
+Go uses `v2.K("field")` with filter functions for the same semantic clarity:
+```go
+v2.EqString(v2.K("status"), "active")
+v2.InString(v2.K("category"), "tech", "ai")
+```
+
+For special fields, Go provides dedicated functions that mirror Python's `K.ID` and `K.DOCUMENT`:
+```go
+v2.IDIn("doc1", "doc2")           // K.ID.is_in([...])
+v2.IDNotIn("excluded1")           // K.ID.not_in([...])
+v2.DocumentContains("text")       // K.DOCUMENT.contains(...)
+v2.DocumentNotContains("text")    // K.DOCUMENT.not_contains(...)
+```
+

--- a/docs/go-examples/cloud/search-api/group-by.md
+++ b/docs/go-examples/cloud/search-api/group-by.md
@@ -1,0 +1,427 @@
+# Group By & Aggregation - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/group-by)
+
+## Overview
+
+Learn how to group search results by metadata keys and select the top results from each group. GroupBy is useful for diversifying results, deduplication, and category-aware ranking.
+
+## Go Examples
+
+### Basic GroupBy
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, GroupBy, MinK
+
+# Get top 3 results per category, ordered by score
+search = (Search()
+    .rank(Knn(query="machine learning research"))
+    .group_by(GroupBy(
+        keys=K("category"),
+        aggregate=MinK(keys=K.SCORE, k=3)
+    ))
+    .limit(30)
+    .select(K.DOCUMENT, K.SCORE, "category"))
+
+results = collection.search(search)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Get top 3 results per category, ordered by score
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(
+				v2.KnnQueryText("machine learning research"),
+				v2.WithKnnLimit(100),
+			),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMinK(3, v2.KScore),     // Top 3 with lowest scores
+					v2.K("category"),             // Group by category
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("category")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### MinK Aggregation
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import MinK, K
+
+# Keep 3 records with lowest scores per group
+MinK(keys=K.SCORE, k=3)
+
+# Keep 2 records with lowest priority, then lowest score as tiebreaker
+MinK(keys=[K("priority"), K.SCORE], k=2)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Keep 3 records with lowest scores per group
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query"), v2.WithKnnLimit(100)),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMinK(3, v2.KScore), // Top 3 lowest scores
+					v2.K("category"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+		),
+	)
+
+	// Keep 2 records with lowest priority, then score as tiebreaker
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query"), v2.WithKnnLimit(100)),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMinK(2, v2.K("priority"), v2.KScore), // Priority first, then score
+					v2.K("category"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+		),
+	)
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### MaxK Aggregation
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import MaxK, K
+
+# Keep 3 records with highest ratings per group
+MaxK(keys=K("rating"), k=3)
+
+# Keep 2 records with highest year, then highest rating as tiebreaker
+MaxK(keys=[K("year"), K("rating")], k=2)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Keep 3 records with highest ratings per group
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query"), v2.WithKnnLimit(100)),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMaxK(3, v2.K("rating")), // Top 3 highest ratings
+					v2.K("category"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+		),
+	)
+
+	// Keep 2 with highest year, then highest rating as tiebreaker
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query"), v2.WithKnnLimit(100)),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMaxK(2, v2.K("year"), v2.K("rating")), // Year first, then rating
+					v2.K("category"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+		),
+	)
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Multiple Grouping Keys
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Top 1 article per (category, year) combination
+search = (Search()
+    .rank(Knn(query="renewable energy"))
+    .group_by(GroupBy(
+        keys=[K("category"), K("year")],
+        aggregate=MinK(keys=K.SCORE, k=1)
+    ))
+    .limit(30))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Top 1 article per (category, year) combination
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(
+				v2.KnnQueryText("renewable energy"),
+				v2.WithKnnLimit(100),
+			),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMinK(1, v2.KScore),
+					v2.K("category"), v2.K("year"), // Multiple keys
+				),
+			),
+			v2.WithPage(v2.WithLimit(30)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Diversified Search Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, GroupBy, MinK
+
+# Diversified product search - ensure results from multiple categories
+search = (Search()
+    .where(K("in_stock") == True)
+    .rank(Knn(query="wireless headphones", limit=100))
+    .group_by(GroupBy(
+        keys=K("category"),
+        aggregate=MinK(keys=K.SCORE, k=2)  # Top 2 per category
+    ))
+    .limit(20)
+    .select(K.DOCUMENT, K.SCORE, "name", "category", "price"))
+
+results = collection.search(search)
+rows = results.rows()[0]
+
+for row in rows:
+    print(f"{row['metadata']['name']}")
+    print(f"  Category: {row['metadata']['category']}")
+    print(f"  Price: ${row['metadata']['price']:.2f}")
+    print(f"  Score: {row['score']:.3f}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Diversified product search - ensure results from multiple categories
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqBool("in_stock", true)),
+			v2.WithKnnRank(
+				v2.KnnQueryText("wireless headphones"),
+				v2.WithKnnLimit(100),
+			),
+			v2.WithGroupBy(
+				v2.NewGroupBy(
+					v2.NewMinK(2, v2.KScore), // Top 2 per category
+					v2.K("category"),
+				),
+			),
+			v2.WithPage(v2.WithLimit(20)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("name"), v2.K("category"), v2.K("price")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Process results using Rows()
+	for _, row := range result.Rows() {
+		name := ""
+		category := ""
+		price := 0.0
+		if row.Metadata != nil {
+			if n, ok := row.Metadata.Get("name"); ok {
+				name = fmt.Sprintf("%v", n)
+			}
+			if c, ok := row.Metadata.Get("category"); ok {
+				category = fmt.Sprintf("%v", c)
+			}
+			if p, ok := row.Metadata.Get("price"); ok {
+				price = p.(float64)
+			}
+		}
+		fmt.Printf("%s\n", name)
+		fmt.Printf("  Category: %s\n", category)
+		fmt.Printf("  Price: $%.2f\n", price)
+		fmt.Printf("  Score: %.3f\n\n", row.Score)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## GroupBy Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `GroupBy(keys=..., aggregate=...)` | `v2.NewGroupBy(aggregate, keys...)` | Create GroupBy with keys and aggregation |
+| `MinK(keys=..., k=N)` | `v2.NewMinK(N, keys...)` | Keep N records with smallest values |
+| `MaxK(keys=..., k=N)` | `v2.NewMaxK(N, keys...)` | Keep N records with largest values |
+| `K.SCORE` | `v2.KScore` | Reference the search score |
+| `K("field")` | `v2.K("field")` | Reference a metadata field |
+
+## Notes
+
+- GroupBy requires a ranking expression (KNN)
+- Use `MinK` with `KScore` for distance-based scoring (lower is better)
+- Use `MaxK` for metrics where higher is better (ratings, popularity)
+- Groups with fewer than k records return all available records
+- Documents missing the grouping key are grouped together as null
+- Set KNN limit high enough to include candidates from all groups
+- Use `Rows()` for ergonomic iteration over results
+- Use `At(group, index)` for safe indexed access with bounds checking
+

--- a/docs/go-examples/cloud/search-api/hybrid-search.md
+++ b/docs/go-examples/cloud/search-api/hybrid-search.md
@@ -1,0 +1,561 @@
+# Hybrid Search with RRF - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/hybrid-search)
+
+## Overview
+
+Learn how to combine multiple ranking strategies using Reciprocal Rank Fusion (RRF). RRF is ideal for hybrid search scenarios where you want to merge results from different ranking methods (e.g., dense and sparse embeddings).
+
+## Go Examples
+
+### Basic RRF
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, Knn, Rrf
+
+# RRF combines multiple rankings by rank position
+rrf = Rrf([
+    Knn(query="machine learning", return_rank=True),
+    Knn(query="machine learning", key="sparse_embedding", return_rank=True)
+])
+
+search = Search().rank(rrf).limit(10)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create KNN ranks with return_rank=True for RRF
+	denseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	sparseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	// Create RRF with weighted ranks
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(1.0),
+					sparseKnn.WithWeight(1.0),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### RRF with Custom Weights
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Custom weights - adjust relative importance
+rrf = Rrf(
+    ranks=[
+        Knn(query="neural networks", return_rank=True),
+        Knn(query="neural networks", key="sparse_embedding", return_rank=True)
+    ],
+    weights=[3.0, 1.0]  # Dense 3x more important than sparse
+)
+
+# Normalized weights - ensures weights sum to 1.0
+rrf = Rrf(
+    ranks=[
+        Knn(query="neural networks", return_rank=True),
+        Knn(query="neural networks", key="sparse_embedding", return_rank=True)
+    ],
+    weights=[75, 25],     # Will be normalized to [0.75, 0.25]
+    normalize=True
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create KNN ranks
+	denseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("neural networks"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	sparseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("neural networks"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	// Custom weights - Dense 3x more important
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(3.0),
+					sparseKnn.WithWeight(1.0),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Normalized weights - ensures weights sum to 1.0
+	denseKnn2, _ := v2.NewKnnRank(
+		v2.KnnQueryText("neural networks"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	sparseKnn2, _ := v2.NewKnnRank(
+		v2.KnnQueryText("neural networks"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn2.WithWeight(75),
+					sparseKnn2.WithWeight(25),
+				),
+				v2.WithRffNormalize(), // Normalize to sum to 1.0
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### RRF with Custom k Parameter
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Small k - top results heavily weighted
+rrf = Rrf(ranks=[...], k=10)
+
+# Default k - balanced (standard in literature)
+rrf = Rrf(ranks=[...], k=60)
+
+# Large k - more uniform weighting across ranks
+rrf = Rrf(ranks=[...], k=200)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	denseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("search query"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	sparseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("search query"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	// Small k=10 - top results heavily weighted
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(1.0),
+					sparseKnn.WithWeight(1.0),
+				),
+				v2.WithRffK(10),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Default k=60 - balanced (default)
+	denseKnn2, _ := v2.NewKnnRank(
+		v2.KnnQueryText("search query"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+	sparseKnn2, _ := v2.NewKnnRank(
+		v2.KnnQueryText("search query"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(100),
+	)
+
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn2.WithWeight(1.0),
+					sparseKnn2.WithWeight(1.0),
+				),
+				// k=60 is default, so not needed
+			),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Dense + Sparse Hybrid Search
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, Rrf
+
+# Dense semantic embeddings
+dense_rank = Knn(
+    query="machine learning research",
+    key="#embedding",
+    return_rank=True,
+    limit=200
+)
+
+# Sparse keyword embeddings
+sparse_rank = Knn(
+    query="machine learning research",
+    key="sparse_embedding",
+    return_rank=True,
+    limit=200
+)
+
+# Combine with RRF
+hybrid_rank = Rrf(
+    ranks=[dense_rank, sparse_rank],
+    weights=[0.7, 0.3],  # 70% semantic, 30% keyword
+    k=60
+)
+
+search = (Search()
+    .where(K("status") == "published")
+    .rank(hybrid_rank)
+    .limit(20)
+    .select(K.DOCUMENT, K.SCORE, "title")
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Dense semantic embeddings (default #embedding key)
+	denseRank, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning research"),
+		v2.WithKnnKey(v2.KEmbedding), // Default key
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(200),
+	)
+
+	// Sparse keyword embeddings
+	sparseRank, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning research"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(200),
+	)
+
+	// Combine with RRF - 70% semantic, 30% keyword
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("status", "published")),
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseRank.WithWeight(0.7),
+					sparseRank.WithWeight(0.3),
+				),
+				v2.WithRffK(60),
+			),
+			v2.WithPage(v2.WithLimit(20)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Hybrid Search Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn, Rrf
+
+# Create RRF ranking with text query
+hybrid_rank = Rrf(
+    ranks=[
+        Knn(query="machine learning applications", return_rank=True, limit=300),
+        Knn(query="machine learning applications", key="sparse_embedding", return_rank=True, limit=300)
+    ],
+    weights=[2.0, 1.0],  # Dense 2x more important
+    k=60
+)
+
+# Build complete search
+search = (Search()
+    .where(
+        (K("language") == "en") &
+        (K("year") >= 2020)
+    )
+    .rank(hybrid_rank)
+    .limit(10)
+    .select(K.DOCUMENT, K.SCORE, "title", "year")
+)
+
+results = collection.search(search)
+rows = results.rows()[0]
+
+for i, row in enumerate(rows, 1):
+    print(f"{i}. {row['metadata']['title']} ({row['metadata']['year']})")
+    print(f"   RRF Score: {row['score']:.4f}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Create KNN ranks for hybrid search
+	denseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning applications"),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(300),
+	)
+
+	sparseKnn, _ := v2.NewKnnRank(
+		v2.KnnQueryText("machine learning applications"),
+		v2.WithKnnKey(v2.K("sparse_embedding")),
+		v2.WithKnnReturnRank(),
+		v2.WithKnnLimit(300),
+	)
+
+	// Build complete search with filter and RRF ranking
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString("language", "en"),
+					v2.GteInt("year", 2020),
+				),
+			),
+			v2.WithRffRank(
+				v2.WithRffRanks(
+					denseKnn.WithWeight(2.0),  // Dense 2x more important
+					sparseKnn.WithWeight(1.0),
+				),
+				v2.WithRffK(60),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("year")),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Process results using Rows()
+	for i, row := range result.Rows() {
+		title := ""
+		year := 0
+		if row.Metadata != nil {
+			if t, ok := row.Metadata.Get("title"); ok {
+				title = fmt.Sprintf("%v", t)
+			}
+			if y, ok := row.Metadata.Get("year"); ok {
+				year = int(y.(float64))
+			}
+		}
+		fmt.Printf("%d. %s (%d)\n", i+1, title, year)
+		fmt.Printf("   RRF Score: %.4f\n", row.Score)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## RRF Parameters Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `ranks=[...]` | `v2.WithRffRanks()` | List of weighted ranks |
+| `weights=[...]` | `.WithWeight(w)` on each rank | Weight for each ranking |
+| `k=N` | `v2.WithRffK(N)` | Smoothing parameter (default: 60) |
+| `normalize=True` | `v2.WithRffNormalize()` | Normalize weights to sum to 1.0 |
+
+## RRF Formula
+
+RRF combines rankings using: `score = -sum(weight_i / (k + rank_i))`
+
+Where:
+- `weight_i` = weight for ranking i (default: 1.0)
+- `rank_i` = rank position from ranking i (0, 1, 2, ...)
+- `k` = smoothing parameter (default: 60)
+
+The score is negative because Chroma uses ascending order (lower = better).
+
+## Notes
+
+- Always use `WithKnnReturnRank()` for all KNN expressions in RRF
+- Set appropriate limits on component KNN expressions (usually 100-500)
+- Default k=60 works well for most cases
+- Use `.WithWeight()` to adjust relative importance of each ranking
+- RRF is scale-agnostic, making it ideal for combining different embedding types
+- Use `Rows()` for ergonomic iteration over results
+- Use `At(group, index)` for safe indexed access with bounds checking
+

--- a/docs/go-examples/cloud/search-api/pagination-selection.md
+++ b/docs/go-examples/cloud/search-api/pagination-selection.md
@@ -1,0 +1,511 @@
+# Pagination & Field Selection - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/pagination-selection)
+
+## Overview
+
+Control how many results to return and which fields to include in your search results.
+
+## Go Examples
+
+### Pagination with Limit and Offset
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search
+
+# Limit results
+search = Search().limit(10)  # Return top 10 results
+
+# Pagination with offset
+search = Search().limit(10, offset=20)  # Skip first 20, return next 10
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Limit results - return top 10
+	result1, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Pagination with offset - skip first 20, return next 10
+	result2, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(
+				v2.WithLimit(10),
+				v2.WithOffset(20),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Pagination Patterns
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Page through results (0-indexed)
+page_size = 10
+
+# Page 0: Results 1-10
+page_0 = Search().limit(page_size, offset=0)
+
+# Page 1: Results 11-20
+page_1 = Search().limit(page_size, offset=10)
+
+# Page 2: Results 21-30
+page_2 = Search().limit(page_size, offset=20)
+
+# General formula
+def get_page(page_number, page_size=10):
+    return Search().limit(page_size, offset=page_number * page_size)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	pageSize := 10
+
+	// Page 0: Results 1-10
+	page0, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(pageSize), v2.WithOffset(0)),
+		),
+	)
+
+	// Page 1: Results 11-20
+	page1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(pageSize), v2.WithOffset(10)),
+		),
+	)
+
+	// Page 2: Results 21-30
+	page2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(pageSize), v2.WithOffset(20)),
+		),
+	)
+
+	// General formula for page N
+	getPage := func(pageNumber int, pageSize int) v2.SearchCollectionOption {
+		return v2.NewSearchRequest(
+			v2.WithPage(
+				v2.WithLimit(pageSize),
+				v2.WithOffset(pageNumber*pageSize),
+			),
+		)
+	}
+
+	// Get page 5
+	page5, _ := collection.Search(ctx, getPage(5, 10))
+
+	log.Printf("Pages: %v, %v, %v, %v", page0, page1, page2, page5)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Field Selection with Select
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K
+
+# Default - returns IDs only
+search = Search()
+
+# Select specific fields
+search = Search().select(K.DOCUMENT, K.SCORE)
+
+# Select metadata fields
+search = Search().select("title", "author", "date")
+
+# Mix predefined and metadata fields
+search = Search().select(K.DOCUMENT, K.SCORE, "title", "author")
+
+# Select all available fields
+search = Search().select_all()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Default - returns IDs only
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Select specific predefined fields
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+
+	// Select metadata fields using K()
+	result3, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.K("title"), v2.K("author"), v2.K("date")),
+		),
+	)
+
+	// Mix predefined and custom metadata fields
+	result4, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("author")),
+		),
+	)
+
+	// Select all available fields
+	result5, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelectAll(),
+		),
+	)
+
+	log.Printf("Results: %v, %v, %v, %v, %v",
+		result1, result2, result3, result4, result5)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Performance-Optimized Selection
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Fast - minimal data
+search = Search().limit(100)  # IDs only
+
+# Moderate - just what you need
+search = Search().limit(100).select(K.SCORE, "title", "date")
+
+# Slower - large fields
+search = Search().limit(100).select(K.DOCUMENT, K.EMBEDDING)
+
+# Slowest - everything
+search = Search().limit(100).select_all()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Fast - minimal data (IDs only)
+	fast, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithPage(v2.WithLimit(100)),
+		),
+	)
+
+	// Moderate - just what you need
+	moderate, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(100)),
+			v2.WithSelect(v2.KScore, v2.K("title"), v2.K("date")),
+		),
+	)
+
+	// Slower - large fields
+	slower, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(100)),
+			v2.WithSelect(v2.KDocument, v2.KEmbedding),
+		),
+	)
+
+	// Slowest - everything
+	slowest, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("query")),
+			v2.WithPage(v2.WithLimit(100)),
+			v2.WithSelectAll(),
+		),
+	)
+
+	log.Printf("Results: %d, %d, %d, %d",
+		len(fast.IDs[0]),
+		len(moderate.IDs[0]),
+		len(slower.IDs[0]),
+		len(slowest.IDs[0]),
+	)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Pagination Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+def search_with_pagination(collection, query_text, page_size=20):
+    current_page = 0
+
+    while True:
+        search = (Search()
+            .where(K("status") == "published")
+            .rank(Knn(query=query_text))
+            .limit(page_size, offset=current_page * page_size)
+            .select(K.DOCUMENT, K.SCORE, "title", "author", "date")
+        )
+
+        results = collection.search(search)
+        rows = results.rows()[0]
+
+        if not rows:
+            break
+
+        print(f"\n--- Page {current_page + 1} ---")
+        for i, row in enumerate(rows, 1):
+            print(f"{i}. {row['metadata']['title']}")
+
+        current_page += 1
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func searchWithPagination(
+	ctx context.Context,
+	collection v2.CollectionAPI,
+	queryText string,
+	pageSize int,
+) error {
+	currentPage := 0
+
+	for {
+		result, err := collection.Search(ctx,
+			v2.NewSearchRequest(
+				v2.WithFilter(v2.EqString("status", "published")),
+				v2.WithKnnRank(
+					v2.KnnQueryText(queryText),
+					v2.WithKnnLimit(100),
+				),
+				v2.WithPage(
+					v2.WithLimit(pageSize),
+					v2.WithOffset(currentPage*pageSize),
+				),
+				v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title"), v2.K("author"), v2.K("date")),
+			),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Check if we have results using Rows()
+		rows := result.Rows()
+		if len(rows) == 0 {
+			break
+		}
+
+		fmt.Printf("\n--- Page %d ---\n", currentPage+1)
+		for i, row := range rows {
+			title := ""
+			if row.Metadata != nil {
+				if t, ok := row.Metadata.Get("title"); ok {
+					title = fmt.Sprintf("%v", t)
+				}
+			}
+			fmt.Printf("%d. %s (ID: %s)\n", i+1, title, row.ID)
+		}
+
+		currentPage++
+
+		// Stop if we got fewer results than requested (last page)
+		if len(rows) < pageSize {
+			break
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	err = searchWithPagination(ctx, collection, "machine learning", 10)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Selectable Fields Reference
+
+| Python | Go Constant | Description |
+|--------|-------------|-------------|
+| `K.DOCUMENT` | `v2.KDocument` | Full document text |
+| `K.EMBEDDING` | `v2.KEmbedding` | Vector embeddings |
+| `K.SCORE` | `v2.KScore` | Ranking score |
+| `K.METADATA` | `v2.KMetadata` | All metadata fields |
+| `K.ID` | `v2.KID` | Document ID |
+| `"field_name"` | `v2.K("field_name")` | Specific metadata field |
+
+## Pagination Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | int | None | Maximum results to return |
+| `offset` | int | 0 | Number of results to skip |
+
+## Notes
+
+- Pagination uses 0-based indexing (first page is page 0)
+- Select only needed fields to improve performance
+- IDs are always included in results
+- Use `WithSelectAll()` sparingly - only when you need all fields
+- Avoid selecting embeddings unless necessary (large data transfer)
+- Use `Rows()` for ergonomic iteration over results
+- Use `At(group, index)` for safe indexed access with bounds checking
+

--- a/docs/go-examples/cloud/search-api/ranking.md
+++ b/docs/go-examples/cloud/search-api/ranking.md
@@ -1,0 +1,507 @@
+# Ranking Expressions - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/ranking)
+
+## Overview
+
+Ranking expressions control how search results are scored and ordered. Chroma provides KNN-based ranking with arithmetic operations for customizing result ordering.
+
+## Go Examples
+
+### Basic KNN Ranking
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, Knn
+
+# Text query (auto-embedded)
+search = Search().rank(Knn(query="machine learning research"))
+
+# With custom limit
+search = Search().rank(Knn(query="AI applications", limit=100))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Text query (auto-embedded)
+	result1, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("machine learning research")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// With custom KNN limit (larger pool before final limit)
+	result2, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(
+				v2.KnnQueryText("AI applications"),
+				v2.WithKnnLimit(100),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### KNN with Vector Embeddings
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Vector query (pre-computed embedding)
+embedding = [0.1, 0.2, 0.3, ...]  # Your embedding vector
+search = Search().rank(Knn(query=embedding))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Pre-computed embedding vector
+	embedding := embeddings.NewEmbeddingFromFloat32([]float32{0.1, 0.2, 0.3})
+
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryVector(embedding)),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Arithmetic Operations
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Knn, Val
+
+# Weighted ranking
+rank = Knn(query="search") * 0.7 + Val(0.3)
+
+# Score adjustment
+rank = Knn(query="search") + Val(1.0)
+
+# Log compression
+rank = (Knn(query="search") + Val(1.0)).log()
+
+# Combining multiple KNN queries
+rank1 = Knn(query="machine learning")
+rank2 = Knn(query="deep learning")
+combined = rank1 * 0.7 + rank2 * 0.3
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Weighted ranking: Knn * 0.7 + 0.3
+	knn, _ := v2.NewKnnRank(v2.KnnQueryText("search"))
+	weightedRank := knn.Multiply(v2.FloatOperand(0.7)).Add(v2.Val(0.3))
+
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(weightedRank),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+
+	// Score adjustment: Knn + 1.0
+	knn2, _ := v2.NewKnnRank(v2.KnnQueryText("search"))
+	adjustedRank := knn2.Add(v2.Val(1.0))
+
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(adjustedRank),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Log compression: log(Knn + 1.0)
+	knn3, _ := v2.NewKnnRank(v2.KnnQueryText("search"))
+	logRank := knn3.Add(v2.Val(1.0)).Log()
+
+	result3, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(logRank),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	// Combining multiple KNN queries: rank1 * 0.7 + rank2 * 0.3
+	knn4, _ := v2.NewKnnRank(v2.KnnQueryText("machine learning"))
+	knn5, _ := v2.NewKnnRank(v2.KnnQueryText("deep learning"))
+	combinedRank := knn4.Multiply(v2.FloatOperand(0.7)).Add(
+		knn5.Multiply(v2.FloatOperand(0.3)),
+	)
+
+	result4, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(combinedRank),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+
+	log.Printf("Results: %v, %v, %v, %v", result1, result2, result3, result4)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Advanced Mathematical Functions
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Knn, Val
+
+knn = Knn(query="search query")
+
+# Absolute value
+rank = knn.abs()
+
+# Exponential
+rank = knn.exp()
+
+# Natural log (requires positive input)
+rank = (knn + Val(1.0)).log()
+
+# Min/Max clamping
+rank = knn.max(Val(0.0))  # Clamp to minimum 0
+rank = knn.min(Val(1.0))  # Clamp to maximum 1
+
+# Negation
+rank = -knn  # Reverse score ordering
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	knn, _ := v2.NewKnnRank(v2.KnnQueryText("search query"))
+
+	// Absolute value
+	absRank := knn.Abs()
+
+	// Exponential
+	expRank := knn.Exp()
+
+	// Natural log (add offset to ensure positive)
+	logRank := knn.Add(v2.Val(1.0)).Log()
+
+	// Min/Max clamping
+	clampMinRank := knn.Max(v2.Val(0.0)) // Clamp to minimum 0
+	clampMaxRank := knn.Min(v2.Val(1.0)) // Clamp to maximum 1
+
+	// Negation (reverse score ordering)
+	negatedRank := knn.Negate()
+
+	// Use any of these in a search
+	result, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(absRank),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+
+	log.Printf("Rank types: %T, %T, %T, %T, %T, %T",
+		absRank, expRank, logRank, clampMinRank, clampMaxRank, negatedRank)
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### KNN with Default Scores
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Knn
+
+# Default score for non-matching documents
+# Documents not in top-K get a default score instead of being excluded
+knn = Knn(query="search", limit=50, default=10.0)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// KNN with default score for non-matching documents
+	// Documents not in top-K get score 10.0 instead of being excluded
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(
+				v2.KnnQueryText("search"),
+				v2.WithKnnLimit(50),
+				v2.WithKnnDefault(10.0),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Constant Values with Val
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Knn, Val
+
+# Val creates constant value rank expressions
+base_score = Val(1.0)
+
+# Combine with KNN for offset
+rank = Knn(query="search") + base_score
+
+# Use in complex expressions
+rank = (Knn(query="search") / Val(2.0)) + Val(0.5)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Val creates constant value rank expressions
+	baseScore := v2.Val(1.0)
+
+	// Combine with KNN for offset
+	knn, _ := v2.NewKnnRank(v2.KnnQueryText("search"))
+	rankWithOffset := knn.Add(baseScore)
+
+	// Use in complex expressions: (Knn / 2.0) + 0.5
+	knn2, _ := v2.NewKnnRank(v2.KnnQueryText("search"))
+	complexRank := knn2.Div(v2.Val(2.0)).Add(v2.Val(0.5))
+
+	result1, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(rankWithOffset),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	result2, _ := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithRank(complexRank),
+			v2.WithPage(v2.WithLimit(10)),
+		),
+	)
+
+	log.Printf("Results: %v, %v", result1, result2)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Arithmetic Operations Reference
+
+| Python | Go Method | Description |
+|--------|-----------|-------------|
+| `rank + value` | `rank.Add()` | Addition |
+| `rank - value` | `rank.Sub()` | Subtraction |
+| `rank * value` | `rank.Multiply()` | Multiplication |
+| `rank / value` | `rank.Div()` | Division |
+| `-rank` | `rank.Negate()` | Negation |
+| `rank.abs()` | `rank.Abs()` | Absolute value |
+| `rank.exp()` | `rank.Exp()` | Exponential (e^x) |
+| `rank.log()` | `rank.Log()` | Natural logarithm |
+| `rank.max(value)` | `rank.Max()` | Maximum of two values |
+| `rank.min(value)` | `rank.Min()` | Minimum of two values |
+| `Val(x)` | `v2.Val(x)` | Constant value |
+
+## KNN Options Reference
+
+| Python | Go Function | Description |
+|--------|-------------|-------------|
+| `query="text"` | `v2.KnnQueryText("text")` | Text query (auto-embedded) |
+| `query=[...]` | `v2.KnnQueryVector(vec)` | Vector query |
+| `limit=N` | `v2.WithKnnLimit(N)` | Max neighbors to retrieve |
+| `key="field"` | `v2.WithKnnKey(K("field"))` | Embedding field to search |
+| `default=N` | `v2.WithKnnDefault(N)` | Score for non-matches |
+| `return_rank=True` | `v2.WithKnnReturnRank()` | Return rank position (for RRF) |
+
+## Notes
+
+- Lower scores are better (distance-based scoring)
+- Use `Val()` to create constant values for arithmetic operations
+- Use `FloatOperand()` or `IntOperand()` when multiplying/dividing by constants
+- Log requires positive values - add an offset before calling `.Log()`
+- The `WithKnnLimit()` controls the candidate pool before filtering
+- Use `WithKnnDefault()` for inclusive multi-query searches
+

--- a/docs/go-examples/cloud/search-api/search-basics.md
+++ b/docs/go-examples/cloud/search-api/search-basics.md
@@ -1,0 +1,332 @@
+# Search API Basics - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/cloud/search-api/search-basics)
+
+## Overview
+
+The Search API provides advanced search capabilities with filtering, ranking, pagination, and field selection. This page covers the basics of constructing search requests.
+
+## Go Examples
+
+### Basic Search Request
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search
+
+search = Search()
+result = collection.search(search)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Basic search request
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Search with All Components
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+search = Search(
+    where={"status": "active"},
+    rank={"$knn": {"query": [0.1, 0.2]}},
+    limit=10,
+    select=["#document", "#score"]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Search with filter, ranking, pagination, and projection
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("status", "active")),
+			v2.WithKnnRank(v2.KnnQueryText("machine learning")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Builder Pattern with Method Chaining
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Search, K, Knn
+
+search = (Search()
+    .where(K("status") == "published")
+    .rank(Knn(query="machine learning applications"))
+    .limit(10)
+    .select(K.DOCUMENT, K.SCORE))
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Go uses functional options pattern instead of method chaining
+	result, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(v2.EqString("status", "published")),
+			v2.WithKnnRank(v2.KnnQueryText("machine learning applications")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Results: %v", result)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Common Search Patterns
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database", "tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Pattern 1: Filter only (no ranking)
+	filterOnly, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString("category", "science"),
+					v2.GteInt("year", 2023),
+				),
+			),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KMetadata),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Pattern 2: Rank only (no filtering)
+	rankOnly, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithKnnRank(v2.KnnQueryText("AI research")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Pattern 3: Both filter and rank
+	combined, err := collection.Search(ctx,
+		v2.NewSearchRequest(
+			v2.WithFilter(
+				v2.And(
+					v2.EqString("category", "science"),
+					v2.GteInt("year", 2023),
+				),
+			),
+			v2.WithKnnRank(v2.KnnQueryText("AI research")),
+			v2.WithPage(v2.WithLimit(10)),
+			v2.WithSelect(v2.KDocument, v2.KScore),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Filter only: %v", filterOnly)
+	log.Printf("Rank only: %v", rankOnly)
+	log.Printf("Combined: %v", combined)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Search Components
+
+| Component | Go Function | Description |
+|-----------|-------------|-------------|
+| Filter | `WithFilter()` | Narrow down results by metadata |
+| Filter IDs | `WithFilterIDs()` | Filter by specific document IDs |
+| Filter Document | `WithFilterDocument()` | Filter by document content |
+| Rank | `WithKnnRank()`, `WithRank()` | Score and order results |
+| Page | `WithPage()` | Pagination with limit/offset |
+| Select | `WithSelect()` | Choose which fields to return |
+| Group By | `WithGroupBy()` | Group results by metadata |
+
+## Projection Keys
+
+| Key | Go Constant | Description |
+|-----|-------------|-------------|
+| `#document` | `v2.KDocument` | Document text |
+| `#embedding` | `v2.KEmbedding` | Vector embedding |
+| `#score` | `v2.KScore` | Ranking score |
+| `#metadata` | `v2.KMetadata` | All metadata fields |
+| `#id` | `v2.KID` | Document ID |
+| Custom field | `v2.K("field")` | Specific metadata field |
+
+## Iterating Over Results
+
+Use the `Rows()` method for ergonomic result iteration:
+
+```go
+results, err := collection.Search(ctx,
+    v2.NewSearchRequest(
+        v2.WithKnnRank(v2.KnnQueryText("machine learning")),
+        v2.WithPage(v2.WithLimit(10)),
+        v2.WithSelect(v2.KDocument, v2.KScore, v2.K("title")),
+    ),
+)
+if err != nil {
+    log.Fatalf("Error: %v", err)
+}
+
+// Iterate using Rows() - no manual index tracking needed
+for i, row := range results.Rows() {
+    fmt.Printf("%d. ID: %s, Score: %.3f\n", i+1, row.ID, row.Score)
+    fmt.Printf("   Document: %s\n", row.Document)
+    if row.Metadata != nil {
+        if title, ok := row.Metadata.Get("title"); ok {
+            fmt.Printf("   Title: %v\n", title)
+        }
+    }
+}
+
+// Or use At() for safe indexed access
+if row, ok := results.At(0, 0); ok {
+    fmt.Printf("First result: %s\n", row.ID)
+}
+```
+
+## Notes
+
+- Go uses functional options pattern instead of Python's builder pattern
+- Use `NewSearchRequest()` to create a search request
+- Combine options like `WithFilter()`, `WithKnnRank()`, `WithPage()`, `WithSelect()`
+- Use `Rows()` for easy iteration over results
+- Use `RowGroups()` when executing multiple search requests in a batch
+- Use `At(group, index)` for safe indexed access with bounds checking

--- a/docs/go-examples/docs/cli/run.md
+++ b/docs/go-examples/docs/cli/run.md
@@ -1,0 +1,299 @@
+# Running a Chroma Server - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/cli/run)
+
+## Overview
+
+The Chroma CLI lets you run a Chroma server locally. This document shows how to connect to a running Chroma server from Go.
+
+## Running the Server
+
+Start a Chroma server using the CLI:
+
+```bash
+# Basic usage
+chroma run --path /path/to/persist/data
+
+# With custom host and port
+chroma run --path /path/to/data --host 0.0.0.0 --port 8080
+
+# With configuration file
+chroma run --config ./config.yaml
+```
+
+## Go Examples
+
+### Connecting to Your Chroma Server
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+chroma_client = chromadb.HttpClient(host='localhost', port=8000)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect to local Chroma server
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Verify connection
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Cannot connect to Chroma server: %v", err)
+	}
+
+	log.Printf("Connected to Chroma server. Heartbeat: %d", heartbeat)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Using Default Connection
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Default connection: http://localhost:8000
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Check server version
+	version, err := client.Version(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Chroma version: %s", version)
+}
+```
+
+### Custom Configuration
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect with custom configuration
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("https://chroma-server.example.com:8080"),
+		v2.WithDatabaseAndTenant("my_database", "my_tenant"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// List collections in the configured database/tenant
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	for _, col := range collections {
+		log.Printf("Collection: %s", col.Name())
+	}
+}
+```
+
+### Using Base URL
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect using full base URL
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Connected. Heartbeat: %d", heartbeat)
+}
+```
+
+### With Authentication
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Bearer token authentication
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+		v2.WithAuth(v2.NewTokenAuthCredentialsProvider("your-token", v2.AuthorizationTokenHeader)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Found %d collections", len(collections))
+}
+```
+
+### Complete Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create client
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Check connection
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Server not responding: %v", err)
+	}
+	fmt.Printf("Connected! Heartbeat: %d\n", heartbeat)
+
+	// Get server version
+	version, err := client.Version(ctx)
+	if err != nil {
+		log.Fatalf("Error getting version: %v", err)
+	}
+	fmt.Printf("Chroma version: %s\n", version)
+
+	// Create or get a collection
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error with collection: %v", err)
+	}
+	fmt.Printf("Using collection: %s\n", collection.Name())
+
+	// Add documents
+	err = collection.Add(ctx,
+		v2.WithIDs("doc1", "doc2", "doc3"),
+		v2.WithDocuments(
+			"The quick brown fox",
+			"Machine learning basics",
+			"Vector database concepts",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+	fmt.Println("Documents added successfully")
+
+	// Query the collection
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("fox"),
+		v2.WithNResults(2),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	fmt.Printf("\nQuery results:\n")
+	for i, row := range results.Rows() {
+		fmt.Printf("  %d. %s\n", i+1, row.ID)
+	}
+}
+```
+
+## Server Configuration Reference
+
+| CLI Argument | Description | Default |
+|--------------|-------------|---------|
+| `--path` | Data persistence directory | `./chroma` |
+| `--host` | Server hostname | `localhost` |
+| `--port` | Server port | `8000` |
+| `--config_path` | Configuration file path | - |
+
+## Notes
+
+- Start the Chroma server before running your Go application
+- Use `v2.NewHTTPClient()` with no arguments for default localhost:8000 connection
+- Always call `client.Close()` to release resources (use `defer`)
+- Check the server is running with `client.Heartbeat(ctx)`
+- For production, consider using Chroma Cloud instead of self-hosted
+

--- a/docs/go-examples/docs/collections/add-data.md
+++ b/docs/go-examples/docs/collections/add-data.md
@@ -1,0 +1,271 @@
+# Adding Data - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/collections/add-data)
+
+## Overview
+
+Add data to a Chroma collection with the `.Add` method. It takes unique string IDs and documents. Chroma will embed these documents using the collection's embedding function.
+
+## Go Examples
+
+### Add Documents with Metadata
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.add(
+    ids=["id1", "id2", "id3"],
+    documents=["lorem ipsum...", "doc2", "doc3"],
+    metadatas=[{"chapter": 3, "verse": 16}, {"chapter": 3, "verse": 5}, {"chapter": 29, "verse": 11}],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Add documents with metadata
+	err = collection.Add(ctx,
+		v2.WithIDs("id1", "id2", "id3"),
+		v2.WithTexts("lorem ipsum...", "doc2", "doc3"),
+		v2.WithMetadatas(
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 16),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 5),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 29),
+				v2.NewIntAttribute("verse", 11),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Documents added successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Add Documents with Pre-computed Embeddings
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.add(
+    ids=["id1", "id2", "id3"],
+    embeddings=[[1.1, 2.3, 3.2], [4.5, 6.9, 4.4], [1.1, 2.3, 3.2]],
+    documents=["doc1", "doc2", "doc3"],
+    metadatas=[{"chapter": 3, "verse": 16}, {"chapter": 3, "verse": 5}, {"chapter": 29, "verse": 11}],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Add documents with pre-computed embeddings
+	err = collection.Add(ctx,
+		v2.WithIDs("id1", "id2", "id3"),
+		v2.WithEmbeddings(
+			[]float32{1.1, 2.3, 3.2},
+			[]float32{4.5, 6.9, 4.4},
+			[]float32{1.1, 2.3, 3.2},
+		),
+		v2.WithTexts("doc1", "doc2", "doc3"),
+		v2.WithMetadatas(
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 16),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 5),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 29),
+				v2.NewIntAttribute("verse", 11),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Documents with embeddings added successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Add Embeddings Only (No Documents)
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.add(
+    embeddings=[[1.1, 2.3, 3.2], [4.5, 6.9, 4.4], [1.1, 2.3, 3.2]],
+    metadatas=[{"chapter": 3, "verse": 16}, {"chapter": 3, "verse": 5}, {"chapter": 29, "verse": 11}],
+    ids=["id1", "id2", "id3"]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection without embedding function for manual embeddings
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(nil),
+	)
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Add only embeddings and metadata (documents stored elsewhere)
+	err = collection.Add(ctx,
+		v2.WithIDs("id1", "id2", "id3"),
+		v2.WithEmbeddings(
+			[]float32{1.1, 2.3, 3.2},
+			[]float32{4.5, 6.9, 4.4},
+			[]float32{1.1, 2.3, 3.2},
+		),
+		v2.WithMetadatas(
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 16),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 5),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 29),
+				v2.NewIntAttribute("verse", 11),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding embeddings: %v", err)
+	}
+
+	log.Println("Embeddings added successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Add with ID Generator
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Use ULID generator for automatic ID generation
+	err = collection.Add(ctx,
+		v2.WithIDGenerator(v2.NewULIDGenerator()),
+		v2.WithTexts("hello world", "goodbye world"),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Documents added with auto-generated IDs")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- If you add a record with an ID that already exists, it will be ignored
+- Embedding dimensions must match those already in the collection
+- Use `Upsert` instead of `Add` if you want to update existing records
+- Go uses `float32` slices for embeddings
+- Use `v2.NewDocumentMetadata()` with attribute helpers for type-safe metadata

--- a/docs/go-examples/docs/collections/configure.md
+++ b/docs/go-examples/docs/collections/configure.md
@@ -1,0 +1,339 @@
+# Configuring Collections - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/collections/configure)
+
+## Overview
+
+Chroma collections have a configuration that determines how their embeddings index is constructed and used. You can customize index configuration values when creating a collection.
+
+## HNSW Index Configuration
+
+### Creating Collection with HNSW Configuration
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.create_collection(
+    name="my-collection",
+    embedding_function=OpenAIEmbeddingFunction(model_name="text-embedding-3-small"),
+    configuration={
+        "hnsw": {
+            "space": "cosine",
+            "ef_construction": 200
+        }
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create OpenAI embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with HNSW configuration
+	collection, err := client.CreateCollection(ctx, "my-collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+		v2.WithHNSWSpaceCreate(v2.Cosine),        // Distance function
+		v2.WithHNSWConstructionEfCreate(200),     // Construction EF
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Distance Space Options
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// L2 (Squared L2 norm) - default
+	// Measures absolute geometric distance
+	l2Collection, err := client.CreateCollection(ctx, "l2-collection",
+		v2.WithHNSWSpaceCreate(v2.L2),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Cosine similarity
+	// Measures angle between vectors (ignoring magnitude)
+	// Ideal for text embeddings
+	cosineCollection, err := client.CreateCollection(ctx, "cosine-collection",
+		v2.WithHNSWSpaceCreate(v2.Cosine),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Inner product
+	// Focuses on vector alignment and magnitude
+	// Often used for recommendation systems
+	ipCollection, err := client.CreateCollection(ctx, "ip-collection",
+		v2.WithHNSWSpaceCreate(v2.IP),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collections created: %s, %s, %s",
+		l2Collection.Name(),
+		cosineCollection.Name(),
+		ipCollection.Name(),
+	)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Full HNSW Configuration
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection with all HNSW parameters
+	collection, err := client.CreateCollection(ctx, "configured-collection",
+		v2.WithHNSWSpaceCreate(v2.Cosine),        // Distance function
+		v2.WithHNSWConstructionEfCreate(200),     // Construction EF (index quality)
+		v2.WithHNSWSearchEfCreate(100),           // Search EF (recall vs speed)
+		v2.WithHNSWMCreate(16),                   // Max neighbors per node
+		v2.WithHNSWBatchSizeCreate(100),          // Vectors per batch
+		v2.WithHNSWSyncThresholdCreate(1000),     // Sync to storage threshold
+		v2.WithHNSWResizeFactorCreate(1.2),       // Index resize factor
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection with HNSW config: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Embedding Function Configuration
+
+### Collection with OpenAI Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import os
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+openai_collection = client.create_collection(
+    name="my_openai_collection",
+    embedding_function=OpenAIEmbeddingFunction(
+        model_name="text-embedding-3-small"
+    ),
+    configuration={"hnsw": {"space": "cosine"}}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create OpenAI embedding function
+	openaiEF, err := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with OpenAI embeddings and cosine distance
+	collection, err := client.CreateCollection(ctx, "my_openai_collection",
+		v2.WithEmbeddingFunctionCreate(openaiEF),
+		v2.WithHNSWSpaceCreate(v2.Cosine),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created OpenAI collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Collection with Cohere Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb.utils.embedding_functions import CohereEmbeddingFunction
+
+cohere_collection = client.get_or_create_collection(
+    name="my_cohere_collection",
+    configuration={
+        "embedding_function": CohereEmbeddingFunction(
+            model_name="embed-english-light-v2.0",
+            truncate="NONE"
+        ),
+        "hnsw": {"space": "cosine"}
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/cohere"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create Cohere embedding function
+	cohereEF, err := cohere.NewCohereEmbeddingFunction(
+		os.Getenv("COHERE_API_KEY"),
+		cohere.WithModel("embed-english-light-v2.0"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with Cohere embeddings
+	collection, err := client.GetOrCreateCollection(ctx, "my_cohere_collection",
+		v2.WithEmbeddingFunctionCreate(cohereEF),
+		v2.WithHNSWSpaceCreate(v2.Cosine),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created Cohere collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## HNSW Parameters Reference
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `space` | `l2` | Distance function: `l2`, `cosine`, or `ip` |
+| `ef_construction` | `100` | Index quality (higher = better, slower build) |
+| `ef_search` | `100` | Search quality (higher = better recall, slower query) |
+| `max_neighbors` (M) | `16` | Max connections per node |
+| `batch_size` | `100` | Vectors processed per batch |
+| `sync_threshold` | `1000` | When to sync to storage |
+| `resize_factor` | `1.2` | Index growth factor |
+
+## Go Option Functions
+
+| Python Config | Go Function |
+|--------------|-------------|
+| `space: "l2"` | `v2.WithHNSWSpaceCreate(v2.L2)` |
+| `space: "cosine"` | `v2.WithHNSWSpaceCreate(v2.Cosine)` |
+| `space: "ip"` | `v2.WithHNSWSpaceCreate(v2.IP)` |
+| `ef_construction: N` | `v2.WithHNSWConstructionEfCreate(N)` |
+| `ef_search: N` | `v2.WithHNSWSearchEfCreate(N)` |
+| `max_neighbors: N` | `v2.WithHNSWMCreate(N)` |
+
+## Notes
+
+- Choose `space` based on your embedding function's recommendation
+- Higher `ef_construction` improves index quality but increases build time
+- Higher `ef_search` improves recall but increases query time
+- Embedding functions are persisted with the collection (Chroma >= 1.1.13)
+- API keys for embedding providers are read from standard environment variables

--- a/docs/go-examples/docs/collections/delete-data.md
+++ b/docs/go-examples/docs/collections/delete-data.md
@@ -1,0 +1,208 @@
+# Deleting Data - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/collections/delete-data)
+
+## Overview
+
+Chroma supports deleting items from a collection by ID using `.Delete`. The embeddings, documents, and metadata associated with each item will be deleted.
+
+> **Warning**: Deleting data is destructive and cannot be undone.
+
+## Go Examples
+
+### Delete by IDs
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.delete(
+    ids=["id1", "id2", "id3"],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Delete records by IDs
+	err = collection.Delete(ctx,
+		v2.WithIDsDelete("id1", "id2", "id3"),
+	)
+	if err != nil {
+		log.Fatalf("Error deleting documents: %v", err)
+	}
+
+	log.Println("Documents deleted successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Delete with Where Filter
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.delete(
+    ids=["id1", "id2", "id3"],
+    where={"chapter": "20"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Delete records by IDs with additional where filter
+	err = collection.Delete(ctx,
+		v2.WithIDsDelete("id1", "id2", "id3"),
+		v2.WithWhereDelete(v2.EqString("chapter", "20")),
+	)
+	if err != nil {
+		log.Fatalf("Error deleting documents: %v", err)
+	}
+
+	log.Println("Documents matching filter deleted")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Delete All Matching Filter (No IDs)
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Delete all records matching the where filter
+	// No IDs specified - deletes all matching documents
+	err = collection.Delete(ctx,
+		v2.WithWhereDelete(v2.EqString("status", "archived")),
+	)
+	if err != nil {
+		log.Fatalf("Error deleting documents: %v", err)
+	}
+
+	log.Println("All archived documents deleted")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Delete with Complex Filter
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Delete with complex filter using AND
+	err = collection.Delete(ctx,
+		v2.WithWhereDelete(
+			v2.And(
+				v2.EqString("category", "draft"),
+				v2.LtInt("version", 5),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error deleting documents: %v", err)
+	}
+
+	log.Println("Draft documents with version < 5 deleted")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- Delete is a destructive operation and cannot be undone
+- If no IDs are supplied, all records matching the `where` filter will be deleted
+- Use `where` filters to narrow down which records to delete
+- Deleting removes embeddings, documents, and metadata for each record

--- a/docs/go-examples/docs/collections/manage-collections.md
+++ b/docs/go-examples/docs/collections/manage-collections.md
@@ -1,0 +1,574 @@
+# Managing Collections - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/collections/manage-collections)
+
+## Overview
+
+Chroma lets you manage collections of embeddings. Collections are the fundamental unit of storage and querying in Chroma.
+
+## Creating Collections
+
+Collection names must follow these rules:
+- Length between 3 and 512 characters
+- Start and end with a lowercase letter or digit
+- Can contain dots, dashes, and underscores in between
+- No two consecutive dots
+- Not a valid IP address
+
+### Basic Collection Creation
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.create_collection(name="my_collection")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create a new collection
+	collection, err := client.CreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Collection with Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import os
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=OpenAIEmbeddingFunction(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        model_name="text-embedding-3-small"
+    )
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create OpenAI embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with embedding function
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Collection without Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=None
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection without embedding function
+	// You must provide embeddings directly when adding data
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(nil),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Collection with Metadata
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from datetime import datetime
+
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=emb_fn,
+    metadata={
+        "description": "my first Chroma collection",
+        "created": str(datetime.now())
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection with metadata
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithCollectionMetadataCreate(
+			v2.NewMetadata(
+				v2.NewStringAttribute("description", "my first Chroma collection"),
+				v2.NewStringAttribute("created", time.Now().String()),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Getting Collections
+
+### Get Collection by Name
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.get_collection(name="my-collection")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get existing collection
+	collection, err := client.GetCollection(ctx, "my-collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	log.Printf("Got collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Get or Create Collection
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.get_or_create_collection(
+    name="my-collection",
+    metadata={"description": "..."}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get or create collection with metadata
+	collection, err := client.GetOrCreateCollection(ctx, "my-collection",
+		v2.WithCollectionMetadataCreate(
+			v2.NewMetadata(
+				v2.NewStringAttribute("description", "..."),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error getting/creating collection: %v", err)
+	}
+
+	log.Printf("Collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### List Collections
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collections = client.list_collections()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// List all collections
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error listing collections: %v", err)
+	}
+
+	for _, col := range collections {
+		log.Printf("Collection: %s", col.Name)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### List Collections with Pagination
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+first_collections_batch = client.list_collections(limit=100)
+second_collections_batch = client.list_collections(limit=100, offset=100)
+collections_subset = client.list_collections(limit=20, offset=50)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get first 100 collections
+	firstBatch, err := client.ListCollections(ctx,
+		v2.ListWithLimit(100),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Get next 100 collections
+	secondBatch, err := client.ListCollections(ctx,
+		v2.ListWithLimit(100),
+		v2.ListWithOffset(100),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Get 20 collections starting from the 50th
+	subset, err := client.ListCollections(ctx,
+		v2.ListWithLimit(20),
+		v2.ListWithOffset(50),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("First batch: %d, Second batch: %d, Subset: %d",
+		len(firstBatch), len(secondBatch), len(subset))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Modifying Collections
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.modify(
+   name="new-name",
+   metadata={"description": "new description"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my-collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Modify collection name and metadata
+	err = collection.Modify(ctx,
+		v2.WithCollectionNameUpdate("new-name"),
+		v2.WithCollectionMetadataUpdate(
+			v2.NewMetadata(
+				v2.NewStringAttribute("description", "new description"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error modifying collection: %v", err)
+	}
+
+	log.Println("Collection modified successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Deleting Collections
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+client.delete_collection(name="my-collection")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Delete collection by name
+	err = client.DeleteCollection(ctx, "my-collection")
+	if err != nil {
+		log.Fatalf("Error deleting collection: %v", err)
+	}
+
+	log.Println("Collection deleted successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Convenience Methods
+
+### Count and Peek
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.count()
+collection.peek()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my-collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get document count
+	count, err := collection.Count(ctx)
+	if err != nil {
+		log.Fatalf("Error getting count: %v", err)
+	}
+	log.Printf("Collection has %d documents", count)
+
+	// Peek at first 10 documents
+	peek, err := collection.Peek(ctx)
+	if err != nil {
+		log.Fatalf("Error peeking: %v", err)
+	}
+	log.Printf("First documents: %v", peek.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- Collection names must be unique within a database
+- The embedding function is persisted with the collection (Chroma >= 1.1.13)
+- Use `GetOrCreateCollection` to avoid errors when collection might already exist
+- Deleting a collection is permanent and removes all associated data
+- Use `defer client.Close()` to properly release resources

--- a/docs/go-examples/docs/collections/update-data.md
+++ b/docs/go-examples/docs/collections/update-data.md
@@ -1,0 +1,251 @@
+# Updating Data - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/collections/update-data)
+
+## Overview
+
+Any property of records in a collection can be updated with `.Update`. Chroma also supports `.Upsert` which updates existing items or adds them if they don't exist.
+
+## Go Examples
+
+### Update Records
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.update(
+    ids=["id1", "id2", "id3"],
+    embeddings=[[1.1, 2.3, 3.2], [4.5, 6.9, 4.4], [1.1, 2.3, 3.2]],
+    metadatas=[{"chapter": 3, "verse": 16}, {"chapter": 3, "verse": 5}, {"chapter": 29, "verse": 11}],
+    documents=["doc1", "doc2", "doc3"],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Update existing records
+	err = collection.Update(ctx,
+		v2.WithIDsUpdate("id1", "id2", "id3"),
+		v2.WithEmbeddingsUpdate(
+			[]float32{1.1, 2.3, 3.2},
+			[]float32{4.5, 6.9, 4.4},
+			[]float32{1.1, 2.3, 3.2},
+		),
+		v2.WithMetadatasUpdate(
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 16),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 3),
+				v2.NewIntAttribute("verse", 5),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewIntAttribute("chapter", 29),
+				v2.NewIntAttribute("verse", 11),
+			),
+		),
+		v2.WithTextsUpdate("doc1", "doc2", "doc3"),
+	)
+	if err != nil {
+		log.Fatalf("Error updating documents: %v", err)
+	}
+
+	log.Println("Documents updated successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Update Documents Only
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Update only documents - embeddings will be recomputed
+	err = collection.Update(ctx,
+		v2.WithIDsUpdate("id1", "id2"),
+		v2.WithTextsUpdate("new document 1", "new document 2"),
+	)
+	if err != nil {
+		log.Fatalf("Error updating documents: %v", err)
+	}
+
+	log.Println("Documents updated - embeddings recomputed")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Upsert Records
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.upsert(
+    ids=["id1", "id2", "id3"],
+    embeddings=[[1.1, 2.3, 3.2], [4.5, 6.9, 4.4], [1.1, 2.3, 3.2]],
+    metadatas=[{"chapter": 3, "verse": 16}, {"chapter": 3, "verse": 5}, {"chapter": 29, "verse": 11}],
+    documents=["doc1", "doc2", "doc3"],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Upsert - insert or update records
+	err = collection.Upsert(ctx,
+		v2.WithIDs("id1", "id2", "id3"),
+		v2.WithEmbeddings(
+			[]float32{1.1, 2.3, 3.2},
+			[]float32{4.5, 6.9, 4.4},
+			[]float32{1.1, 2.3, 3.2},
+		),
+		v2.WithMetadatas(
+			v2.NewDocumentMetadata(
+				v2.NewStringAttribute("chapter", "3"),
+				v2.NewStringAttribute("verse", "16"),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewStringAttribute("chapter", "3"),
+				v2.NewStringAttribute("verse", "5"),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewStringAttribute("chapter", "29"),
+				v2.NewStringAttribute("verse", "11"),
+			),
+		),
+		v2.WithTexts("doc1", "doc2", "doc3"),
+	)
+	if err != nil {
+		log.Fatalf("Error upserting documents: %v", err)
+	}
+
+	log.Println("Documents upserted successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Simple Upsert with Documents
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Simple upsert with just IDs and documents
+	// Embeddings will be computed automatically
+	err = collection.Upsert(ctx,
+		v2.WithIDs("id1", "id2"),
+		v2.WithTexts(
+			"This document will be inserted or updated",
+			"Another document to upsert",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error upserting: %v", err)
+	}
+
+	log.Println("Upsert completed")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- If an ID is not found during `Update`, an error will be logged and ignored
+- If documents are supplied without embeddings, embeddings are recomputed
+- Embedding dimensions must match the collection's existing embeddings
+- `Upsert` creates new records for IDs that don't exist
+- `Upsert` updates records for IDs that already exist

--- a/docs/go-examples/docs/embeddings/embedding-functions.md
+++ b/docs/go-examples/docs/embeddings/embedding-functions.md
@@ -1,0 +1,526 @@
+# Embedding Functions - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/embeddings/embedding-functions)
+
+## Overview
+
+Embeddings are vector representations of data that enable similarity search. Chroma-go provides wrappers around popular embedding providers.
+
+## Supported Embedding Providers
+
+| Provider | Package | Import Path |
+|----------|---------|-------------|
+| Default (ONNX) | `default_ef` | `github.com/amikos-tech/chroma-go/pkg/embeddings/default_ef` |
+| OpenAI | `openai` | `github.com/amikos-tech/chroma-go/pkg/embeddings/openai` |
+| Cohere | `cohere` | `github.com/amikos-tech/chroma-go/pkg/embeddings/cohere` |
+| HuggingFace TEI | `hf` | `github.com/amikos-tech/chroma-go/pkg/embeddings/hf` |
+| Ollama | `ollama` | `github.com/amikos-tech/chroma-go/pkg/embeddings/ollama` |
+| Jina AI | `jina` | `github.com/amikos-tech/chroma-go/pkg/embeddings/jina` |
+| Mistral | `mistral` | `github.com/amikos-tech/chroma-go/pkg/embeddings/mistral` |
+| Nomic | `nomic` | `github.com/amikos-tech/chroma-go/pkg/embeddings/nomic` |
+| Voyage | `voyage` | `github.com/amikos-tech/chroma-go/pkg/embeddings/voyage` |
+| Gemini | `gemini` | `github.com/amikos-tech/chroma-go/pkg/embeddings/gemini` |
+| Cloudflare | `cloudflare` | `github.com/amikos-tech/chroma-go/pkg/embeddings/cloudflare` |
+| Together AI | `together` | `github.com/amikos-tech/chroma-go/pkg/embeddings/together` |
+| Chroma Cloud | `chromacloud` | `github.com/amikos-tech/chroma-go/pkg/embeddings/chromacloud` |
+
+## Default Embedding Function
+
+The default embedding function uses a local ONNX model.
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = client.create_collection(name="my_collection")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Collection uses default embedding function automatically
+	collection, err := client.CreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection with default EF: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## OpenAI Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+collection = client.create_collection(
+    name="my_collection",
+    embedding_function=OpenAIEmbeddingFunction(
+        model_name="text-embedding-3-small"
+    )
+)
+
+collection.add(
+    ids=["id1", "id2"],
+    documents=["doc1", "doc2"]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create OpenAI embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with OpenAI embeddings
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	// Add documents - OpenAI will embed them
+	err = collection.Add(ctx,
+		v2.WithIDs("id1", "id2"),
+		v2.WithTexts("doc1", "doc2"),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Documents added with OpenAI embeddings")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Cohere Embedding Function
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/cohere"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create Cohere embedding function
+	ef, err := cohere.NewCohereEmbeddingFunction(
+		os.Getenv("COHERE_API_KEY"),
+		cohere.WithModel("embed-english-v3.0"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with Cohere embeddings
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection with Cohere EF: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Ollama Embedding Function (Local)
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/ollama"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create Ollama embedding function (local)
+	ef, err := ollama.NewOllamaEmbeddingFunction(
+		"http://localhost:11434",
+		"nomic-embed-text",
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection with Ollama embeddings
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection with Ollama EF: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## HuggingFace Text Embedding Inference
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/hf"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create HuggingFace TEI embedding function
+	ef, err := hf.NewHuggingFaceEmbeddingFunction(
+		os.Getenv("HF_API_KEY"),
+		"BAAI/bge-small-en-v1.5",
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithEmbeddingFunctionCreate(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection with HuggingFace EF: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Using Embedding Functions Directly
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+default_ef = DefaultEmbeddingFunction()
+embeddings = default_ef(["foo"])
+print(embeddings)
+
+collection.query(query_embeddings=embeddings)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Use embedding function directly
+	embeddings, err := ef.EmbedDocuments(ctx, []string{"foo"})
+	if err != nil {
+		log.Fatalf("Error embedding: %v", err)
+	}
+	log.Printf("Embeddings: %v", embeddings)
+
+	// Use embeddings in query
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	results, err := collection.Query(ctx,
+		v2.WithQueryEmbeddings(embeddings[0]),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetIDsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Custom Embedding Functions
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+from chromadb import Documents, EmbeddingFunction, Embeddings
+
+class MyEmbeddingFunction(EmbeddingFunction):
+    def __call__(self, input: Documents) -> Embeddings:
+        # embed the documents somehow
+        return embeddings
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+// MyEmbeddingFunction implements the EmbeddingFunction interface
+type MyEmbeddingFunction struct {
+	apiKey string
+}
+
+func NewMyEmbeddingFunction(apiKey string) *MyEmbeddingFunction {
+	return &MyEmbeddingFunction{apiKey: apiKey}
+}
+
+// EmbedDocuments embeds a list of documents
+func (ef *MyEmbeddingFunction) EmbedDocuments(ctx context.Context, docs []string) ([][]float32, error) {
+	// Implement your embedding logic here
+	embeddings := make([][]float32, len(docs))
+	for i := range docs {
+		// Generate embedding for each document
+		embeddings[i] = []float32{0.1, 0.2, 0.3} // placeholder
+	}
+	return embeddings, nil
+}
+
+// EmbedQuery embeds a single query
+func (ef *MyEmbeddingFunction) EmbedQuery(ctx context.Context, query string) ([]float32, error) {
+	embeddings, err := ef.EmbedDocuments(ctx, []string{query})
+	if err != nil {
+		return nil, err
+	}
+	return embeddings[0], nil
+}
+
+// Ensure it implements the interface
+var _ embeddings.EmbeddingFunction = (*MyEmbeddingFunction)(nil)
+```
+{% /codetab %}
+{% /codetabs %}
+
+## All Available Providers
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/cloudflare"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/cohere"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/gemini"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/hf"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/jina"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/mistral"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/nomic"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/ollama"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/together"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/voyage"
+)
+
+func createEmbeddingFunctions() {
+	// OpenAI
+	openaiEF, _ := openai.NewOpenAIEmbeddingFunction(
+		os.Getenv("OPENAI_API_KEY"),
+		openai.WithModel(openai.TextEmbedding3Small),
+	)
+
+	// Cohere
+	cohereEF, _ := cohere.NewCohereEmbeddingFunction(
+		os.Getenv("COHERE_API_KEY"),
+		cohere.WithModel("embed-english-v3.0"),
+	)
+
+	// Ollama (local)
+	ollamaEF, _ := ollama.NewOllamaEmbeddingFunction(
+		"http://localhost:11434",
+		"nomic-embed-text",
+	)
+
+	// HuggingFace TEI
+	hfEF, _ := hf.NewHuggingFaceEmbeddingFunction(
+		os.Getenv("HF_API_KEY"),
+		"BAAI/bge-small-en-v1.5",
+	)
+
+	// Jina
+	jinaEF, _ := jina.NewJinaEmbeddingFunction(
+		os.Getenv("JINA_API_KEY"),
+		jina.WithModel("jina-embeddings-v2-base-en"),
+	)
+
+	// Mistral
+	mistralEF, _ := mistral.NewMistralEmbeddingFunction(
+		os.Getenv("MISTRAL_API_KEY"),
+		mistral.WithModel("mistral-embed"),
+	)
+
+	// Nomic
+	nomicEF, _ := nomic.NewNomicEmbeddingFunction(
+		os.Getenv("NOMIC_API_KEY"),
+	)
+
+	// Voyage
+	voyageEF, _ := voyage.NewVoyageEmbeddingFunction(
+		os.Getenv("VOYAGE_API_KEY"),
+		voyage.WithModel("voyage-2"),
+	)
+
+	// Gemini
+	geminiEF, _ := gemini.NewGeminiEmbeddingFunction(
+		os.Getenv("GEMINI_API_KEY"),
+	)
+
+	// Cloudflare
+	cloudflareEF, _ := cloudflare.NewCloudflareEmbeddingFunction(
+		os.Getenv("CF_ACCOUNT_ID"),
+		os.Getenv("CF_API_TOKEN"),
+		"@cf/baai/bge-base-en-v1.5",
+	)
+
+	// Together AI
+	togetherEF, _ := together.NewTogetherEmbeddingFunction(
+		os.Getenv("TOGETHER_API_KEY"),
+		together.WithModel("togethercomputer/m2-bert-80M-8k-retrieval"),
+	)
+
+	_ = openaiEF
+	_ = cohereEF
+	_ = ollamaEF
+	_ = hfEF
+	_ = jinaEF
+	_ = mistralEF
+	_ = nomicEF
+	_ = voyageEF
+	_ = geminiEF
+	_ = cloudflareEF
+	_ = togetherEF
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- API keys are typically read from environment variables
+- Use `defer client.Close()` to properly release embedding function resources
+- Embedding dimensions must match when adding to existing collections
+- The default embedding function uses ONNX Runtime locally
+- Set `CHROMAGO_ONNX_RUNTIME_PATH` to use a custom ONNX Runtime library

--- a/docs/go-examples/docs/embeddings/multimodal.md
+++ b/docs/go-examples/docs/embeddings/multimodal.md
@@ -1,0 +1,155 @@
+# Multimodal Embeddings - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/embeddings/multimodal)
+
+## Overview
+
+Multimodal collections can store and query data from multiple modalities (text, images, etc.) in a single embedding space.
+
+> **Note**: Multimodal support (images, data loaders, OpenCLIP embedding function) is not yet available in chroma-go. This page documents the Python API for reference. Track progress at the [chroma-go GitHub repository](https://github.com/amikos-tech/chroma-go).
+
+## Python Examples (For Reference)
+
+### Multi-modal Embedding Functions
+
+```python
+from chromadb.utils.embedding_functions import OpenCLIPEmbeddingFunction
+embedding_function = OpenCLIPEmbeddingFunction()
+```
+
+### Adding Multimodal Data with Data Loaders
+
+```python
+import chromadb
+from chromadb.utils.data_loaders import ImageLoader
+from chromadb.utils.embedding_functions import OpenCLIPEmbeddingFunction
+
+client = chromadb.Client()
+
+data_loader = ImageLoader()
+embedding_function = OpenCLIPEmbeddingFunction()
+
+collection = client.create_collection(
+    name='multimodal_collection',
+    embedding_function=embedding_function,
+    data_loader=data_loader
+)
+```
+
+### Adding Images via URIs
+
+```python
+collection.add(
+    ids=["id1", "id2"],
+    uris=["path/to/file/1", "path/to/file/2"]
+)
+```
+
+### Querying with Images
+
+```python
+results = collection.query(
+    query_images=[...]  # A list of numpy arrays representing images
+)
+```
+
+### Querying with Text
+
+```python
+results = collection.query(
+    query_texts=["This is a query document", "This is another query document"]
+)
+```
+
+## Go Workaround
+
+While multimodal is not directly supported, you can use text-based embeddings or pre-compute image embeddings externally:
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// For multimodal-like functionality, pre-compute embeddings externally
+	// and add them directly to the collection
+
+	// Create collection without embedding function (manual embeddings)
+	collection, err := client.CreateCollection(ctx, "multimodal_workaround",
+		v2.WithEmbeddingFunctionCreate(nil),
+	)
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	// Pre-computed CLIP embeddings for images (computed externally)
+	imageEmbedding1 := []float32{0.1, 0.2, 0.3} // ... actual CLIP embedding
+	imageEmbedding2 := []float32{0.4, 0.5, 0.6} // ... actual CLIP embedding
+
+	// Add with pre-computed embeddings and URIs as metadata
+	err = collection.Add(ctx,
+		v2.WithIDs("img1", "img2"),
+		v2.WithEmbeddings(imageEmbedding1, imageEmbedding2),
+		v2.WithMetadatas(
+			v2.NewDocumentMetadata(
+				v2.NewStringAttribute("uri", "/path/to/image1.jpg"),
+				v2.NewStringAttribute("type", "image"),
+			),
+			v2.NewDocumentMetadata(
+				v2.NewStringAttribute("uri", "/path/to/image2.jpg"),
+				v2.NewStringAttribute("type", "image"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding: %v", err)
+	}
+
+	// Query with pre-computed query embedding
+	queryEmbedding := []float32{0.15, 0.25, 0.35} // CLIP embedding of query image
+	results, err := collection.Query(ctx,
+		v2.WithQueryEmbeddings(queryEmbedding),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetIDsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Feature Status
+
+| Feature | Python | Go |
+|---------|--------|-----|
+| OpenCLIP Embedding Function | ✓ | Not available |
+| ImageLoader Data Loader | ✓ | Not available |
+| `query_images` parameter | ✓ | Not available |
+| `images` parameter in add | ✓ | Not available |
+| `uris` parameter | ✓ | Store as metadata |
+| Pre-computed embeddings | ✓ | ✓ |
+
+## Notes
+
+- Multimodal support requires data loaders and multi-modal embedding functions
+- As a workaround, compute embeddings externally (using Python or other tools) and add them directly
+- Store URIs in metadata for reference to original files
+- Text queries work normally with text embedding functions

--- a/docs/go-examples/docs/overview/getting-started.md
+++ b/docs/go-examples/docs/overview/getting-started.md
@@ -1,0 +1,330 @@
+# Getting Started - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/overview/getting-started)
+
+## Overview
+
+Chroma is an AI-native open-source vector database. This guide shows how to get started with Chroma using the Go client.
+
+## 1. Install
+
+```terminal
+go get github.com/amikos-tech/chroma-go
+```
+
+## 2. Create a Chroma Client
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+chroma_client = chromadb.Client()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// The Go client connects to a running Chroma server
+	// Start the server first: chroma run --path ./getting-started
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+> **Note**: Unlike Python's ephemeral `Client()`, the Go client requires a running Chroma server. Start the server with `chroma run --path ./data` or use Docker.
+
+## 3. Create a Collection
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection = chroma_client.create_collection(name="my_collection")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create a new collection
+	collection, err := client.CreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	log.Printf("Created collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## 4. Add Documents
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.add(
+    ids=["id1", "id2"],
+    documents=[
+        "This is a document about pineapple",
+        "This is a document about oranges"
+    ]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Add documents with IDs
+	err = collection.Add(ctx,
+		v2.WithIDs("id1", "id2"),
+		v2.WithTexts(
+			"This is a document about pineapple",
+			"This is a document about oranges",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Documents added successfully")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## 5. Query the Collection
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+results = collection.query(
+    query_texts=["This is a query document about hawaii"],
+    n_results=2
+)
+print(results)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query the collection
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("This is a query document about hawaii"),
+		v2.WithNResults(2),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	// Access results
+	documents := results.GetDocumentsGroups()
+	ids := results.GetIDsGroups()
+	distances := results.GetDistances()
+
+	log.Printf("Documents: %v", documents)
+	log.Printf("IDs: %v", ids)
+	log.Printf("Distances: %v", distances)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## 6. Inspect Results
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+{
+  'documents': [[
+      'This is a document about pineapple',
+      'This is a document about oranges'
+  ]],
+  'ids': [['id1', 'id2']],
+  'distances': [[1.0404009819030762, 1.243080496788025]],
+  'uris': None,
+  'data': None,
+  'metadatas': [[None, None]],
+  'embeddings': None,
+}
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+// In Go, results are accessed through typed methods:
+documents := results.GetDocumentsGroups() // [][]string
+ids := results.GetIDsGroups()             // [][]string
+distances := results.GetDistances()       // [][]float32
+metadatas := results.GetMetadatasGroups() // [][]map[string]interface{}
+embeddings := results.GetEmbeddingsGroups() // [][][]float32
+
+// Example output:
+// documents[0] = ["This is a document about pineapple", "This is a document about oranges"]
+// ids[0] = ["id1", "id2"]
+// distances[0] = [1.0404009819030762, 1.243080496788025]
+```
+{% /codetab %}
+{% /codetabs %}
+
+## 7. Complete Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+chroma_client = chromadb.Client()
+
+collection = chroma_client.get_or_create_collection(name="my_collection")
+
+collection.upsert(
+    documents=[
+        "This is a document about pineapple",
+        "This is a document about oranges"
+    ],
+    ids=["id1", "id2"]
+)
+
+results = collection.query(
+    query_texts=["This is a query document about florida"],
+    n_results=2
+)
+
+print(results)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create client (requires running Chroma server)
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Get or create collection
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Upsert documents (insert or update)
+	err = collection.Upsert(ctx,
+		v2.WithIDs("id1", "id2"),
+		v2.WithTexts(
+			"This is a document about pineapple",
+			"This is a document about oranges",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error upserting documents: %v", err)
+	}
+
+	// Query the collection
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("This is a query document about florida"),
+		v2.WithNResults(2),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	// Print results
+	log.Printf("Documents: %v", results.GetDocumentsGroups())
+	log.Printf("IDs: %v", results.GetIDsGroups())
+	log.Printf("Distances: %v", results.GetDistances())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- The Go client requires a running Chroma server (unlike Python's ephemeral client)
+- Start the server with: `chroma run --path ./data` or use Docker
+- Always use `defer client.Close()` to release resources
+- All operations require a `context.Context` for cancellation/timeout support
+- Results are accessed through typed getter methods (`GetDocumentsGroups()`, `GetIDsGroups()`, etc.)

--- a/docs/go-examples/docs/overview/migration.md
+++ b/docs/go-examples/docs/overview/migration.md
@@ -1,0 +1,369 @@
+# Migration - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/overview/migration)
+
+## Overview
+
+This document covers migration notes and breaking changes when upgrading Chroma versions. Since chroma-go is an HTTP client, most migration concerns relate to API changes and server compatibility.
+
+## Go Client Considerations
+
+### Version Compatibility
+
+The chroma-go client is tested against Chroma versions 0.4.8 to 1.4.0. When upgrading your Chroma server, check for any API changes that might affect your client code.
+
+### API v1 vs v2
+
+chroma-go provides two API versions:
+
+{% codetabs group="lang" %}
+{% codetab label="v1 API (Legacy)" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	chroma "github.com/amikos-tech/chroma-go"
+)
+
+func main() {
+	// V1 API - Legacy, maintained for backward compatibility
+	client, err := chroma.NewClient("http://localhost:8000")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection", nil)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection: %s", collection.Name)
+}
+```
+{% /codetab %}
+{% codetab label="v2 API (Current)" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// V2 API - Current primary API, all new features go here
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Key v2 API Changes
+
+1. **Client creation returns error**: All client constructors return `(client, error)`
+2. **Close method**: Clients should be closed with `defer client.Close()`
+3. **Functional options**: Configuration uses functional options pattern
+4. **Collection methods**: `collection.Name()` instead of `collection.Name`
+5. **Search API**: New Search API with `collection.Search()` for advanced queries
+
+### Migrating from v1 to v2
+
+{% codetabs group="lang" %}
+{% codetab label="v1 API" %}
+```go
+package main
+
+import (
+	"context"
+
+	chroma "github.com/amikos-tech/chroma-go"
+)
+
+func main() {
+	// v1 client creation
+	client, _ := chroma.NewClient("http://localhost:8000")
+
+	ctx := context.Background()
+
+	// v1 collection operations
+	collection, _ := client.GetCollection(ctx, "my_collection", nil)
+
+	// v1 query
+	results, _ := collection.Query(ctx,
+		[]string{"query text"},
+		10,
+		nil,  // where
+		nil,  // whereDocument
+		nil,  // include
+	)
+
+	_ = results
+}
+```
+{% /codetab %}
+{% codetab label="v2 API" %}
+```go
+package main
+
+import (
+	"context"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// v2 client creation with error handling
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		panic(err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// v2 collection operations
+	collection, _ := client.GetCollection(ctx, "my_collection")
+
+	// v2 query with functional options
+	results, _ := collection.Query(ctx,
+		v2.WithQueryTexts("query text"),
+		v2.WithNResults(10),
+	)
+
+	_ = results
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Server Migration Notes
+
+### v1.0.0 Changes (March 2025)
+
+Key changes that may affect Go clients:
+
+1. **Authentication changes**: Chroma no longer provides built-in authentication implementations
+2. **Configuration changes**: Server now uses config files instead of environment variables
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# list_collections now returns Collection objects again
+collections = client.list_collections()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// ListCollections returns collection objects with metadata
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	for _, col := range collections {
+		log.Printf("Collection: %s (ID: %s)", col.Name(), col.ID())
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### v0.5.11 Changes (September 2024)
+
+Query results ordering changed:
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Results from get() are now ordered by internal IDs (insertion order)
+# Previously ordered by user-provided IDs
+results = collection.get(limit=2, offset=2)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, _ := v2.NewHTTPClient()
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, _ := client.GetCollection(ctx, "my_collection")
+
+	// Results ordered by internal IDs (newer documents have larger IDs)
+	// Limit and offset behavior depends on this ordering
+	results, err := collection.Get(ctx,
+		v2.WithGetLimit(2),
+		v2.WithGetOffset(2),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("IDs: %v", results.Ids)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### v0.5.17 Changes (October 2024)
+
+Empty filters are no longer supported:
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# This is no longer supported:
+# collection.get(ids=["id1", "id2"], where={})
+
+# Use this instead:
+collection.get(ids=["id1", "id2"])
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, _ := v2.NewHTTPClient()
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, _ := client.GetCollection(ctx, "my_collection")
+
+	// Don't pass empty where filters - omit them instead
+	results, err := collection.Get(ctx,
+		v2.WithGetIDs("id1", "id2"),
+		// Don't use empty where: v2.WithGetWhere(...)
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("IDs: %v", results.Ids)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Authentication Migration
+
+When upgrading to Chroma v1.0.0+, update your authentication configuration:
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+# Token auth
+client = chromadb.HttpClient(
+    host="localhost",
+    port=8000,
+    headers={"Authorization": "Bearer your-token"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Token auth (Bearer)
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+		v2.WithAuth(v2.NewTokenAuthCredentialsProvider("your-token", v2.AuthorizationTokenHeader)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	// Or use X-Chroma-Token header
+	clientWithToken, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+		v2.WithAuth(v2.NewTokenAuthCredentialsProvider("your-token", v2.XChromaTokenHeader)),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer clientWithToken.Close()
+
+	// Or use Basic auth
+	clientWithBasic, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+		v2.WithAuth(v2.NewBasicAuthCredentialsProvider("username", "password")),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer clientWithBasic.Close()
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- chroma-go is an HTTP-only client; it always connects to a Chroma server
+- No in-process/embedded mode is available in Go (unlike Python's PersistentClient/EphemeralClient)
+- API v2 is recommended for all new projects
+- Always check the [chroma-go releases](https://github.com/amikos-tech/chroma-go/releases) for client-specific changes
+- Server upgrades may require updating your Go client version for full compatibility
+

--- a/docs/go-examples/docs/overview/telemetry.md
+++ b/docs/go-examples/docs/overview/telemetry.md
@@ -1,0 +1,173 @@
+# Telemetry - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/overview/telemetry)
+
+## Overview
+
+Chroma contains a telemetry feature that collects **anonymous** usage information. This is configured on the Chroma server side, not in the Go client.
+
+## Server-Side Configuration
+
+Telemetry is controlled by the Chroma server, not the client. When using the Go client, you need to configure telemetry on your Chroma server.
+
+### Opting Out
+
+{% codetabs group="lang" %}
+{% codetab label="Python (Server Config)" %}
+```python
+from chromadb.config import Settings
+
+# Python in-process mode can disable telemetry
+client = chromadb.Client(Settings(anonymized_telemetry=False))
+
+# Or with PersistentClient
+client = chromadb.PersistentClient(
+    path="/path/to/save/to",
+    settings=Settings(anonymized_telemetry=False)
+)
+```
+{% /codetab %}
+{% codetab label="Go (Client)" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Go client cannot control server telemetry
+	// Telemetry is configured on the Chroma server side
+
+	// Connect to server (which may have telemetry enabled/disabled)
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Normal operations...
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Found %d collections", len(collections))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Using Environment Variables
+
+To disable telemetry on your Chroma server:
+
+```bash
+# Set environment variable before starting Chroma server
+export ANONYMIZED_TELEMETRY=False
+chroma run --path /path/to/data
+```
+
+Or in a Docker environment:
+
+```bash
+# docker-compose.yml
+version: '3'
+services:
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - ANONYMIZED_TELEMETRY=False
+    volumes:
+      - ./chroma-data:/data
+```
+
+Or with an `.env` file:
+
+```
+# .env file in the same directory as docker-compose.yml
+ANONYMIZED_TELEMETRY=False
+```
+
+### Connecting to Configured Server
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect to Chroma server (telemetry status depends on server config)
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Check connection
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Server not responding: %v", err)
+	}
+
+	log.Printf("Connected to Chroma server. Heartbeat: %d", heartbeat)
+
+	// Your application code...
+	collection, err := client.GetOrCreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Operations here are tracked by server telemetry (if enabled)
+	err = collection.Add(ctx,
+		v2.WithIDs("doc1"),
+		v2.WithDocuments("Sample document"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Document added to collection: %s", collection.Name())
+}
+```
+
+## What Chroma Tracks
+
+When telemetry is enabled on the server, it tracks:
+
+- Chroma version and environment details
+- Usage of embedding functions
+- Collection commands (add, update, query, get, delete)
+- Anonymized collection UUIDs and item counts
+
+Chroma does **not** collect:
+
+- Usernames, hostnames, or file names
+- Environment variables
+- Actual document content or embeddings
+- Personally-identifiable information
+
+## Notes
+
+- Telemetry is a server-side setting, not controlled by the Go client
+- The Go client simply makes HTTP requests; tracking happens on the server
+- Use environment variables or Docker configuration to control telemetry
+- Telemetry data is stored in Posthog for product analytics
+- For Chroma Cloud, telemetry helps improve the service
+

--- a/docs/go-examples/docs/overview/troubleshooting.md
+++ b/docs/go-examples/docs/overview/troubleshooting.md
@@ -1,0 +1,361 @@
+# Troubleshooting - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/overview/troubleshooting)
+
+## Overview
+
+This page covers common issues when using chroma-go and how to resolve them.
+
+## Connection Issues
+
+### Cannot Connect to Server
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create client with timeout
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	// Use context with timeout for connection check
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Check if server is running
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Cannot connect to Chroma server at localhost:8000: %v", err)
+		log.Println("Make sure the Chroma server is running:")
+		log.Println("  docker run -p 8000:8000 chromadb/chroma")
+		log.Println("  OR")
+		log.Println("  chroma run --path /path/to/data")
+	}
+
+	log.Printf("Connected! Heartbeat: %d", heartbeat)
+}
+```
+
+### SSL/TLS Issues
+
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// For HTTPS connections
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("https://chroma.example.com"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	// If using self-signed certificates, you may need custom transport
+	// See Go's http.Transport for TLS configuration
+}
+```
+
+## Embeddings Issues
+
+### Embeddings Return nil
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Embeddings are not returned by default
+results = collection.query(
+    query_texts="hello",
+    n_results=1,
+    include=["embeddings", "documents", "metadatas", "distances"],
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, _ := client.GetCollection(ctx, "my_collection")
+
+	// By default, embeddings are NOT returned (they're large)
+	results, _ := collection.Query(ctx,
+		v2.WithQueryTexts("hello"),
+		v2.WithNResults(1),
+	)
+	// results.Embeddings will be nil
+
+	// To include embeddings, use WithInclude
+	resultsWithEmbeddings, err := collection.Query(ctx,
+		v2.WithQueryTexts("hello"),
+		v2.WithNResults(1),
+		v2.WithInclude(v2.IncludeEmbeddings, v2.IncludeDocuments, v2.IncludeMetadatas, v2.IncludeDistances),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Now embeddings are included
+	if resultsWithEmbeddings.Embeddings != nil {
+		log.Printf("Embeddings: %v", resultsWithEmbeddings.Embeddings[0][0][:5]) // First 5 dims
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Embedding Function Not Set
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/openai"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create embedding function
+	ef, err := openai.NewOpenAIEmbeddingFunction(
+		openai.WithAPIKey("your-api-key"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating embedding function: %v", err)
+	}
+
+	// Create collection WITH embedding function
+	collection, err := client.CreateCollection(ctx, "my_collection",
+		v2.WithCollectionEmbeddingFunction(ef),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Now you can add documents without providing embeddings
+	err = collection.Add(ctx,
+		v2.WithIDs("doc1"),
+		v2.WithDocuments("This will be embedded automatically"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+}
+```
+
+## HNSW Configuration Issues
+
+### "Cannot return results in contiguous 2D array"
+
+This error occurs when HNSW parameters are too restrictive:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection with larger HNSW parameters
+	schema, _ := v2.NewSchema(
+		v2.WithDefaultVectorIndex(v2.NewVectorIndexConfig(
+			v2.WithSpace(v2.SpaceCosine),
+			v2.WithHnsw(v2.NewHnswConfig(
+				v2.WithEfConstruction(200), // Increase from default 100
+				v2.WithMaxNeighbors(32),    // Increase from default 16
+				v2.WithEfSearch(100),       // Increase for better recall
+			)),
+		)),
+	)
+
+	collection, err := client.CreateCollection(ctx, "better_hnsw_collection",
+		v2.WithCollectionSchema(schema),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Or reduce n_results in your query
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("query"),
+		v2.WithNResults(5), // Reduce from larger number
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Found %d results", len(results.IDs[0]))
+}
+```
+
+## Data Type Issues
+
+### Metadata Type Assertions
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, _ := v2.NewHTTPClient()
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, _ := client.GetCollection(ctx, "my_collection")
+
+	results, _ := collection.Get(ctx,
+		v2.WithGetIDs("doc1"),
+		v2.WithGetInclude(v2.IncludeMetadatas),
+	)
+
+	// Safely access metadata with type assertions
+	if len(results.Metadatas) > 0 && len(results.Metadatas[0]) > 0 {
+		metadata := results.Metadatas[0][0]
+
+		// Use Get method which returns (value, ok)
+		if category, ok := metadata.Get("category"); ok {
+			fmt.Printf("Category: %s\n", category)
+		}
+
+		// Type assertion for specific types
+		if year, ok := metadata.Get("year"); ok {
+			switch v := year.(type) {
+			case int:
+				fmt.Printf("Year (int): %d\n", v)
+			case float64:
+				fmt.Printf("Year (float64): %.0f\n", v)
+			default:
+				fmt.Printf("Year (unknown type): %v\n", v)
+			}
+		}
+	}
+}
+```
+
+## Context and Timeout Issues
+
+### Operations Timing Out
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	// Use longer timeout for large operations
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	collection, _ := client.GetCollection(ctx, "large_collection")
+
+	// Large batch operation with timeout
+	ids := make([]string, 10000)
+	docs := make([]string, 10000)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("doc_%d", i)
+		docs[i] = fmt.Sprintf("Document content %d", i)
+	}
+
+	err = collection.Add(ctx,
+		v2.WithIDs(ids...),
+		v2.WithDocuments(docs...),
+	)
+	if err != nil {
+		log.Fatalf("Error (check timeout): %v", err)
+	}
+}
+```
+
+## Common Error Messages
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `connection refused` | Server not running | Start Chroma server first |
+| `context deadline exceeded` | Operation timeout | Increase context timeout |
+| `embeddings is nil` | Embeddings not requested | Use `WithInclude(v2.IncludeEmbeddings)` |
+| `collection not found` | Collection doesn't exist | Use `GetOrCreateCollection` |
+| `invalid api key` | Authentication failed | Check API key configuration |
+
+## Notes
+
+- Always check errors returned from chroma-go functions
+- Use contexts with timeouts for production code
+- For large batch operations, consider chunking data
+- When using embedding functions, ensure API keys are configured
+- Check Chroma server logs for server-side errors
+- Visit [GitHub Issues](https://github.com/amikos-tech/chroma-go/issues) for more help
+

--- a/docs/go-examples/docs/querying-collections/full-text-search.md
+++ b/docs/go-examples/docs/querying-collections/full-text-search.md
@@ -1,0 +1,305 @@
+# Full Text Search and Regex - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/querying-collections/full-text-search)
+
+## Overview
+
+The `where_document` argument in `get` and `query` is used to filter records based on their document content. Chroma supports full-text search with `$contains`/`$not_contains` operators and regex pattern matching with `$regex`/`$not_regex` operators.
+
+## Go Examples
+
+### Contains Search
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.get(
+   where_document={"$contains": "search string"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get documents containing a specific string
+	results, err := collection.Get(ctx,
+		v2.WithWhereDocumentGet(v2.ContainsString("search string")),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	log.Printf("Documents: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Regex Pattern Matching
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.get(
+   where_document={
+       "$regex": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+   }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get documents matching email regex pattern
+	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+	results, err := collection.Get(ctx,
+		v2.WithWhereDocumentGet(v2.MatchesRegex(emailRegex)),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	log.Printf("Documents matching email pattern: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Logical AND with Document Filters
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["query1", "query2"],
+    where_document={
+        "$and": [
+            {"$contains": "search_string_1"},
+            {"$regex": "[a-z]+"},
+        ]
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with AND document filter
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("query1", "query2"),
+		v2.WithWhereDocumentQuery(
+			v2.AndDocument(
+				v2.ContainsString("search_string_1"),
+				v2.MatchesRegex("[a-z]+"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Logical OR with Document Filters
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["query1", "query2"],
+    where_document={
+        "$or": [
+            {"$contains": "search_string_1"},
+            {"$not_contains": "search_string_2"},
+        ]
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with OR document filter
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("query1", "query2"),
+		v2.WithWhereDocumentQuery(
+			v2.OrDocument(
+				v2.ContainsString("search_string_1"),
+				v2.NotContainsString("search_string_2"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Combining Metadata and Document Filters
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["doc10", "thus spake zarathustra"],
+    n_results=10,
+    where={"metadata_field": "is_equal_to_this"},
+    where_document={"$contains":"search_string"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Combined metadata and document filters
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("doc10", "thus spake zarathustra"),
+		v2.WithNResults(10),
+		v2.WithWhereQuery(v2.EqString("metadata_field", "is_equal_to_this")),
+		v2.WithWhereDocumentQuery(v2.ContainsString("search_string")),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Available Document Filter Functions
+
+| Python Operator | Go Function | Description |
+|----------------|-------------|-------------|
+| `{"$contains": "text"}` | `v2.ContainsString("text")` | Document contains text |
+| `{"$not_contains": "text"}` | `v2.NotContainsString("text")` | Document does not contain text |
+| `{"$regex": "pattern"}` | `v2.MatchesRegex("pattern")` | Document matches regex |
+| `{"$not_regex": "pattern"}` | `v2.NotMatchesRegex("pattern")` | Document does not match regex |
+| `{"$and": [...]}` | `v2.AndDocument(...)` | All conditions must match |
+| `{"$or": [...]}` | `v2.OrDocument(...)` | Any condition must match |
+
+## Notes
+
+- Full-text search is case-sensitive
+- Regex patterns use standard regex syntax
+- Document filters can be combined with metadata filters
+- Use `Query` for semantic search + filtering, `Get` for filtering only

--- a/docs/go-examples/docs/querying-collections/metadata-filtering.md
+++ b/docs/go-examples/docs/querying-collections/metadata-filtering.md
@@ -1,0 +1,570 @@
+# Metadata Filtering - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/querying-collections/metadata-filtering)
+
+## Overview
+
+The `where` argument in `get` and `query` is used to filter records by their metadata. Use `v2.K("field")` to clearly mark metadata field names in filter expressions.
+
+## Go Examples
+
+### Basic Equality Filter
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["first query", "second query"],
+    where={"page": 10}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with metadata filter - page equals 10
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("first query", "second query"),
+		v2.WithWhereQuery(v2.EqInt(v2.K("page"), 10)),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Comparison Operators
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["first query", "second query"],
+    where={"page": { "$gt": 10 }}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with greater than filter
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("first query", "second query"),
+		v2.WithWhereQuery(v2.GtInt(v2.K("page"), 10)),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Logical AND Operator
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["first query", "second query"],
+    where={
+        "$and": [
+            {"page": {"$gte": 5 }},
+            {"page": {"$lte": 10 }},
+        ]
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with AND filter - page between 5 and 10
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("first query", "second query"),
+		v2.WithWhereQuery(
+			v2.And(
+				v2.GteInt(v2.K("page"), 5),
+				v2.LteInt(v2.K("page"), 10),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Logical OR Operator
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.get(
+    where={
+        "$or": [
+            {"color": "red"},
+            {"color": "blue"},
+        ]
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get with OR filter - color is red OR blue
+	results, err := collection.Get(ctx,
+		v2.WithWhereGet(
+			v2.Or(
+				v2.EqString(v2.K("color"), "red"),
+				v2.EqString(v2.K("color"), "blue"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Inclusion Operators ($in)
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.get(
+    where={
+       "author": {"$in": ["Rowling", "Fitzgerald", "Herbert"]}
+    }
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get with $in filter - author in list
+	results, err := collection.Get(ctx,
+		v2.WithWhereGet(
+			v2.InString(v2.K("author"), "Rowling", "Fitzgerald", "Herbert"),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Exclusion Operators ($nin)
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get with $nin filter - author NOT in list
+	results, err := collection.Get(ctx,
+		v2.WithWhereGet(
+			v2.NinString(v2.K("author"), "Unknown", "Anonymous"),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### ID Filtering
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Include only specific IDs
+collection.get(
+    where={"#id": {"$in": ["doc1", "doc2", "doc3"]}}
+)
+
+# Exclude specific IDs
+collection.get(
+    where={"#id": {"$nin": ["excluded1", "excluded2"]}}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Include only specific IDs using IDIn
+	results1, err := collection.Get(ctx,
+		v2.WithWhereGet(v2.IDIn("doc1", "doc2", "doc3")),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	// Exclude specific IDs using IDNotIn
+	results2, err := collection.Get(ctx,
+		v2.WithWhereGet(v2.IDNotIn("excluded1", "excluded2")),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	// Combine ID filter with metadata filter
+	results3, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithWhereQuery(
+			v2.And(
+				v2.IDNotIn("seen1", "seen2", "seen3"),
+				v2.EqString(v2.K("status"), "active"),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v, %v, %v", results1, results2, results3)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Document Content Filtering
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Filter documents containing specific text
+collection.get(
+    where={"#document": {"$contains": "machine learning"}}
+)
+
+# Filter documents NOT containing specific text
+collection.get(
+    where={"#document": {"$not_contains": "deprecated"}}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Filter documents containing specific text
+	results1, err := collection.Get(ctx,
+		v2.WithWhereGet(v2.DocumentContains("machine learning")),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	// Filter documents NOT containing specific text
+	results2, err := collection.Get(ctx,
+		v2.WithWhereGet(v2.DocumentNotContains("deprecated")),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	// Combine with other filters
+	results3, err := collection.Query(ctx,
+		v2.WithQueryTexts("AI research"),
+		v2.WithWhereQuery(
+			v2.And(
+				v2.DocumentContains("neural network"),
+				v2.EqString(v2.K("category"), "research"),
+				v2.GteInt(v2.K("year"), 2023),
+			),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v, %v, %v", results1, results2, results3)
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Combining Metadata and Document Filters
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["doc10", "thus spake zarathustra"],
+    n_results=10,
+    where={"metadata_field": "is_equal_to_this"},
+    where_document={"$contains":"search_string"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with both metadata and document filters
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("doc10", "thus spake zarathustra"),
+		v2.WithNResults(10),
+		v2.WithWhereQuery(v2.EqString(v2.K("metadata_field"), "is_equal_to_this")),
+		v2.WithWhereDocumentQuery(v2.ContainsString("search_string")),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Available Filter Functions
+
+| Python Operator | Go Function | Description |
+|----------------|-------------|-------------|
+| `{"field": value}` | `v2.EqString(v2.K("field"), value)` | Equal to (string) |
+| `{"field": value}` | `v2.EqInt(v2.K("field"), value)` | Equal to (integer) |
+| `{"field": value}` | `v2.EqFloat(v2.K("field"), value)` | Equal to (float) |
+| `{"$ne": value}` | `v2.NeString(v2.K("field"), value)` | Not equal to |
+| `{"$gt": value}` | `v2.GtInt(v2.K("field"), value)` | Greater than |
+| `{"$gte": value}` | `v2.GteInt(v2.K("field"), value)` | Greater than or equal |
+| `{"$lt": value}` | `v2.LtInt(v2.K("field"), value)` | Less than |
+| `{"$lte": value}` | `v2.LteInt(v2.K("field"), value)` | Less than or equal |
+| `{"$in": [...]}` | `v2.InString(v2.K("field"), ...)` | Value in list |
+| `{"$nin": [...]}` | `v2.NinString(v2.K("field"), ...)` | Value not in list |
+| `{"#id": {"$in": [...]}}` | `v2.IDIn(...)` | Include specific document IDs |
+| `{"#id": {"$nin": [...]}}` | `v2.IDNotIn(...)` | Exclude specific document IDs |
+| `{"#document": {"$contains": ...}}` | `v2.DocumentContains(...)` | Document contains text |
+| `{"#document": {"$not_contains": ...}}` | `v2.DocumentNotContains(...)` | Document doesn't contain text |
+| `{"$and": [...]}` | `v2.And(...)` | All conditions must match |
+| `{"$or": [...]}` | `v2.Or(...)` | Any condition must match |
+
+## Notes
+
+- Use `v2.K("field")` to clearly mark metadata field names in filter expressions
+- Filters can be applied to both `Query` and `Get` operations
+- Use appropriate type-specific functions (EqString, EqInt, EqFloat)
+- Logical operators can be nested for complex queries
+- `$in` and `$nin` work with strings, ints, floats, and bools
+- `IDIn` and `IDNotIn` are convenience functions for filtering by document IDs
+- `DocumentContains` and `DocumentNotContains` filter by document text content
+- All filter types can be combined with `And()` and `Or()`

--- a/docs/go-examples/docs/querying-collections/query-and-get.md
+++ b/docs/go-examples/docs/querying-collections/query-and-get.md
@@ -1,0 +1,661 @@
+# Query and Get - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/querying-collections/query-and-get)
+
+## Overview
+
+Query a Chroma collection to run similarity searches using `.Query`, or retrieve records directly using `.Get`.
+
+## Query Examples
+
+### Basic Query with Text
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_texts=["thus spake zarathustra", "the oracle speaks"]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with text - Chroma embeds the query for you
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("thus spake zarathustra", "the oracle speaks"),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	// Results are indexed by query
+	// results.GetIDsGroups()[0] contains IDs for first query
+	// results.GetIDsGroups()[1] contains IDs for second query
+	log.Printf("Query 1 IDs: %v", results.GetIDsGroups()[0])
+	log.Printf("Query 2 IDs: %v", results.GetIDsGroups()[1])
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Query with Embeddings
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_embeddings=[[11.1, 12.1, 13.1], [1.1, 2.3, 3.2]]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with pre-computed embeddings
+	results, err := collection.Query(ctx,
+		v2.WithQueryEmbeddings(
+			[]float32{11.1, 12.1, 13.1},
+			[]float32{1.1, 2.3, 3.2},
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetIDsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Query with N Results
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_embeddings=[[11.1, 12.1, 13.1], [1.1, 2.3, 3.2]],
+    n_results=5
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with custom number of results (default is 10)
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Got %d results", len(results.GetIDsGroups()[0]))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Query with ID Constraint
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_embeddings=[[11.1, 12.1, 13.1], [1.1, 2.3, 3.2]],
+    n_results=5,
+    ids=["id1", "id2"]
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query constrained to specific IDs
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithNResults(5),
+		v2.WithIDsQuery("id1", "id2"),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Results: %v", results.GetIDsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Query with Metadata and Document Filters
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(
+    query_embeddings=[[11.1, 12.1, 13.1], [1.1, 2.3, 3.2]],
+    n_results=5,
+    where={"page": 10},
+    where_document={"$contains": "search string"}
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with metadata filter and document filter
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithNResults(5),
+		v2.WithWhereQuery(v2.EqInt("page", 10)),
+		v2.WithWhereDocumentQuery(v2.ContainsString("search string")),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	log.Printf("Filtered results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Get Examples
+
+### Get by IDs
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.get(ids=["id1", "id2"])
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get records by IDs
+	results, err := collection.Get(ctx,
+		v2.WithIDsGet("id1", "id2"),
+	)
+	if err != nil {
+		log.Fatalf("Error getting documents: %v", err)
+	}
+
+	log.Printf("IDs: %v", results.GetIDs())
+	log.Printf("Documents: %v", results.GetDocuments())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Get with Pagination
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Get with limit and offset for pagination
+	results, err := collection.Get(ctx,
+		v2.WithLimitGet(50),
+		v2.WithOffsetGet(100),
+	)
+	if err != nil {
+		log.Fatalf("Error getting documents: %v", err)
+	}
+
+	log.Printf("Got %d documents", len(results.GetIDs()))
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Choosing What Data is Returned
+
+### Include Specific Fields
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+collection.query(query_texts=["my query"]) # 'ids', 'documents', and 'metadatas' are returned
+
+collection.get(include=["documents"]) # Only 'ids' and 'documents' are returned
+
+collection.query(
+    query_texts=["my query"],
+    include=["documents", "metadatas", "embeddings"]
+) # 'ids', 'documents', 'metadatas', and 'embeddings' are returned
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Default query - returns ids, documents, metadatas
+	results1, err := collection.Query(ctx,
+		v2.WithQueryTexts("my query"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Get with only documents
+	results2, err := collection.Get(ctx,
+		v2.WithIncludeGet(v2.IncludeDocuments),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Query with specific includes
+	results3, err := collection.Query(ctx,
+		v2.WithQueryTexts("my query"),
+		v2.WithIncludeQuery(v2.IncludeDocuments, v2.IncludeMetadatas, v2.IncludeEmbeddings),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Query 1 docs: %v", results1.GetDocumentsGroups())
+	log.Printf("Get docs: %v", results2.GetDocuments())
+	log.Printf("Query 3 embeddings: %v", results3.GetEmbeddingsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Include Distances
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query with distances included
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithNResults(5),
+		v2.WithIncludeQuery(v2.IncludeDocuments, v2.IncludeDistances),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Access distances
+	distances := results.GetDistances()
+	for i, dist := range distances[0] {
+		log.Printf("Result %d: distance=%f", i, dist)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Results Structure
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+class QueryResult(TypedDict):
+    ids: List[IDs]
+    embeddings: Optional[List[Embeddings]],
+    documents: Optional[List[List[Document]]]
+    metadatas: Optional[List[List[Metadata]]]
+    distances: Optional[List[List[float]]]
+    included: Include
+
+class GetResult(TypedDict):
+    ids: List[ID]
+    embeddings: Optional[Embeddings],
+    documents: Optional[List[Document]],
+    metadatas: Optional[List[Metadata]]
+    included: Include
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+// QueryResult methods (raw access):
+results.GetIDsGroups()         // [][]string - IDs grouped by query
+results.GetDocumentsGroups()   // [][]string - Documents grouped by query
+results.GetMetadatasGroups()   // [][]map[string]interface{} - Metadata grouped by query
+results.GetEmbeddingsGroups()  // [][][]float32 - Embeddings grouped by query
+results.GetDistancesGroups()   // [][]float32 - Distances grouped by query
+
+// GetResult methods (raw access):
+results.GetIDs()        // []string - List of IDs
+results.GetDocuments()  // []string - List of documents
+results.GetMetadatas()  // []map[string]interface{} - List of metadata
+results.GetEmbeddings() // [][]float32 - List of embeddings
+
+// Ergonomic iteration with Rows():
+// Query results are indexed by input query:
+// results.GetIDsGroups()[0] - Results for first query
+// results.GetIDsGroups()[1] - Results for second query
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Ergonomic Result Iteration
+
+Use `Rows()` for clean iteration without manual index tracking:
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Python uses direct iteration over results
+results = collection.query(query_texts=["search query"])
+for i, doc_id in enumerate(results['ids'][0]):
+    print(f"ID: {doc_id}")
+    print(f"Document: {results['documents'][0][i]}")
+    print(f"Distance: {results['distances'][0][i]}")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	collection, err := client.GetCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error getting collection: %v", err)
+	}
+
+	// Query results - use Rows() for first query group
+	queryResults, err := collection.Query(ctx,
+		v2.WithQueryTexts("search query"),
+		v2.WithNResults(10),
+		v2.WithIncludeQuery(v2.IncludeDocuments, v2.IncludeDistances),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	// Iterate using Rows() - no manual index tracking needed
+	fmt.Println("Query Results:")
+	for i, row := range queryResults.Rows() {
+		fmt.Printf("%d. ID: %s\n", i+1, row.ID)
+		fmt.Printf("   Document: %s\n", row.Document)
+		fmt.Printf("   Distance: %.4f\n\n", row.Score) // Score contains distance for Query
+	}
+
+	// For multiple queries, use RowGroups()
+	multiQueryResults, err := collection.Query(ctx,
+		v2.WithQueryTexts("first query", "second query"),
+		v2.WithNResults(5),
+	)
+	if err != nil {
+		log.Fatalf("Error querying: %v", err)
+	}
+
+	for queryIdx, rows := range multiQueryResults.RowGroups() {
+		fmt.Printf("Query %d results:\n", queryIdx+1)
+		for _, row := range rows {
+			fmt.Printf("  - %s\n", row.ID)
+		}
+	}
+
+	// Get results - use Rows() for flat iteration
+	getResults, err := collection.Get(ctx,
+		v2.WithIDsGet("id1", "id2", "id3"),
+		v2.WithIncludeGet(v2.IncludeDocuments, v2.IncludeMetadatas),
+	)
+	if err != nil {
+		log.Fatalf("Error getting: %v", err)
+	}
+
+	fmt.Println("\nGet Results:")
+	for i, row := range getResults.Rows() {
+		fmt.Printf("%d. ID: %s\n", i+1, row.ID)
+		fmt.Printf("   Document: %s\n", row.Document)
+		if row.Metadata != nil {
+			fmt.Printf("   Metadata: %v\n", row.Metadata)
+		}
+	}
+
+	// Safe indexed access with At()
+	if row, ok := queryResults.At(0, 0); ok {
+		fmt.Printf("\nFirst result: %s\n", row.ID)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## ResultRow Structure
+
+The `ResultRow` struct provides unified access to all result fields:
+
+```go
+type ResultRow struct {
+    ID        DocumentID       // Document ID
+    Document  string           // Document text (if included)
+    Metadata  DocumentMetadata // Metadata map (if included)
+    Embedding []float32        // Embedding vector (if included)
+    Score     float64          // Query: distance, Search: relevance score, Get: 0
+}
+```
+
+## Notes
+
+- Default `n_results` is 10
+- IDs are always returned
+- Query results are grouped by input query
+- Get results are flat lists
+- Use `Rows()` for easy iteration over results (first query group for Query)
+- Use `RowGroups()` to iterate over all query groups
+- Use `At(group, index)` for safe indexed access with bounds checking
+- Use include options to control which fields are returned
+- Distances are only available in query results (not get)
+- The `Score` field contains distance for Query results, relevance score for Search results

--- a/docs/go-examples/docs/run-chroma/client-server.md
+++ b/docs/go-examples/docs/run-chroma/client-server.md
@@ -1,0 +1,241 @@
+# Client-Server Mode - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/run-chroma/client-server)
+
+## Overview
+
+Chroma can run in client/server mode where the Chroma client connects to a Chroma server running in a separate process. This document shows how to connect to a Chroma server using the Go client.
+
+## Starting the Server
+
+Start the Chroma server:
+
+```terminal
+chroma run --path /db_path
+```
+
+Or using Docker:
+
+```terminal
+docker pull chromadb/chroma
+docker run -p 8000:8000 chromadb/chroma
+```
+
+## Go Examples
+
+### Basic HTTP Client
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+chroma_client = chromadb.HttpClient(host='localhost', port=8000)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create HTTP client connecting to default localhost:8000
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	// Client is now connected and ready to use
+	log.Println("Connected to Chroma server")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### HTTP Client with Custom Host and Port
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+chroma_client = chromadb.HttpClient(host='my-chroma-server.com', port=8080)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create HTTP client with custom base URL
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://my-chroma-server.com:8080"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	log.Println("Connected to custom Chroma server")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Async Client Example
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import asyncio
+import chromadb
+
+async def main():
+    client = await chromadb.AsyncHttpClient()
+
+    collection = await client.create_collection(name="my_collection")
+    await collection.add(
+        documents=["hello world"],
+        ids=["id1"]
+    )
+
+asyncio.run(main())
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Go uses goroutines for concurrency instead of async/await
+	// The chroma-go client is synchronous but can be used with goroutines
+
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create collection
+	collection, err := client.CreateCollection(ctx, "my_collection")
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	// Add documents
+	err = collection.Add(ctx,
+		v2.WithIDs("id1"),
+		v2.WithTexts("hello world"),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	log.Println("Successfully added documents")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+> **Note**: Go does not have async/await syntax like Python. Instead, Go uses goroutines and channels for concurrency. The chroma-go client methods are synchronous, but you can run them in goroutines if needed for concurrent operations.
+
+### Client with SSL/TLS
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+# Python HttpClient with SSL
+chroma_client = chromadb.HttpClient(
+    host='my-chroma-server.com',
+    port=443,
+    ssl=True
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Use HTTPS URL for SSL/TLS connections
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("https://my-chroma-server.com:443"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	log.Println("Connected via HTTPS")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Client with Custom Timeout
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+	"time"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create client with custom timeout
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+		v2.WithTimeout(60*time.Second),
+	)
+	if err != nil {
+		log.Fatalf("Error creating client: %v", err)
+	}
+	defer client.Close()
+
+	log.Println("Client created with 60 second timeout")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- Always call `defer client.Close()` to properly release resources, especially embedding functions
+- The default URL is `http://localhost:8000/api/v2`
+- Environment variables `CHROMA_TENANT` and `CHROMA_DATABASE` are automatically applied if set
+- Use `v2.WithBaseURL()` to configure custom server addresses
+- Use `v2.WithTimeout()` to set custom request timeouts

--- a/docs/go-examples/docs/run-chroma/cloud-client.md
+++ b/docs/go-examples/docs/run-chroma/cloud-client.md
@@ -1,0 +1,164 @@
+# Cloud Client - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/run-chroma/cloud-client)
+
+## Overview
+
+The Cloud Client connects to Chroma Cloud, a fast, scalable, and serverless database-as-a-service.
+
+## Go Examples
+
+### Basic Cloud Client
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+client = CloudClient(
+    tenant='Tenant ID',
+    database='Database name',
+    api_key='Chroma Cloud API key'
+)
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create Cloud client with explicit credentials
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey("your-api-key"),
+		v2.WithDatabaseAndTenant("database-name", "tenant-id"),
+	)
+	if err != nil {
+		log.Fatalf("Error creating cloud client: %v", err)
+	}
+	defer client.Close()
+
+	log.Println("Connected to Chroma Cloud")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Cloud Client with Environment Variables
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+# Set environment variables:
+# CHROMA_API_KEY, CHROMA_TENANT, CHROMA_DATABASE
+
+client = CloudClient()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Environment variables used:
+	// CHROMA_CLOUD_API_KEY - Cloud API key
+	// CHROMA_CLOUD_TENANT - Cloud tenant ID
+	// CHROMA_CLOUD_DATABASE - Cloud database name
+
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey(os.Getenv("CHROMA_CLOUD_API_KEY")),
+		v2.WithDatabaseAndTenant(
+			os.Getenv("CHROMA_CLOUD_DATABASE"),
+			os.Getenv("CHROMA_CLOUD_TENANT"),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error creating cloud client: %v", err)
+	}
+	defer client.Close()
+
+	log.Println("Connected to Chroma Cloud using environment variables")
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Complete Cloud Client Example
+
+{% codetabs group="lang" %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Create Cloud client
+	client, err := v2.NewCloudClient(
+		v2.WithCloudAPIKey(os.Getenv("CHROMA_CLOUD_API_KEY")),
+		v2.WithDatabaseAndTenant(
+			os.Getenv("CHROMA_CLOUD_DATABASE"),
+			os.Getenv("CHROMA_CLOUD_TENANT"),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error creating cloud client: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create or get a collection
+	collection, err := client.GetOrCreateCollection(ctx, "my_cloud_collection")
+	if err != nil {
+		log.Fatalf("Error creating collection: %v", err)
+	}
+
+	// Add documents
+	err = collection.Add(ctx,
+		v2.WithIDs("doc1", "doc2"),
+		v2.WithTexts(
+			"This is a document about machine learning",
+			"This is a document about data science",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error adding documents: %v", err)
+	}
+
+	// Query the collection
+	results, err := collection.Query(ctx,
+		v2.WithQueryTexts("AI and ML"),
+		v2.WithNResults(2),
+	)
+	if err != nil {
+		log.Fatalf("Error querying collection: %v", err)
+	}
+
+	log.Printf("Query results: %v", results.GetDocumentsGroups())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+## Notes
+
+- The Go client uses `CHROMA_CLOUD_API_KEY`, `CHROMA_CLOUD_TENANT`, and `CHROMA_CLOUD_DATABASE` environment variable names
+- Always call `defer client.Close()` to properly release resources
+- Cloud client automatically configures the correct API endpoint for Chroma Cloud

--- a/docs/go-examples/docs/run-chroma/ephemeral-client.md
+++ b/docs/go-examples/docs/run-chroma/ephemeral-client.md
@@ -1,0 +1,194 @@
+# Ephemeral Client - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/run-chroma/ephemeral-client)
+
+## Overview
+
+In Python, you can run a Chroma server in-memory with the ephemeral client. This is useful for experimenting and testing without data persistence.
+
+> **Note**: Go does not have an equivalent ephemeral client. The chroma-go library is an HTTP-only client that connects to a Chroma server. For testing and experimentation in Go, you can use testcontainers to run a temporary Chroma server.
+
+## Go Examples
+
+### Python Ephemeral Client
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+# Python can run Chroma in-memory
+client = chromadb.EphemeralClient()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Go always connects to an external Chroma server
+	// No in-memory mode available - use testcontainers for testing
+
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Create a collection for experimentation
+	collection, err := client.CreateCollection(ctx, "test_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Collection created: %s", collection.Name())
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Using Testcontainers for Testing
+
+For Go tests that need an ephemeral-like experience, use testcontainers:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func TestWithEphemeralChroma(t *testing.T) {
+	ctx := context.Background()
+
+	// Start a Chroma container
+	req := testcontainers.ContainerRequest{
+		Image:        "chromadb/chroma:latest",
+		ExposedPorts: []string{"8000/tcp"},
+		WaitingFor:   wait.ForHTTP("/api/v2/heartbeat").WithPort("8000"),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to start container: %v", err)
+	}
+	defer container.Terminate(ctx)
+
+	// Get the container's host and port
+	host, _ := container.Host(ctx)
+	port, _ := container.MappedPort(ctx, "8000")
+
+	// Connect to the ephemeral Chroma instance
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL(fmt.Sprintf("http://%s:%d", host, port.Int())),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	// Run your tests...
+	collection, err := client.CreateCollection(ctx, "test_collection")
+	if err != nil {
+		t.Fatalf("Failed to create collection: %v", err)
+	}
+
+	// Data is ephemeral - container and data are destroyed after test
+	t.Logf("Created ephemeral collection: %s", collection.Name())
+}
+```
+
+### Running a Local Server for Development
+
+For development, start a Chroma server locally:
+
+```bash
+# Option 1: Using Docker
+docker run -p 8000:8000 chromadb/chroma
+
+# Option 2: Using the Chroma CLI (requires Python)
+pip install chromadb
+chroma run --path /tmp/chroma-data
+
+# Option 3: Using Docker Compose
+# docker-compose.yml:
+# version: '3'
+# services:
+#   chroma:
+#     image: chromadb/chroma:latest
+#     ports:
+#       - "8000:8000"
+
+docker-compose up
+```
+
+Then connect from Go:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect to local development server
+	client, err := v2.NewHTTPClient() // Defaults to localhost:8000
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Check connection
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Server not responding: %v", err)
+	}
+
+	log.Printf("Connected to Chroma server. Heartbeat: %d", heartbeat)
+
+	// Create and use collections
+	collection, err := client.GetOrCreateCollection(ctx, "dev_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Using collection: %s", collection.Name())
+}
+```
+
+## Notes
+
+- Go is an HTTP-only client - no in-process Chroma support
+- Use testcontainers for isolated testing environments
+- Use Docker for local development servers
+- For Cloud development, use `v2.NewCloudClient()`
+- Data in Docker containers without volume mounts is ephemeral by design
+

--- a/docs/go-examples/docs/run-chroma/persistent-client.md
+++ b/docs/go-examples/docs/run-chroma/persistent-client.md
@@ -1,0 +1,259 @@
+# Persistent Client - Go Examples
+
+> **Reference**: [Original Documentation](https://docs.trychroma.com/docs/run-chroma/persistent-client)
+
+## Overview
+
+In Python, you can use `PersistentClient` to save and load data from your local machine. In Go, you always connect to a Chroma server via HTTP, so persistence is handled by the server's configuration.
+
+## Go Examples
+
+### Python vs Go Client
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+import chromadb
+
+# Python can run Chroma embedded with persistence
+client = chromadb.PersistentClient(path="/path/to/save/to")
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Go connects to a Chroma server - persistence is server-side
+	// Start server with: chroma run --path /path/to/save/to
+
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	// Data persists on the server based on server configuration
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Running a Persistent Chroma Server
+
+Start a Chroma server with persistence enabled:
+
+```bash
+# Using the Chroma CLI
+chroma run --path /path/to/save/to
+
+# Using Docker with a volume mount for persistence
+docker run -p 8000:8000 -v /path/to/save/to:/data chromadb/chroma
+```
+
+Then connect from Go:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Connect to persistent Chroma server
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Data will persist on the server between restarts
+	collection, err := client.GetOrCreateCollection(ctx, "persistent_collection")
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	// Add data
+	err = collection.Add(ctx,
+		v2.WithIDs("doc1", "doc2"),
+		v2.WithDocuments(
+			"First document content",
+			"Second document content",
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Data added to collection: %s", collection.Name())
+	log.Println("Data will persist on server restart")
+}
+```
+
+### Utility Methods
+
+{% codetabs group="lang" %}
+{% codetab label="Python" %}
+```python
+client.heartbeat()
+client.reset()
+```
+{% /codetab %}
+{% codetab label="Go" %}
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient()
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Heartbeat - check if server is running
+	heartbeat, err := client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Server not responding: %v", err)
+	}
+	log.Printf("Server heartbeat: %d nanoseconds", heartbeat)
+
+	// Reset - empties and resets the database
+	// Warning: This is destructive and not reversible!
+	// Server must have allow_reset=true in config
+	err = client.Reset(ctx)
+	if err != nil {
+		log.Printf("Reset failed (may be disabled): %v", err)
+	}
+}
+```
+{% /codetab %}
+{% /codetabs %}
+
+### Docker Compose Example
+
+Create a `docker-compose.yml` for persistent Chroma:
+
+```yaml
+version: '3'
+services:
+  chroma:
+    image: chromadb/chroma:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./chroma-data:/data
+    environment:
+      - CHROMA_HOST=0.0.0.0
+```
+
+Connect from Go:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL("http://localhost:8000"),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Check connection
+	_, err = client.Heartbeat(ctx)
+	if err != nil {
+		log.Fatalf("Cannot connect to Chroma: %v", err)
+	}
+
+	// List existing collections (will persist across restarts)
+	collections, err := client.ListCollections(ctx)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
+	log.Printf("Found %d persistent collections", len(collections))
+	for _, col := range collections {
+		count, _ := col.Count(ctx)
+		log.Printf("  - %s: %d documents", col.Name(), count)
+	}
+}
+```
+
+### Environment Variables
+
+Configure the Go client using environment variables:
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+func main() {
+	// Set CHROMA_URL environment variable
+	// export CHROMA_URL=http://chroma-server:8000
+
+	chromaURL := os.Getenv("CHROMA_URL")
+	if chromaURL == "" {
+		chromaURL = "http://localhost:8000"
+	}
+
+	client, err := v2.NewHTTPClient(
+		v2.WithBaseURL(chromaURL),
+	)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+	defer client.Close()
+
+	log.Printf("Connected to: %s", chromaURL)
+}
+```
+
+## Notes
+
+- Go is HTTP-only - persistence is configured on the server side
+- Use Docker volumes to persist data when running Chroma in containers
+- The `reset()` method requires `allow_reset=true` in server configuration
+- For production, always mount a persistent volume to `/data` in the Docker container
+- Consider using Chroma Cloud for managed persistence
+


### PR DESCRIPTION
## Summary
- Add comprehensive Go code examples documentation in `docs/go-examples/`
- Covers getting started, collections, querying, embedding functions, and Cloud Search API
- Provides side-by-side Python and Go comparisons referencing official Chroma docs

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Check example code snippets compile