### PR TITLE
fix(docs): add WithInclude to README query example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ func main() {
 	}
 	fmt.Printf("Count collection: %d\n", count)
 
-	qr, err := col.Query(context.Background(), chroma.WithQueryTexts("say hello"))
+	qr, err := col.Query(context.Background(),
+		chroma.WithQueryTexts("say hello"),
+		chroma.WithInclude(chroma.IncludeDocuments),
+	)
 	if err != nil {
 		log.Fatalf("Error querying collection: %s \n", err)
 		return


### PR DESCRIPTION
## Summary
- Add `WithInclude(chroma.IncludeDocuments)` to the Getting Started query example in the README
- Without it, `Query` returns only IDs and distances by default, so `GetDocumentsGroups()[0][0]` returns empty
- Aligns the README example with the working `examples/v2/basic/main.go`

## Test plan
- [x] Verified the updated example compiles
- [x] Verified all other README code snippets reference existing functions
- [x] Linter passes (`make lint` — 0 issues)

Closes #150