### PR TITLE
fix(http): add response body size limits to embedding/reranking providers

### DIFF
--- a/pkg/commons/http/errors.go
+++ b/pkg/commons/http/errors.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -36,7 +35,7 @@ func ChromaErrorFromHTTPResponse(resp *http.Response, err error) *ChromaError {
 	chromaAPIError.ErrorCode = resp.StatusCode
 
 	// Read body into buffer first to allow fallback if JSON decode fails
-	bodyBytes, readErr := io.ReadAll(resp.Body)
+	bodyBytes, readErr := ReadLimitedBody(resp.Body)
 	if readErr != nil {
 		return chromaAPIError
 	}

--- a/pkg/commons/http/utils.go
+++ b/pkg/commons/http/utils.go
@@ -1,6 +1,26 @@
 package http
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
+
+// MaxResponseBodySize is the maximum allowed response body size (200 MB).
+const MaxResponseBodySize = 200 * 1024 * 1024
+
+// ReadLimitedBody reads up to MaxResponseBodySize bytes from r.
+// Returns an error if the response exceeds the limit.
+func ReadLimitedBody(r io.Reader) ([]byte, error) {
+	limitedReader := io.LimitReader(r, int64(MaxResponseBodySize)+1)
+	data, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > MaxResponseBodySize {
+		return nil, fmt.Errorf("response body exceeds maximum size of %d bytes", MaxResponseBodySize)
+	}
+	return data, nil
+}
 
 func ReadRespBody(resp io.Reader) string {
 	if resp == nil {

--- a/pkg/commons/http/utils_test.go
+++ b/pkg/commons/http/utils_test.go
@@ -1,0 +1,39 @@
+package http
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadLimitedBody(t *testing.T) {
+	t.Run("under limit", func(t *testing.T) {
+		input := []byte("hello world")
+		data, err := ReadLimitedBody(bytes.NewReader(input))
+		require.NoError(t, err)
+		assert.Equal(t, input, data)
+	})
+
+	t.Run("empty reader", func(t *testing.T) {
+		data, err := ReadLimitedBody(bytes.NewReader(nil))
+		require.NoError(t, err)
+		assert.Empty(t, data)
+	})
+
+	t.Run("exactly at limit", func(t *testing.T) {
+		input := strings.Repeat("a", MaxResponseBodySize)
+		data, err := ReadLimitedBody(strings.NewReader(input))
+		require.NoError(t, err)
+		assert.Len(t, data, MaxResponseBodySize)
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		input := strings.Repeat("a", MaxResponseBodySize+1)
+		_, err := ReadLimitedBody(strings.NewReader(input))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "response body exceeds maximum size")
+	})
+}

--- a/pkg/embeddings/baseten/baseten.go
+++ b/pkg/embeddings/baseten/baseten.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -152,7 +151,7 @@ func (c *BasetenClient) CreateEmbedding(ctx context.Context, req *CreateEmbeddin
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/chromacloud/chromacloud.go
+++ b/pkg/embeddings/chromacloud/chromacloud.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -149,7 +148,7 @@ func (c *Client) embed(ctx context.Context, texts []string, forQuery bool) ([][]
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response")
 	}

--- a/pkg/embeddings/chromacloudsplade/chromacloudsplade.go
+++ b/pkg/embeddings/chromacloudsplade/chromacloudsplade.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -120,7 +119,7 @@ func (c *Client) embed(ctx context.Context, texts []string) ([]*embeddings.Spars
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response")
 	}

--- a/pkg/embeddings/cloudflare/cloudflare.go
+++ b/pkg/embeddings/cloudflare/cloudflare.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -145,7 +144,7 @@ func (c *CloudflareClient) CreateEmbedding(ctx context.Context, req *CreateEmbed
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/cohere/cohere.go
+++ b/pkg/embeddings/cohere/cohere.go
@@ -3,7 +3,6 @@ package cohere
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 
@@ -169,7 +168,7 @@ func (c *CohereEmbeddingFunction) CreateEmbedding(ctx context.Context, req *Crea
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/hf/hf.go
+++ b/pkg/embeddings/hf/hf.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -118,7 +117,7 @@ func (c *HuggingFaceClient) CreateEmbedding(ctx context.Context, req *CreateEmbe
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/jina/jina.go
+++ b/pkg/embeddings/jina/jina.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -130,7 +129,7 @@ func (e *JinaEmbeddingFunction) sendRequest(ctx context.Context, req *EmbeddingR
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read response body")
 	}

--- a/pkg/embeddings/mistral/mistral.go
+++ b/pkg/embeddings/mistral/mistral.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -135,7 +134,7 @@ func (c *Client) CreateEmbedding(ctx context.Context, req CreateEmbeddingRequest
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/morph/morph.go
+++ b/pkg/embeddings/morph/morph.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -121,7 +120,7 @@ func (c *MorphClient) CreateEmbedding(ctx context.Context, req *CreateEmbeddingR
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/nomic/nomic.go
+++ b/pkg/embeddings/nomic/nomic.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -175,7 +174,7 @@ func (c *Client) CreateEmbedding(ctx context.Context, req CreateEmbeddingRequest
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/ollama/ollama.go
+++ b/pkg/embeddings/ollama/ollama.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -100,7 +99,7 @@ func (c *OllamaClient) createEmbedding(ctx context.Context, req *CreateEmbedding
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/openai/openai.go
+++ b/pkg/embeddings/openai/openai.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -189,7 +188,7 @@ func (c *OpenAIClient) CreateEmbedding(ctx context.Context, req *CreateEmbedding
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/roboflow/roboflow.go
+++ b/pkg/embeddings/roboflow/roboflow.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -157,9 +156,6 @@ func (e *RoboflowEmbeddingFunction) sendImageRequest(ctx context.Context, imageT
 	return e.doRequest(ctx, endpoint, payload)
 }
 
-// maxAPIResponseSize limits API response body reads to prevent memory exhaustion.
-const maxAPIResponseSize = 10 * 1024 * 1024 // 10 MB
-
 func (e *RoboflowEmbeddingFunction) doRequest(ctx context.Context, endpoint string, payload []byte) (*embeddingResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBuffer(payload))
 	if err != nil {
@@ -176,13 +172,9 @@ func (e *RoboflowEmbeddingFunction) doRequest(ctx context.Context, endpoint stri
 	}
 	defer resp.Body.Close()
 
-	limitedReader := io.LimitReader(resp.Body, maxAPIResponseSize+1)
-	respData, err := io.ReadAll(limitedReader)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
-	}
-	if len(respData) > maxAPIResponseSize {
-		return nil, errors.Errorf("response exceeds maximum size of %d bytes", maxAPIResponseSize)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/embeddings/together/together.go
+++ b/pkg/embeddings/together/together.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -147,7 +146,7 @@ func (c *TogetherAIClient) CreateEmbedding(ctx context.Context, req *CreateEmbed
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/embeddings/voyage/voyage.go
+++ b/pkg/embeddings/voyage/voyage.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -244,7 +243,7 @@ func (c *VoyageAIClient) CreateEmbedding(ctx context.Context, req *CreateEmbeddi
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/pkg/rerankings/cohere/cohere.go
+++ b/pkg/rerankings/cohere/cohere.go
@@ -9,6 +9,7 @@ import (
 
 	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
 	ccommons "github.com/amikos-tech/chroma-go/pkg/commons/cohere"
+	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
 	"github.com/amikos-tech/chroma-go/pkg/rerankings"
 )
 
@@ -106,7 +107,7 @@ func (c CohereRerankingFunction) Rerank(ctx context.Context, query string, resul
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		all, err := io.ReadAll(resp.Body)
+		all, err := chttp.ReadLimitedBody(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("rerank failed with status code: %d, failed to read response: %v", resp.StatusCode, err)
@@ -197,7 +198,7 @@ func (c CohereRerankingFunction) RerankResults(ctx context.Context, queryTexts [
 			return nil, err
 		}
 		if resp.StatusCode != 200 {
-			all, err := io.ReadAll(resp.Body)
+			all, err := chttp.ReadLimitedBody(resp.Body)
 			resp.Body.Close()
 			if err != nil {
 				return nil, fmt.Errorf("rerank failed with status code: %d, failed to read response: %v", resp.StatusCode, err)

--- a/pkg/rerankings/hf/huggingface.go
+++ b/pkg/rerankings/hf/huggingface.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
@@ -78,7 +77,7 @@ func (r *HFRerankingFunction) sendRequest(ctx context.Context, req *RerankingReq
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rerankings/jina/jina.go
+++ b/pkg/rerankings/jina/jina.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
@@ -101,7 +100,7 @@ func (r *JinaRerankingFunction) sendRequest(ctx context.Context, req *RerankingR
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rerankings/together/together.go
+++ b/pkg/rerankings/together/together.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
@@ -99,7 +98,7 @@ func (r *TogetherRerankingFunction) sendRequest(ctx context.Context, req *Rerank
 		return nil, err
 	}
 	defer resp.Body.Close()
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := chttp.ReadLimitedBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Add shared `ReadLimitedBody` utility (200MB cap) to `pkg/commons/http` to protect against excessive memory allocation from malicious or misconfigured servers (CWE-400/770)
- Replace all 19 unbounded `io.ReadAll(resp.Body)` calls across 18 files with the new limited reader
- Refactor Roboflow's local 10MB limit to use the shared utility

## Details

Previously, most embedding and reranking providers used unbounded `io.ReadAll(resp.Body)`, allowing a malicious server to cause OOM. The 200MB limit safely covers all known worst cases (OpenAI max-batch ~130MB, Voyage ~41MB) while still protecting against pathological responses.

**Files not modified (intentionally):**
- Gemini (uses SDK, no raw HTTP)
- BM25/Default EF (local computation)
- `ReadRespBody` in utils.go (used by V2 API client, out of scope)
- Test files (unbounded reads acceptable per project guidelines)

## Test plan

- [x] New unit tests for `ReadLimitedBody`: under limit, at limit, over limit, empty reader
- [x] `make lint` — 0 issues
- [x] `make build` — clean compilation
- [x] `make test` — 798 tests pass

Closes #372