### PR TITLE
refactor(v2): replace deprecated WithDebug with slog-based WithLogger in tests

### DIFF
--- a/pkg/api/v2/client_cloud_test.go
+++ b/pkg/api/v2/client_cloud_test.go
@@ -29,7 +29,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		require.NoError(t, err)
 	}
 	client, err := NewCloudClient(
-		WithDebug(),
+		WithLogger(testLogger()),
 		WithDatabaseAndTenant(os.Getenv("CHROMA_DATABASE"), os.Getenv("CHROMA_TENANT")),
 		WithCloudAPIKey(os.Getenv("CHROMA_API_KEY")),
 	)
@@ -1215,7 +1215,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 	t.Run("Without API Key", func(t *testing.T) {
 		t.Setenv("CHROMA_API_KEY", "")
 		client, err := NewCloudClient(
-			WithDebug(),
+			WithLogger(testLogger()),
 			WithDatabaseAndTenant("test_database", "test_tenant"),
 		)
 		require.Error(t, err)
@@ -1227,7 +1227,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "")
 		t.Setenv("CHROMA_DATABASE", "")
 		client, err := NewCloudClient(
-			WithDebug(),
+			WithLogger(testLogger()),
 			WithCloudAPIKey("test"),
 		)
 		require.Error(t, err)
@@ -1238,7 +1238,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "test_tenant")
 		t.Setenv("CHROMA_DATABASE", "test_database")
 		client, err := NewCloudClient(
-			WithDebug(),
+			WithLogger(testLogger()),
 			WithCloudAPIKey("test"),
 		)
 		require.NoError(t, err)
@@ -1252,7 +1252,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_DATABASE", "test_database")
 		t.Setenv("CHROMA_API_KEY", "test")
 		client, err := NewCloudClient(
-			WithDebug(),
+			WithLogger(testLogger()),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, client)
@@ -1270,7 +1270,7 @@ func TestCloudClientHTTPIntegration(t *testing.T) {
 		t.Setenv("CHROMA_DATABASE", "test_database")
 		t.Setenv("CHROMA_API_KEY", "test")
 		client, err := NewCloudClient(
-			WithDebug(),
+			WithLogger(testLogger()),
 			WithCloudAPIKey("different_test_key"),
 			WithDatabaseAndTenant("other_db", "other_tenant"),
 		)

--- a/pkg/api/v2/client_http_integration_test.go
+++ b/pkg/api/v2/client_http_integration_test.go
@@ -116,7 +116,7 @@ func TestClientHTTPIntegration(t *testing.T) {
 	if chromaURL == "" {
 		chromaURL = endpoint
 	}
-	c, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug())
+	c, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()))
 	require.NoError(t, err)
 
 	// For Chroma versions < 1.0.0, disable EF config storage as they don't support it
@@ -644,7 +644,7 @@ func TestClientHTTPIntegrationWithBasicAuth(t *testing.T) {
 		chromaURL = endpoint
 	}
 	t.Run("success auth", func(t *testing.T) {
-		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewBasicAuthCredentialsProvider("admin", "password123")))
+		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewBasicAuthCredentialsProvider("admin", "password123")))
 		require.NoError(t, err)
 		require.NotNil(t, c)
 		collections, err := c.ListCollections(ctx)
@@ -652,7 +652,7 @@ func TestClientHTTPIntegrationWithBasicAuth(t *testing.T) {
 		require.Equal(t, 0, len(collections))
 	})
 	t.Run("wrong auth", func(t *testing.T) {
-		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewBasicAuthCredentialsProvider("admin", "wrong_password")))
+		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewBasicAuthCredentialsProvider("admin", "wrong_password")))
 		require.NoError(t, err)
 		_, err = wrongAuthClient.ListCollections(ctx)
 		require.Error(t, err)
@@ -709,7 +709,7 @@ func TestClientHTTPIntegrationWithBearerAuthorizationHeaderAuth(t *testing.T) {
 		chromaURL = endpoint
 	}
 	t.Run("success auth", func(t *testing.T) {
-		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewTokenAuthCredentialsProvider(token, AuthorizationTokenHeader)))
+		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewTokenAuthCredentialsProvider(token, AuthorizationTokenHeader)))
 		require.NoError(t, err)
 		require.NotNil(t, c)
 		collections, err := c.ListCollections(ctx)
