### PR TITLE
docs: add sitewide EthicalAds integration

### DIFF
--- a/docs/docs/javascripts/ethicalads-init.js
+++ b/docs/docs/javascripts/ethicalads-init.js
@@ -1,0 +1,18 @@
+(() => {
+  if (typeof document$ === "undefined") {
+    return;
+  }
+
+  let firstRender = true;
+
+  document$.subscribe(() => {
+    if (firstRender) {
+      firstRender = false;
+      return;
+    }
+
+    if (window.ethicalads && typeof window.ethicalads.reload === "function") {
+      window.ethicalads.reload();
+    }
+  });
+})();

--- a/docs/docs/stylesheets/ethicalads.css
+++ b/docs/docs/stylesheets/ethicalads.css
@@ -1,0 +1,19 @@
+.mdx-ethicalads-container {
+  display: flex;
+  justify-content: center;
+  padding-top: 0.5rem;
+}
+
+[data-ea-style="stickybox"] {
+  z-index: 30;
+}
+
+@media screen and (max-width: 1300px) {
+  .mdx-ethicalads-container {
+    padding-top: 0;
+  }
+
+  [data-ea-publisher] {
+    margin: 0.75rem 0 0;
+  }
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/amikos-tech/chroma-go
 copyright: "Amikos Tech LTD, 2024 (core ChromaDB contributors)"
 theme:
   name: material
+  custom_dir: overrides
   palette:
     primary: black
   logo: assets/images/logo.png
@@ -42,6 +43,9 @@ extra:
       We use cookies for analytics purposes. By continuing to use this website, you agree to their use.
 extra_javascript:
   - javascripts/gtag.js
+  - javascripts/ethicalads-init.js
+extra_css:
+  - stylesheets/ethicalads.css
 markdown_extensions:
   - abbr
   - admonition

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <script async src="https://media.ethicalads.io/media/client/ethicalads.min.js"></script>
+{% endblock %}
+
+{% block hero %}
+  {{ super() }}
+  <div class="md-grid mdx-ethicalads-container">
+    <div
+      id="go-client-stickybox"
+      class="raised"
+      data-ea-publisher="chromadbdev"
+      data-ea-type="image"
+      data-ea-style="stickybox"
+      data-ea-placement-bottom="56px"
+    ></div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary\n- add MkDocs Material override template to load EthicalAds client script\n- add sitewide stickybox placement for the Go docs domain\n- add EthicalAds CSS and SPA reload hook for instant navigation\n- wire new assets in docs/mkdocs.yml\n\n## Validation\n- mkdocs build -f docs/mkdocs.yml