### PR TITLE
Bump github.com/amikos-tech/pure-tokenizers to v0.1.5

### DIFF
--- a/examples/v2/array_metadata/go.mod
+++ b/examples/v2/array_metadata/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/array_metadata/go.sum
+++ b/examples/v2/array_metadata/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/auth/go.mod
+++ b/examples/v2/auth/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/auth/go.sum
+++ b/examples/v2/auth/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/basic/go.mod
+++ b/examples/v2/basic/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/basic/go.sum
+++ b/examples/v2/basic/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/embedding_function_basic/go.mod
+++ b/examples/v2/embedding_function_basic/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/embedding_function_basic/go.sum
+++ b/examples/v2/embedding_function_basic/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/metadata_filters/go.mod
+++ b/examples/v2/metadata_filters/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/metadata_filters/go.sum
+++ b/examples/v2/metadata_filters/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/persistent_client/go.mod
+++ b/examples/v2/persistent_client/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/persistent_client/go.sum
+++ b/examples/v2/persistent_client/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/schema/go.mod
+++ b/examples/v2/schema/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/schema/go.sum
+++ b/examples/v2/schema/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/search/go.mod
+++ b/examples/v2/search/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/search/go.sum
+++ b/examples/v2/search/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/examples/v2/tenant_and_db/go.mod
+++ b/examples/v2/tenant_and_db/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/amikos-tech/chroma-go-local v0.3.3 // indirect
 	github.com/amikos-tech/pure-onnx v0.0.1 // indirect
-	github.com/amikos-tech/pure-tokenizers v0.1.4 // indirect
+	github.com/amikos-tech/pure-tokenizers v0.1.5 // indirect
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect

--- a/examples/v2/tenant_and_db/go.sum
+++ b/examples/v2/tenant_and_db/go.sum
@@ -20,6 +20,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/amikos-tech/chroma-go-local v0.3.3
 	github.com/amikos-tech/pure-onnx v0.0.1
-	github.com/amikos-tech/pure-tokenizers v0.1.4
+	github.com/amikos-tech/pure-tokenizers v0.1.5
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/amikos-tech/pure-onnx v0.0.1 h1:FGMe+NyPOAlaMce+QFn2o+PkREXtHztAHgU1B
 github.com/amikos-tech/pure-onnx v0.0.1/go.mod h1:pTYlj5NC8Q5vyhB0tYWliJOCPUuoIWm/8qsyit/84Y4=
 github.com/amikos-tech/pure-tokenizers v0.1.4 h1:32Xd6kJ699b4LDyQh6HoQP7aFcbzQKILAuNlHPZlsHI=
 github.com/amikos-tech/pure-tokenizers v0.1.4/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
+github.com/amikos-tech/pure-tokenizers v0.1.5 h1:/Itkw6d7mtfKoWc9sjWaH80gPXwVxKzs2QlL5BnF3XE=
+github.com/amikos-tech/pure-tokenizers v0.1.5/go.mod h1:o0ICQtz7tM7pukqwfybBk6FvWKFZLyIWs4uFYbH+CG4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
## Summary
- Bump `github.com/amikos-tech/pure-tokenizers` from `v0.1.4` to `v0.1.5` in:
  - root module `go.mod` / `go.sum`
  - `examples/v2/*/go.mod`
  - `examples/v2/*/go.sum` where `pure-tokenizers` is present

## Validation
- `make lint` ✅
- `make test` ✅
  - `DONE 1249 tests, 7 skipped in 28.903s`
  - skipped tests are expected for cloud-only / opt-in slow checks

Closes #434