@@ -717,7 +717,7 @@ func TestClientHTTPIntegrationWithBearerAuthorizationHeaderAuth(t *testing.T) {
 		require.Equal(t, 0, len(collections))
 	})
 	t.Run("wrong auth", func(t *testing.T) {
-		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewTokenAuthCredentialsProvider("wrong_token", AuthorizationTokenHeader)))
+		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewTokenAuthCredentialsProvider("wrong_token", AuthorizationTokenHeader)))
 		require.NoError(t, err)
 		_, err = wrongAuthClient.ListCollections(ctx)
 		require.Error(t, err)
@@ -789,7 +789,7 @@ func TestClientHTTPIntegrationWithBearerXChromaTokenHeaderAuth(t *testing.T) {
 		chromaURL = endpoint
 	}
 	t.Run("success auth", func(t *testing.T) {
-		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewTokenAuthCredentialsProvider(token, XChromaTokenHeader)))
+		c, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewTokenAuthCredentialsProvider(token, XChromaTokenHeader)))
 		require.NoError(t, err)
 		require.NotNil(t, c)
 		collections, err := c.ListCollections(ctx)
@@ -797,7 +797,7 @@ func TestClientHTTPIntegrationWithBearerXChromaTokenHeaderAuth(t *testing.T) {
 		require.Equal(t, 0, len(collections))
 	})
 	t.Run("wrong auth", func(t *testing.T) {
-		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug(), WithAuth(NewTokenAuthCredentialsProvider("wrong_token", XChromaTokenHeader)))
+		wrongAuthClient, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()), WithAuth(NewTokenAuthCredentialsProvider("wrong_token", XChromaTokenHeader)))
 		require.NoError(t, err)
 		_, err = wrongAuthClient.ListCollections(ctx)
 		require.Error(t, err)
@@ -887,7 +887,7 @@ func TestClientHTTPIntegrationWithSSL(t *testing.T) {
 	chromaURL = strings.ReplaceAll(endpoint, "http://", "https://")
 	time.Sleep(5 * time.Second)
 	t.Run("Test with insecure client", func(t *testing.T) {
-		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithInsecure(), WithDebug())
+		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithInsecure(), WithLogger(testLogger()))
 		require.NoError(t, err)
 		version, err := client.GetVersion(ctx)
 		require.NoError(t, err)
@@ -895,7 +895,7 @@ func TestClientHTTPIntegrationWithSSL(t *testing.T) {
 	})
 
 	t.Run("Test without SSL", func(t *testing.T) {
-		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug())
+		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()))
 		require.NoError(t, err)
 		_, err = client.GetVersion(ctx)
 		require.Error(t, err)
