### PR TITLE
ci: scope EF matrix secrets by provider

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -250,7 +250,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # API-based providers
+          # Keep provider matrix simple; scope secrets in the test step env below.
           - provider: openai
             test_path: ./pkg/embeddings/openai/...
           - provider: cohere
@@ -318,27 +318,27 @@ jobs:
             -coverprofile=coverage-ef-${{ matrix.provider }}.out \
             -timeout=15m
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-          HF_API_KEY: ${{ secrets.HF_API_KEY }}
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          CF_GATEWAY_ENDPOINT: ${{ secrets.CF_GATEWAY_ENDPOINT }}
-          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
-          VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          NOMIC_API_KEY: ${{ secrets.NOMIC_API_KEY }}
-          JINA_API_KEY: ${{ secrets.JINA_API_KEY }}
-          ROBOFLOW_API_KEY: ${{ secrets.ROBOFLOW_API_KEY }}
-          MORPH_API_KEY: ${{ secrets.MORPH_API_KEY }}
-          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-          BASETEN_API_KEY: ${{ secrets.BASETEN_API_KEY }}
-          BASETEN_BASE_URL: ${{ secrets.BASETEN_BASE_URL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          OPENAI_API_KEY: ${{ matrix.provider == 'openai' && secrets.OPENAI_API_KEY || '' }}
+          COHERE_API_KEY: ${{ matrix.provider == 'cohere' && secrets.COHERE_API_KEY || '' }}
+          HF_API_KEY: ${{ matrix.provider == 'hf' && secrets.HF_API_KEY || '' }}
+          CF_API_TOKEN: ${{ matrix.provider == 'cloudflare' && secrets.CF_API_TOKEN || '' }}
+          CF_ACCOUNT_ID: ${{ matrix.provider == 'cloudflare' && secrets.CF_ACCOUNT_ID || '' }}
+          CF_GATEWAY_ENDPOINT: ${{ matrix.provider == 'cloudflare' && secrets.CF_GATEWAY_ENDPOINT || '' }}
+          TOGETHER_API_KEY: ${{ matrix.provider == 'together' && secrets.TOGETHER_API_KEY || '' }}
+          VOYAGE_API_KEY: ${{ matrix.provider == 'voyage' && secrets.VOYAGE_API_KEY || '' }}
+          GEMINI_API_KEY: ${{ matrix.provider == 'gemini' && secrets.GEMINI_API_KEY || '' }}
+          MISTRAL_API_KEY: ${{ matrix.provider == 'mistral' && secrets.MISTRAL_API_KEY || '' }}
+          NOMIC_API_KEY: ${{ matrix.provider == 'nomic' && secrets.NOMIC_API_KEY || '' }}
+          JINA_API_KEY: ${{ matrix.provider == 'jina' && secrets.JINA_API_KEY || '' }}
+          ROBOFLOW_API_KEY: ${{ matrix.provider == 'roboflow' && secrets.ROBOFLOW_API_KEY || '' }}
+          MORPH_API_KEY: ${{ matrix.provider == 'morph' && secrets.MORPH_API_KEY || '' }}
+          PERPLEXITY_API_KEY: ${{ matrix.provider == 'perplexity' && secrets.PERPLEXITY_API_KEY || '' }}
+          BASETEN_API_KEY: ${{ matrix.provider == 'baseten' && secrets.BASETEN_API_KEY || '' }}
+          BASETEN_BASE_URL: ${{ matrix.provider == 'baseten' && secrets.BASETEN_BASE_URL || '' }}
+          AWS_ACCESS_KEY_ID: ${{ matrix.provider == 'bedrock' && secrets.AWS_ACCESS_KEY_ID || '' }}
+          AWS_SECRET_ACCESS_KEY: ${{ matrix.provider == 'bedrock' && secrets.AWS_SECRET_ACCESS_KEY || '' }}
+          AWS_REGION: ${{ matrix.provider == 'bedrock' && secrets.AWS_REGION || '' }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ matrix.provider == 'bedrock' && secrets.AWS_BEARER_TOKEN_BEDROCK || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- scope EF test-step secrets using `matrix.provider` conditionals in `.github/workflows/go.yml`
- keep local providers (`default_ef`, `bm25`, `ollama`) free of external provider and AWS credentials
- keep Bedrock credentials scoped to only the `bedrock` EF matrix entry
- keep `GITHUB_TOKEN` available for test infra needs

## Validation
- `actionlint -ignore 'the runner of "actions/setup-go@v4" action is too old to run on GitHub Actions' .github/workflows/go.yml`

## Tracking
- Closes #420
- Follow-up for action upgrades: #424
