### PR TITLE
docs: update README and docs for new embedding providers and stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A simple Chroma Vector Database client written in Go
 
-Works with Chroma Version: v0.6.3+
+Works with Chroma Version: v0.6.3 - v1.5.0
 
 We invite users to visit the docs site for the library for more in-depth
 information: [Chroma Go Docs](https://go-client.chromadb.dev/)
@@ -48,7 +48,7 @@ Additional support features:
 - ✅ Chroma Cloud support
 - ✅ [Structured Logging](https://go-client.chromadb.dev/logging/) - Injectable logger with Zap bridge for structured
   logging
-- ⚒️ Persistent Embedding Function support (coming soon) - automatically load embedding function from Chroma collection
+- ✅ Persistent Embedding Function support - automatically load embedding function from Chroma collection
   configuration
 - ⚒️ Persistent Client support (coming soon) - Run/embed full-featured Chroma in your go application without the need
   for Chroma server.
@@ -62,7 +62,7 @@ Additional support features:
 - ✅ [OpenAI Embedding](https://go-client.chromadb.dev/embeddings/#openai) Support
 - ✅ [Cohere](https://go-client.chromadb.dev/embeddings/#cohere) (including Multi-language support)
 - ✅ [Sentence Transformers](https://go-client.chromadb.dev/embeddings/#huggingface-inference-api) (HuggingFace Inference
-  API and [HFEI local server]())
+  API and [HFEI local server](https://go-client.chromadb.dev/embeddings/#huggingface-embedding-inference-server))
 - ✅ [Google Gemini Embedding](https://go-client.chromadb.dev/embeddings/#google-gemini-ai) Support
 - ✅ [HuggingFace Embedding Inference Server Support](https://go-client.chromadb.dev/embeddings/#huggingface-embedding-inference-server)
 - ✅ [Ollama Embedding](https://go-client.chromadb.dev/embeddings/#ollama) Support
@@ -74,6 +74,14 @@ Additional support features:
 - ✅ [Jina AI Embedding](https://go-client.chromadb.dev/embeddings/#jina-ai) Support
 - ✅ [Roboflow CLIP Embedding](https://go-client.chromadb.dev/embeddings/#roboflow) Support (Multimodal: text + images)
 - ✅ [Amazon Bedrock Embedding](https://go-client.chromadb.dev/embeddings/#amazon-bedrock) Support (Titan models, bearer token + SDK auth)
+- ✅ [Baseten Embedding](https://go-client.chromadb.dev/embeddings/#baseten) Support
+- ✅ [Morph Embedding](https://go-client.chromadb.dev/embeddings/#morph) Support
+
+**Sparse & Specialized Embedding Functions:**
+
+- ✅ [Chroma Cloud Embedding](https://go-client.chromadb.dev/embeddings/#chroma-cloud) Support
+- ✅ [Chroma Cloud Splade Embedding](https://go-client.chromadb.dev/embeddings/#chroma-cloud-splade) Support (sparse)
+- ✅ [BM25 Embedding](https://go-client.chromadb.dev/embeddings/#bm25) Support (sparse)
 
 ## Reranking Functions
 

--- a/docs/docs/embeddings.md
+++ b/docs/docs/embeddings.md
@@ -20,6 +20,15 @@ The following embedding wrappers are available:
 | [Roboflow](#roboflow)                                                             | Roboflow CLIP Embedding (Multimodal: text + images).<br/> For more info see [Roboflow Docs](https://inference.roboflow.com/).                               |
 | [Baseten](#baseten)                                                               | Baseten BEI (Baseten Embeddings Inference).<br/> Deploy your own embedding models. See [Baseten Docs](https://docs.baseten.co/engines/bei/overview).        |
 | [Amazon Bedrock](#amazon-bedrock)                                                 | Amazon Bedrock Embeddings (Titan models).<br/> For more info see [Bedrock Docs](https://docs.aws.amazon.com/bedrock/latest/userguide/embeddings.html).      |
+| [Morph](#morph)                                                                   | Morph AI Embeddings.<br/> For more info see [Morph Docs](https://docs.morphllm.com/).                                                                       |
+
+**Sparse & Specialized Embedding Functions:**
+
+| Embedding Model                                                                   | Description                                                                                                                                                 |
+|-----------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Chroma Cloud](#chroma-cloud)                                                     | Chroma Cloud hosted embeddings. Requires a Chroma Cloud API key.                                                                                            |
+| [Chroma Cloud Splade](#chroma-cloud-splade)                                       | Chroma Cloud SPLADE sparse embeddings for hybrid search.                                                                                                    |
+| [BM25](#bm25)                                                                     | Local BM25 sparse embeddings. No external API needed.                                                                                                       |
 
 ## Default Embeddings
 
@@ -184,7 +193,7 @@ import (
 	"context"
 	"fmt"
 
-	huggingface "github.com/amikos-tech/chroma-go/hf"
+	huggingface "github.com/amikos-tech/chroma-go/pkg/embeddings/hf"
 )
 
 func main() {
@@ -393,7 +402,7 @@ func main() {
 
 To use Mistral AI embeddings, you will need to create an [API Key](https://console.mistral.ai/api-keys/).
 
-Currently, (as of July 2024) only `mistral-embed` model is available, which is the default model we use.
+The default model is `mistral-embed`.
 
 ```go
 package main
@@ -898,5 +907,183 @@ func main() {
 		return
 	}
 	fmt.Printf("Embedding response: %v \n", resp)
+}
+```
+
+## Morph
+
+[Morph](https://docs.morphllm.com/) provides embedding models via an OpenAI-compatible API.
+
+Supported Embedding Function Options:
+
+- `WithAPIKey` - Set the API key directly.
+- `WithEnvAPIKey` - Use the `MORPH_API_KEY` environment variable.
+- `WithAPIKeyFromEnvVar` - Use a custom environment variable for the API key.
+- `WithModel` - Set the model. Default is `morph-embedding-v2`.
+- `WithBaseURL` - Set a custom base URL (default: `https://api.morphllm.com/v1/`).
+- `WithInsecure` - Allow HTTP connections (for local development only).
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	morph "github.com/amikos-tech/chroma-go/pkg/embeddings/morph"
+)
+
+func main() {
+	documents := []string{
+		"Document 1 content here",
+		"Document 2 content here",
+	}
+	// Make sure that you have the `MORPH_API_KEY` set in your environment
+	ef, err := morph.NewMorphEmbeddingFunction(morph.WithEnvAPIKey())
+	if err != nil {
+		fmt.Printf("Error creating Morph embedding function: %s \n", err)
+		return
+	}
+	resp, err := ef.EmbedDocuments(context.Background(), documents)
+	if err != nil {
+		fmt.Printf("Error embedding documents: %s \n", err)
+		return
+	}
+	fmt.Printf("Embedding response: %v \n", resp)
+}
+```
+
+## Chroma Cloud
+
+Chroma Cloud provides hosted dense embeddings via the Chroma embedding service. This requires a Chroma Cloud API key.
+
+The default model is `Qwen/Qwen3-Embedding-0.6B`.
+
+Supported Embedding Function Options:
+
+- `WithAPIKey` - Set the API key directly.
+- `WithEnvAPIKey` - Use the `CHROMA_API_KEY` environment variable.
+- `WithAPIKeyFromEnvVar` - Use a custom environment variable for the API key.
+- `WithModel` - Set the embedding model.
+- `WithTask` - Set a task type (e.g., `TaskNLToCode` for natural language to code retrieval).
+- `WithBaseURL` - Set a custom base URL (default: `https://embed.trychroma.com`).
+- `WithHTTPClient` - Use a custom HTTP client.
+- `WithInsecure` - Allow HTTP connections (for local development only).
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	chromacloud "github.com/amikos-tech/chroma-go/pkg/embeddings/chromacloud"
+)
+
+func main() {
+	documents := []string{
+		"Document 1 content here",
+		"Document 2 content here",
+	}
+	// Make sure that you have the `CHROMA_API_KEY` set in your environment
+	ef, err := chromacloud.NewEmbeddingFunction(chromacloud.WithEnvAPIKey())
+	if err != nil {
+		fmt.Printf("Error creating Chroma Cloud embedding function: %s \n", err)
+		return
+	}
+	resp, err := ef.EmbedDocuments(context.Background(), documents)
+	if err != nil {
+		fmt.Printf("Error embedding documents: %s \n", err)
+		return
+	}
+	fmt.Printf("Embedding response: %v \n", resp)
+}
+```
+
+## Chroma Cloud Splade
+
+Chroma Cloud Splade provides hosted SPLADE sparse embeddings for hybrid search. This is a sparse embedding function that returns `SparseVector` results instead of dense float vectors. Requires a Chroma Cloud API key.
+
+The default model is `prithivida/Splade_PP_en_v1`.
+
+Supported Embedding Function Options:
+
+- `WithAPIKey` - Set the API key directly.
+- `WithEnvAPIKey` - Use the `CHROMA_API_KEY` environment variable.
+- `WithAPIKeyFromEnvVar` - Use a custom environment variable for the API key.
+- `WithModel` - Set the embedding model.
+- `WithBaseURL` - Set a custom base URL (default: `https://embed.trychroma.com/embed_sparse`).
+- `WithHTTPClient` - Use a custom HTTP client.
+- `WithInsecure` - Allow HTTP connections (for local development only).
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	splade "github.com/amikos-tech/chroma-go/pkg/embeddings/chromacloudsplade"
+)
+
+func main() {
+	documents := []string{
+		"Document 1 content here",
+		"Document 2 content here",
+	}
+	// Make sure that you have the `CHROMA_API_KEY` set in your environment
+	ef, err := splade.NewEmbeddingFunction(splade.WithEnvAPIKey())
+	if err != nil {
+		fmt.Printf("Error creating Chroma Cloud Splade embedding function: %s \n", err)
+		return
+	}
+	resp, err := ef.EmbedDocumentsSparse(context.Background(), documents)
+	if err != nil {
+		fmt.Printf("Error embedding documents: %s \n", err)
+		return
+	}
+	for i, sv := range resp {
+		fmt.Printf("Document %d: %d non-zero entries\n", i, len(sv.Indices))
+	}
+}
+```
+
+## BM25
+
+BM25 is a local sparse embedding function that requires no external API. It computes term-frequency-based sparse vectors using the BM25 scoring formula with murmur3 hashing, compatible with the Python Chroma client's BM25 implementation.
+
+Supported Embedding Function Options:
+
+- `WithK` - Set the BM25 saturation parameter (default: `1.2`).
+- `WithB` - Set the document length normalization parameter (default: `0.75`).
+- `WithAvgDocLength` - Set the expected average document length (default: `256.0`).
+- `WithTokenMaxLength` - Set the maximum token character length (default: `40`).
+- `WithStopwords` - Set custom stopwords.
+- `WithIncludeTokens` - Include token labels in the output (default: `false`).
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings/bm25"
+)
+
+func main() {
+	documents := []string{
+		"Document 1 content here",
+		"Document 2 content here",
+	}
+	ef, err := bm25.NewEmbeddingFunction()
+	if err != nil {
+		fmt.Printf("Error creating BM25 embedding function: %s \n", err)
+		return
+	}
+	resp, err := ef.EmbedDocumentsSparse(context.Background(), documents)
+	if err != nil {
+		fmt.Printf("Error embedding documents: %s \n", err)
+		return
+	}
+	for i, sv := range resp {
+		fmt.Printf("Document %d: %d non-zero entries\n", i, len(sv.Indices))
+	}
 }
 ```

--- a/docs/docs/records.md
+++ b/docs/docs/records.md
@@ -1,59 +1,20 @@
 # Records
 
-Records are a mechanism that allows you to manage Chroma documents as a cohesive unit. This has several advantages over
-the traditional approach of managing documents, ids, embeddings, and metadata separately.
+!!! warning "Removed in V2"
 
-Two concepts are important to keep in mind here:
+    The `RecordSet` API was part of the V1 API which has been removed in v0.3.0.
+    In the V2 API, use the unified options pattern directly with collection operations:
 
-- Record - corresponds to a single document in Chroma which includes id, embedding, metadata, the document or URI
-- RecordSet - a single unit of work to insert, upsert, update or delete records.
+    ```go
+    // Add documents directly
+    col.Add(ctx,
+        chroma.WithIDs("id1", "id2"),
+        chroma.WithTexts("Document 1", "Document 2"),
+        chroma.WithMetadatas(
+            chroma.NewDocumentMetadata(chroma.NewStringAttribute("key", "value1")),
+            chroma.NewDocumentMetadata(chroma.NewStringAttribute("key", "value2")),
+        ),
+    )
+    ```
 
-
-## Record
-
-A Record contains the following fields:
-
-- ID (string)
-- Document (string) - optional
-- Metadata (map[string]interface{}) - optional
-- Embedding ([]float32 or []int32, wrapped in Embedding struct)
-- URI (string) - optional
-
-Here's the `Record` type:
-
-```go
-package types
-
-type Record struct {
-	ID        string
-	Embedding Embedding
-	Metadata  map[string]interface{}
-	Document  string
-	URI       string
-	err       error // indicating whether the record is valid
-}
-```
-
-## RecordSet
-
-A record set is a cohesive unit of work, allowing the user to add, upsert, update, or delete records.
-
-
-!!! note "Operation support"
-
-    Currently the record set only supports add operation
-
-```go
-rs, rerr := types.NewRecordSet(
-			types.WithEmbeddingFunction(types.NewConsistentHashEmbeddingFunction()),
-			types.WithIDGenerator(types.NewULIDGenerator()),
-		)
-if err != nil {
-    log.Fatalf("Error creating record set: %s", err)
-}
-// you can loop here to add multiple records
-rs.WithRecord(types.WithDocument("Document 1 content"), types.WithMetadata("key1", "value1"))
-rs.WithRecord(types.WithDocument("Document 2 content"), types.WithMetadata("key2", "value2"))
-records, err = rs.BuildAndValidate(context.Background())
-
-```
+    See the [main README](https://github.com/amikos-tech/chroma-go#unified-options-api) for the full V2 options reference.

--- a/docs/docs/rerankers.md
+++ b/docs/docs/rerankers.md
@@ -1,12 +1,5 @@
 # Reranking Functions
 
-!!! note "V2 API Support"
-
-    The reranking functions work with both V1 and V2 APIs. The `Rerank` method accepts plain text and works universally. The `RerankResults` method interface shown below references V1 types (`chromago.QueryResults`). For V1-specific usage, pin your dependency to `v0.2.5` or earlier:
-    ```bash
-    go get github.com/amikos-tech/chroma-go@v0.2.5
-    ```
-
 Reranking functions allow users to feed Chroma results into a reranking model such
 as `cross-encoder/ms-marco-MiniLM-L-6-v2` to improve the quality of the search results.
 
@@ -16,8 +9,8 @@ Rerankers take the returned documents from Chroma and the original query and ran
 
 Each reranker exposes the following methods:
 
-- `Rerank` which takes plain text query and results and returns a list of ranked results.
-- `RerankResults` which takes a `QueryResults` object and returns a list of `RerankedChromaResults` objects. RerankedChromaResults inherits from `QueryResults` and adds a `Ranks` field which contains the ranks of each result.
+- `Rerank` which takes a query string and `[]Result` inputs, returning a `map[string][]RankedResult` keyed by the reranker's ID.
+- `RerankResults` which takes query texts and a `*QueryResultImpl` and returns `*RerankedChromaResults` with ranking information.
 
 ```go
 package rerankings
@@ -25,24 +18,36 @@ package rerankings
 import (
 	"context"
 
-	chromago "github.com/amikos-tech/chroma-go"
+	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
 )
 
 type RankedResult struct {
-	ID     int // Index in the original input []string
+	Index  int // Index in the original input
 	String string
 	Rank   float32
 }
 
 type RerankedChromaResults struct {
-	chromago.QueryResults
-	Ranks [][]float32
+	*chromago.QueryResultImpl
+	QueryTexts []string
+	Ranks      map[string][][]float32
 }
 
 type RerankingFunction interface {
-	Rerank(ctx context.Context, query string, results []string) ([]*RankedResult, error)
-	RerankResults(ctx context.Context, queryResults *chromago.QueryResults) (RerankedChromaResults, error)
+	ID() string
+	Rerank(ctx context.Context, query string, results []Result) (map[string][]RankedResult, error)
+	RerankResults(ctx context.Context, queryTexts []string, queryResults *chromago.QueryResultImpl) (*RerankedChromaResults, error)
 }
+```
+
+The `Result` type wraps either a text string or an arbitrary object:
+
+```go
+// Create results from text strings
+results := rerankings.FromTexts([]string{"text1", "text2"})
+
+// Or from a single text
+result := rerankings.FromText("some text")
 ```
 
 ## Supported Rerankers
@@ -61,30 +66,32 @@ package main
 import (
 	"context"
 	"fmt"
-	cohere "github.com/amikos-tech/chroma-go/pkg/rerankings/cohere"
 	"os"
+
+	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	cohere "github.com/amikos-tech/chroma-go/pkg/rerankings/cohere"
 )
 
 func main() {
 	var query = "What is the capital of the United States?"
-	var results = []string{
+	var results = rerankings.FromTexts([]string{
 		"Carson City is the capital city of the American state of Nevada.",
 		"The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean that are a political division controlled by the United States. Its capital is Saipan.",
 		"Charlotte Amalie is the capital and largest city of the United States Virgin Islands. It has about 20,000 people. The city is on the island of Saint Thomas.",
 		"Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States.",
 		"Capital punishment (the death penalty) has existed in the United States since before the United States was a country.",
-	}
+	})
 
 	rf, err := cohere.NewCohereRerankingFunction(cohere.WithAPIKey(os.Getenv("COHERE_API_KEY")))
 	if err != nil {
-        fmt.Printf("Error creating Cohere reranking function: %s \n", err)
-    }
+		fmt.Printf("Error creating Cohere reranking function: %s \n", err)
+	}
 
 	res, err := rf.Rerank(context.Background(), query, results)
 	if err != nil {
-        fmt.Printf("Error reranking: %s \n", err)
-    }
-	
+		fmt.Printf("Error reranking: %s \n", err)
+	}
+
 	for _, rs := range res[rf.ID()] {
 		fmt.Printf("Rank: %f, Index: %d\n", rs.Rank, rs.Index)
 	}
@@ -98,37 +105,38 @@ without any registration, scroll down the page and find the automatically genera
 
 Supported models - https://api.jina.ai/redoc#tag/rerank/operation/rank_v1_rerank_post
 
-
 ```go
 package main
 
 import (
 	"context"
 	"fmt"
-	jina "github.com/amikos-tech/chroma-go/pkg/rerankings/jina"
 	"os"
+
+	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	jina "github.com/amikos-tech/chroma-go/pkg/rerankings/jina"
 )
 
 func main() {
 	var query = "What is the capital of the United States?"
-	var results = []string{
+	var results = rerankings.FromTexts([]string{
 		"Carson City is the capital city of the American state of Nevada.",
 		"The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean that are a political division controlled by the United States. Its capital is Saipan.",
 		"Charlotte Amalie is the capital and largest city of the United States Virgin Islands. It has about 20,000 people. The city is on the island of Saint Thomas.",
 		"Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States.",
 		"Capital punishment (the death penalty) has existed in the United States since before the United States was a country.",
-	}
+	})
 
 	rf, err := jina.NewJinaRerankingFunction(jina.WithAPIKey(os.Getenv("JINA_API_KEY")))
 	if err != nil {
-        fmt.Printf("Error creating Jina reranking function: %s \n", err)
-    }
+		fmt.Printf("Error creating Jina reranking function: %s \n", err)
+	}
 
 	res, err := rf.Rerank(context.Background(), query, results)
 	if err != nil {
-        fmt.Printf("Error reranking: %s \n", err)
-    }
-	
+		fmt.Printf("Error reranking: %s \n", err)
+	}
+
 	for _, rs := range res[rf.ID()] {
 		fmt.Printf("Rank: %f, Index: %d\n", rs.Rank, rs.Index)
 	}
@@ -149,29 +157,30 @@ package main
 import (
 	"context"
 	"fmt"
+
+	"github.com/amikos-tech/chroma-go/pkg/rerankings"
 	hf "github.com/amikos-tech/chroma-go/pkg/rerankings/hf"
-	"os"
 )
 
 func main() {
 	var query = "What is the capital of the United States?"
-	var results = []string{
+	var results = rerankings.FromTexts([]string{
 		"Carson City is the capital city of the American state of Nevada.",
 		"The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean that are a political division controlled by the United States. Its capital is Saipan.",
 		"Charlotte Amalie is the capital and largest city of the United States Virgin Islands. It has about 20,000 people. The city is on the island of Saint Thomas.",
 		"Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States.",
 		"Capital punishment (the death penalty) has existed in the United States since before the United States was a country.",
-	}
+	})
 
 	rf, err := hf.NewHFRerankingFunction(hf.WithRerankingEndpoint("http://127.0.0.1:8080/rerank"))
 	if err != nil {
-        fmt.Printf("Error creating HFEI reranking function: %s \n", err)
-    }
+		fmt.Printf("Error creating HFEI reranking function: %s \n", err)
+	}
 
 	res, err := rf.Rerank(context.Background(), query, results)
 	if err != nil {
-        fmt.Printf("Error reranking: %s \n", err)
-    }
+		fmt.Printf("Error reranking: %s \n", err)
+	}
 
 	for _, rs := range res[rf.ID()] {
 		fmt.Printf("Rank: %f, Index: %d\n", rs.Rank, rs.Index)
@@ -191,29 +200,31 @@ package main
 import (
 	"context"
 	"fmt"
-	together "github.com/amikos-tech/chroma-go/pkg/rerankings/together"
 	"os"
+
+	"github.com/amikos-tech/chroma-go/pkg/rerankings"
+	together "github.com/amikos-tech/chroma-go/pkg/rerankings/together"
 )
 
 func main() {
 	var query = "What is the capital of the United States?"
-	var results = []string{
+	var results = rerankings.FromTexts([]string{
 		"Carson City is the capital city of the American state of Nevada.",
 		"The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean that are a political division controlled by the United States. Its capital is Saipan.",
 		"Charlotte Amalie is the capital and largest city of the United States Virgin Islands. It has about 20,000 people. The city is on the island of Saint Thomas.",
 		"Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States.",
 		"Capital punishment (the death penalty) has existed in the United States since before the United States was a country.",
-	}
+	})
 
 	rf, err := together.NewTogetherRerankingFunction(together.WithAPIKey(os.Getenv("TOGETHER_API_KEY")))
 	if err != nil {
-        fmt.Printf("Error creating Together reranking function: %s \n", err)
-    }
+		fmt.Printf("Error creating Together reranking function: %s \n", err)
+	}
 
 	res, err := rf.Rerank(context.Background(), query, results)
 	if err != nil {
-        fmt.Printf("Error reranking: %s \n", err)
-    }
+		fmt.Printf("Error reranking: %s \n", err)
+	}
 
 	for _, rs := range res[rf.ID()] {
 		fmt.Printf("Rank: %f, Index: %d\n", rs.Rank, rs.Index)

--- a/docs/go-examples/README.md
+++ b/docs/go-examples/README.md
@@ -32,7 +32,7 @@ func main() {
 	// Add documents
 	collection.Add(ctx,
 		v2.WithIDs("doc1", "doc2"),
-		v2.WithDocuments("Hello world", "Goodbye world"),
+		v2.WithTexts("Hello world", "Goodbye world"),
 	)
 
 	// Query
@@ -155,8 +155,11 @@ client.DeleteCollection(ctx, "name")
 // Add
 col.Add(ctx,
     v2.WithIDs("id1", "id2"),
-    v2.WithDocuments("doc1", "doc2"),
-    v2.WithMetadatas(map[string]any{"key": "value"}),
+    v2.WithTexts("doc1", "doc2"),
+    v2.WithMetadatas(
+        v2.NewDocumentMetadata(v2.NewStringAttribute("key", "value")),
+        v2.NewDocumentMetadata(v2.NewStringAttribute("key", "value")),
+    ),
 )
 
 // Query
@@ -168,16 +171,16 @@ results, _ := col.Query(ctx,
 
 // Get
 results, _ := col.Get(ctx,
-    v2.WithGetIDs("id1", "id2"),
+    v2.WithIDs("id1", "id2"),
 )
 
 // Update/Upsert
-col.Update(ctx, v2.WithIDs("id1"), v2.WithDocuments("new doc"))
-col.Upsert(ctx, v2.WithIDs("id1"), v2.WithDocuments("doc"))
+col.Update(ctx, v2.WithIDs("id1"), v2.WithTexts("new doc"))
+col.Upsert(ctx, v2.WithIDs("id1"), v2.WithTexts("doc"))
 
 // Delete
-col.Delete(ctx, v2.WithDeleteIDs("id1", "id2"))
-col.Delete(ctx, v2.WithDeleteWhere(v2.EqString("key", "value")))
+col.Delete(ctx, v2.WithIDs("id1", "id2"))
+col.Delete(ctx, v2.WithWhere(v2.EqString("key", "value")))
 ```
 
 ### Search API (Cloud)


### PR DESCRIPTION
## Summary

- Add 5 missing embedding providers (Morph, Chroma Cloud, Chroma Cloud Splade, BM25) to both README and `docs/docs/embeddings.md` with full usage examples and options reference
- Update Chroma version compatibility to `v0.6.3 - v1.5.0`
- Mark Persistent Embedding Function as implemented
- Fix `rerankers.md`: update interface to V2 signature (`[]Result`, `map[string][]RankedResult`), fix all 4 code examples to use `rerankings.FromTexts()`
- Fix stale HuggingFace import path (`chroma-go/hf` -> `pkg/embeddings/hf`), remove stale Mistral date reference
- Replace dead V1 `RecordSet` content in `records.md` with deprecation notice
- Fix broken links and incorrect function names in README and `go-examples/README.md`

## Test plan

- [ ] Verify rendered markdown on all changed files
- [ ] Confirm all doc links resolve to correct anchors
- [ ] `make lint` passes (confirmed locally)