@@ -903,7 +903,7 @@ func TestClientHTTPIntegrationWithSSL(t *testing.T) {
 	})
 
 	t.Run("Test with SSL", func(t *testing.T) {
-		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithSSLCert(certPath), WithDebug())
+		client, err := NewHTTPClient(WithBaseURL(chromaURL), WithSSLCert(certPath), WithLogger(testLogger()))
 		require.NoError(t, err)
 		version, err := client.GetVersion(ctx)
 		require.NoError(t, err)

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -672,7 +672,7 @@ func TestCreateCollection(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			tt.sendRequest(client)
 			err = client.Close()
@@ -695,7 +695,7 @@ func TestClientClose(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 	require.NoError(t, err)
 	err = client.Close()
 	require.NoError(t, err)
@@ -704,7 +704,7 @@ func TestClientClose(t *testing.T) {
 
 func TestClientSetup(t *testing.T) {
 	t.Run("With default tenant and database", func(t *testing.T) {
-		client, err := NewHTTPClient(WithBaseURL("http://localhost:8080"), WithDebug())
+		client, err := NewHTTPClient(WithBaseURL("http://localhost:8080"), WithLogger(testLogger()))
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		require.Equal(t, NewDefaultTenant(), client.CurrentTenant())
@@ -714,7 +714,7 @@ func TestClientSetup(t *testing.T) {
 	t.Run("With env tenant and database", func(t *testing.T) {
 		t.Setenv("CHROMA_TENANT", "test_tenant")
 		t.Setenv("CHROMA_DATABASE", "test_db")
-		client, err := NewHTTPClient(WithBaseURL("http://localhost:8080"), WithDebug())
+		client, err := NewHTTPClient(WithBaseURL("http://localhost:8080"), WithLogger(testLogger()))
 		require.NoError(t, err)
 		require.NotNil(t, client)
 		require.Equal(t, NewTenant("test_tenant"), client.CurrentTenant())

--- a/pkg/api/v2/collection_http_integration_test.go
+++ b/pkg/api/v2/collection_http_integration_test.go
@@ -81,7 +81,7 @@ func TestCollectionAddIntegration(t *testing.T) {
 	if chromaURL == "" {
 		chromaURL = endpoint
 	}
-	c, err := NewHTTPClient(WithBaseURL(chromaURL), WithDebug())
+	c, err := NewHTTPClient(WithBaseURL(chromaURL), WithLogger(testLogger()))
 	require.NoError(t, err)
 
 	// For Chroma versions < 1.0.0, disable EF config storage as they don't support it

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -124,7 +124,7 @@ func TestCollectionAdd(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			collection := &CollectionImpl{
 				name:              "test",
@@ -241,7 +241,7 @@ func TestCollectionUpdate(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			collection := &CollectionImpl{
 				name:              "test",
@@ -358,7 +358,7 @@ func TestCollectionUpsert(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			collection := &CollectionImpl{
 				name:              "test",
@@ -461,7 +461,7 @@ func TestCollectionDelete(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			collection := &CollectionImpl{
 				name:              "test",
@@ -499,7 +499,7 @@ func TestCollectionCount(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 	require.NoError(t, err)
 	collection := &CollectionImpl{
 		name:              "test",
@@ -600,7 +600,7 @@ func TestCollectionQuery(t *testing.T) {
 		}
 	}))
 
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 	require.NoError(t, err)
 
 	collection := &CollectionImpl{
@@ -640,7 +640,7 @@ func TestCollectionModifyName(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 	require.NoError(t, err)
 	collection := &CollectionImpl{
 		name:              "test",
@@ -678,7 +678,7 @@ func TestCollectionModifyMetadata(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 	require.NoError(t, err)
 	collection := &CollectionImpl{
 		name:              "test",
@@ -839,7 +839,7 @@ func TestCollectionGet(t *testing.T) {
 				}
 			}))
 			defer server.Close()
-			client, err := NewHTTPClient(WithBaseURL(server.URL), WithDebug())
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
 			require.NoError(t, err)
 			collection := &CollectionImpl{
 				name:              "test",

--- a/pkg/api/v2/test_helpers_test.go
+++ b/pkg/api/v2/test_helpers_test.go
@@ -1,0 +1,18 @@
+//go:build basicv2 || cloud
+
+package v2
+
+import (
+	"github.com/amikos-tech/chroma-go/pkg/logger"
+)
+
+// testLogger returns a text-based slog logger for use in tests.
+// It outputs debug-level logs to stdout in a human-readable format.
+func testLogger() logger.Logger {
+	l, err := logger.NewTextSlogLogger()
+	if err != nil {
+		// This should never happen as NewTextSlogLogger only creates handlers
+		panic("failed to create test logger: " + err.Error())
+	}
+	return l
+}


### PR DESCRIPTION
## Summary

- Add `testLogger()` helper function that creates an slog text logger with debug level
- Replace `WithDebug()` with `WithLogger(testLogger())` in 30 test locations across 5 files
- Preserve two backward-compatibility tests in `client_logger_test.go` that specifically test `WithDebug()` behavior

## Test plan

- [x] Run linter: `make lint` passes
- [x] Run logger tests: `go test -tags=basicv2 -run TestClientWithLogger ./pkg/api/v2/...`
- [x] Run sanitization tests: `go test -tags=basicv2 -run "Test.*Obfuscation|Test.*Sanitization" ./pkg/api/v2/...`
- [x] Verify API key sanitization works correctly with slog output

Fixes #362