### PR TITLE
docs: add GSD codebase map scaffold

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# Architecture
+
+**Analysis Date:** 2026-03-18
+
+## Pattern Overview
+
+**Overall:** Go SDK/library for Chroma with pluggable embedding and reranking providers, multiple client backends, and a documentation/examples layer.
+
+**Key Characteristics:**
+- Public API is centered in `pkg/api/v2`
+- Embeddings and rerankers are provider packages behind shared interfaces
+- Supports three access modes: remote HTTP, Chroma Cloud, and embedded local runtime
+- Configuration persistence and auto-wiring are first-class concerns for embedding functions
+
+## Layers
+
+**Public Client Layer:**
+- Purpose: expose the library surface users call from applications
+- Contains: `Client`, `Collection`, option structs, metadata/search/schema APIs
+- Location: `pkg/api/v2/*.go`
+- Depends on: HTTP helpers, embedding interfaces, logger, local runtime helpers
+- Used by: examples, external consumers, tests
+
+**Domain / Operation Layer:**
+- Purpose: validate request options and convert high-level calls into concrete operations
+- Contains: collection ops, query/search ops, schema/configuration handling, record and rank types
+- Location: `pkg/api/v2/collection.go`, `pkg/api/v2/search.go`, `pkg/api/v2/schema.go`, `pkg/api/v2/configuration.go`
+- Depends on: embedding interfaces and client implementations
+- Used by: HTTP/cloud/local client flows
+
+**Provider Abstraction Layer:**
+- Purpose: define common embedding and reranking contracts and registry/build-from-config behavior
+- Contains: `EmbeddingFunction`, `SparseEmbeddingFunction`, `MultimodalEmbeddingFunction`, registries, secrets, distance metrics
+- Location: `pkg/embeddings/embedding.go`, `pkg/embeddings/registry.go`, `pkg/rerankings/reranking.go`
+- Depends on: stdlib + validation/util helpers
+- Used by: every provider package and config auto-wiring path
+
+**Provider Implementation Layer:**
+- Purpose: implement specific remote/local embedding and reranking backends
+- Contains: one package per provider with request/response structs, options, config round-tripping, live tests
+- Location: `pkg/embeddings/*`, `pkg/rerankings/*`
+- Depends on: provider abstractions, commons helpers, external SDKs
+- Used by: collection embedding flows and direct provider usage
+
+**Runtime / Support Layer:**
+- Purpose: support embedded local runtime, downloads, verification, tokenizers, and logging
+- Contains: local runtime clients, artifact download helpers, cosign helpers, logger package, tokenizers
+- Location: `pkg/api/v2/client_local*.go`, `pkg/internal/*`, `pkg/tokenizers/*`, `pkg/logger/*`
+- Depends on: filesystem, networking, external libraries, Go runtime
+- Used by: persistent client and runtime bootstrap/perf flows
+
+## Data Flow
+
+**Remote Collection Flow:**
+1. User constructs a client with functional options (`pkg/api/v2/client.go`)
+2. Client stores tenant/database/auth/logging state
+3. Collection operations validate input and serialize request structs
+4. Text inputs may be embedded through the configured embedding function
+5. HTTP client sends requests to Chroma server/cloud and hydrates `Collection`/result types
+
+**Auto-Wired Embedding Flow:**
+1. A collection stores embedding function info in configuration/schema (`pkg/api/v2/configuration.go`)
+2. Client fetches collection metadata/configuration
+3. Registry resolves known provider name + config (`pkg/embeddings/registry.go`)
+4. Provider constructor rebuilds the embedding function from env-var-based config
+
+**Embedded Runtime Flow:**
+1. `NewPersistentClient` resolves runtime library paths/download behavior (`pkg/api/v2/client_local.go`)
+2. Embedded local client maintains collection state and dimensions (`pkg/api/v2/client_local_embedded.go`)
+3. Operations execute against the in-process runtime instead of a remote server
+
+**State Management:**
+- Remote clients are mostly stateless beyond tenant/database/auth/logger/default EF configuration
+- Embedded local client tracks collection state, dimensions, and runtime lifecycle in-memory
+- Persisted collection configuration bridges server-side state with local provider reconstruction
+
+## Key Abstractions
+
+**Client / Collection:**
+- Purpose: primary end-user API
+- Examples: `Client`, `Collection`, `PersistentClient`, `CloudAPIClient`
+- Pattern: interface + concrete backend implementations
+
+**Operation Structs:**
+- Purpose: collect validated options before request execution
+- Examples: `CreateCollectionOp`, `GetCollectionOp`, search/rank options
+- Pattern: functional options over mutable op structs
+
+**Embedding Registry:**
+- Purpose: rebuild known providers from stored config
+- Examples: dense, sparse, multimodal registries in `pkg/embeddings/registry.go`
+- Pattern: init-time registration + factory lookup
+
+## Entry Points
+
+**Library Entry Points:**
+- `pkg/api/v2/client.go` - core client API and options
+- `pkg/api/v2/client_cloud.go` - cloud client construction
+- `pkg/api/v2/client_local.go` - persistent embedded client construction
+
+**Provider Entry Points:**
+- `pkg/embeddings/<provider>/*.go` - provider constructors and config reconstruction
+- `pkg/rerankings/<provider>/*.go` - reranker constructors
+
+**Operational Entry Points:**
+- `Makefile` - main local build/test interface
+- `scripts/offline_bundle/main.go` - offline runtime bundle CLI
+- `docs/mkdocs.yml` - docs site build entry
+
+## Error Handling
+
+**Strategy:** return wrapped errors from validation and request boundaries; avoid panics in normal runtime flows.
+
+**Patterns:**
+- `github.com/pkg/errors` is used heavily for wrap/context
+- Option validation happens early and repeatedly
+- Public APIs favor explicit validation over implicit defaults when safety matters
+- A notable exception is init-time registry duplication checks, which panic intentionally in several provider packages
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Central logger abstraction in `pkg/logger`
+- Client logging is injected/configurable, not hard-coded
+
+**Validation:**
+- Struct validation in several providers
+- Request validation in op structs before I/O
+
+**Compatibility:**
+- The repo actively targets multiple Chroma versions and multiple execution modes
+- Build tags partition incompatible suites (`basicv2`, `cloud`, `ef`, `rf`, `crosslang`, `soak`)
+
+---
+
+*Architecture analysis: 2026-03-18*
+*Update when client backends, provider contracts, or runtime flows change materially*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,131 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-18
+
+## Tech Debt
+
+**Embedding contract fragmentation:**
+- Issue: dense, sparse, and multimodal contracts are split, while provider-specific task semantics and dimensionality controls are implemented inconsistently across providers
+- Files: `pkg/embeddings/embedding.go`, `pkg/embeddings/registry.go`, `pkg/api/v2/configuration.go`, provider packages such as `pkg/embeddings/jina`, `pkg/embeddings/nomic`, `pkg/embeddings/cohere`, `pkg/embeddings/openai`, `pkg/embeddings/roboflow`
+- Why: providers were added incrementally with provider-native models/options
+- Impact: cross-provider multimodal/intent portability is difficult; config auto-wiring and future feature additions have a high compatibility burden
+- Fix approach: introduce a provider-neutral shared contract and map providers to it explicitly
+
+**Deprecated compatibility surface remains large:**
+- Issue: multiple deprecated helpers and the legacy `default_ef` alias package remain in active use
+- Files: `pkg/embeddings/default_ef/*`, `pkg/embeddings/ort/ort.go`, `pkg/api/v2/collection.go`, `pkg/api/v2/search.go`, `pkg/api/v2/rank.go`
+- Why: preserving compatibility for earlier consumers and older docs/examples
+- Impact: broader maintenance surface and more paths to regress
+- Fix approach: keep compatibility tests, but continue consolidating new work onto the preferred APIs
+
+**Runtime bootstrap logic is spread across packages and scripts:**
+- Issue: local runtime download, verification, offline bundle generation, and tokenizer setup are distributed across several packages and scripts
+- Files: `pkg/api/v2/client_local.go`, `pkg/api/v2/client_local_library_download.go`, `pkg/internal/downloadutil/*`, `pkg/internal/cosignutil/*`, `scripts/fetch_runtime_deps.sh`, `scripts/offline_bundle/main.go`
+- Why: platform/runtime needs expanded over time
+- Impact: onboarding and change risk are high for local-runtime work
+- Fix approach: keep docs and tests aligned and avoid touching multiple flows without end-to-end validation
+
+## Known Bugs
+
+**Multimodal docs drift from code reality:**
+- Symptoms: docs page says multimodal support is not yet available, but `roboflow` already implements text+image multimodal embeddings
+- Files: `docs/go-examples/docs/embeddings/multimodal.md`, `pkg/embeddings/roboflow/roboflow.go`
+- Trigger: provider support landed without docs fully catching up
+- Workaround: read provider code/docs in `docs/docs/embeddings.md` instead of relying on the older example page
+- Root cause: documentation and implementation evolved at different speeds
+
+**Delete-heavy local perf path is still unstable enough to be opt-in:**
+- Symptoms: delete+reinsert workload is disabled by default in perf docs/config
+- Files: `README.md`, `docs/docs/performance-testing.md`, `pkg/api/v2/client_local_perf_helpers_test.go`
+- Trigger: local persistent perf or soak runs that include delete-heavy write patterns
+- Workaround: leave `CHROMA_PERF_ENABLE_DELETE_REINSERT` unset unless explicitly validating that path
+- Root cause: local runtime stability under that workload is still being hardened
+
+## Security Considerations
+
+**Secret sprawl risk from provider-heavy env configuration:**
+- Risk: the repo supports many providers, each with its own key/token env vars; docs/examples/scripts make secret handling pervasive
+- Files: `pkg/embeddings/*`, `pkg/rerankings/*`, `docs/docs/embeddings.md`, `docs/docs/rerankers.md`, root `.env`
+- Current mitigation: persisted configs usually store env-var names instead of secret values
+- Recommendations: keep generated docs/maps free of actual credentials and avoid reading or copying `.env` values into committed artifacts
+
+**Insecure transport escape hatches exist for some providers:**
+- Risk: providers can allow non-HTTPS or insecure overrides for development/testing flows
+- Files: provider packages such as `pkg/embeddings/roboflow/roboflow.go` and shared helpers in `pkg/embeddings/embedding.go`
+- Current mitigation: secure defaults and validation in constructors
+- Recommendations: call out insecure usage clearly in docs/tests and avoid enabling it in production paths
+
+## Performance Bottlenecks
+
+**Per-item multimodal/provider batching gaps:**
+- Problem: some provider implementations still loop item-by-item instead of using a true batch API path
+- Files: `pkg/embeddings/roboflow/roboflow.go` (`EmbedDocuments`, `EmbedImages`)
+- Cause: simplest provider integration path favored correctness first
+- Improvement path: add true batch request support where providers allow it
+
+**Runtime/bootstrap latency for local default embeddings:**
+- Problem: first-run local embedding/runtime setup can require downloads, verification, and library discovery
+- Files: `pkg/embeddings/default_ef/*`, `pkg/api/v2/client_local_library_download.go`, `scripts/fetch_runtime_deps.sh`
+- Cause: native/runtime dependencies are resolved lazily or via bootstrap tooling
+- Improvement path: lean on offline bundle flow and cache reuse in CI/dev workflows
+
+## Fragile Areas
+
+**Embedding auto-wiring across config + schema + client modes:**
+- Why fragile: behavior crosses `configuration.go`, schema resolution, registry lookup, and multiple client backends
+- Common failures: provider config mismatch, env-var naming issues, unsupported provider registrations, version-specific server behavior
+- Safe modification: change shared contracts and config tests together; validate HTTP, cloud, and local flows
+- Test coverage: decent config tests exist, but cross-provider semantic consistency is still a risk
+
+**Embedded local client state and dimension tracking:**
+- Why fragile: embedded runtime must track collection dimension/state while staying compatible with remote collection semantics
+- Files: `pkg/api/v2/client_local_embedded.go`, `pkg/api/v2/client_local_embedded_test.go`
+- Common failures: dimension mismatch, runtime init/download issues, state drift between operations
+- Safe modification: run focused local/client/perf tests and keep fallback paths intact
+
+## Scaling Limits
+
+**CI and provider surface area scale maintenance cost quickly:**
+- Current capacity: broad but manageable provider matrix
+- Limit: each new provider or shared embedding contract change multiplies config, docs, example, and test obligations
+- Symptoms at limit: doc drift, inconsistent task semantics, growing compatibility branches
+- Scaling path: centralize provider-neutral contracts and reduce bespoke per-provider branching
+
+## Dependencies at Risk
+
+**External provider APIs and models:**
+- Risk: remote embedding/reranking APIs evolve independently, especially around tasks, models, and response formats
+- Impact: provider packages and config persistence can drift or break silently
+- Migration plan: keep provider packages isolated and cover config round-trip/live behavior where credentials are available
+
+**Deprecated default embedding alias package:**
+- Risk: `pkg/embeddings/default_ef` remains intentionally supported but deprecated in favor of `pkg/embeddings/ort`
+- Impact: duplicate maintenance and user confusion
+- Migration plan: continue steering new code toward `ort` while preserving tests for legacy paths
+
+## Missing Critical Features
+
+**Provider-neutral multimodal foundation:**
+- Problem: the shared interface still treats multimodal as “dense + image methods” rather than a generalized modality/intention model
+- Current workaround: rely on provider-specific options and the single current multimodal implementation (`roboflow`)
+- Blocks: portable multimodal support across providers and cleaner config/capability introspection
+- Implementation complexity: medium-high, because it touches shared contracts, registries, persistence, docs, and tests
+
+## Test Coverage Gaps
+
+**Live-provider coverage is opportunistic:**
+- What's not tested: many provider behaviors in CI unless secrets are available
+- Risk: regressions in task mapping, auth handling, or API compatibility can slip through
+- Priority: High for shared embedding contract changes
+- Difficulty to test: requires external credentials and provider availability
+
+**Docs/example consistency is lightly enforced:**
+- What's not tested: that docs and examples reflect current supported embedding capabilities
+- Risk: user confusion and planning mistakes from stale guidance
+- Priority: Medium
+- Difficulty to test: mostly documentation process rather than code complexity
+
+---
+
+*Concerns audit: 2026-03-18*
+*Update as issues are fixed or new risk areas emerge*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,118 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-18
+
+## Naming Patterns
+
+**Files:**
+- lowercase Go filenames by concern (`client.go`, `collection.go`, `configuration.go`)
+- provider packages usually use `<provider>.go` plus `option.go` and `*_test.go`
+- examples and docs directories are feature-oriented (`examples/v2/search`, `docs/docs/embeddings.md`)
+
+**Functions:**
+- Constructors use `New...` (`NewHTTPClient`, `NewPersistentClient`, `NewOpenAIEmbeddingFunction`)
+- Options use `With...` consistently across clients, collections, providers, and rerankers
+- Validation helpers and request builders are explicit and verb-oriented (`PrepareAndValidateCollectionRequest`, `BuildEmbeddingFunctionFromConfig`)
+
+**Variables:**
+- camelCase for locals and fields
+- exported constants/types use Go-standard PascalCase / ALL_CAPS where appropriate
+- env-var names are explicit string constants in many provider packages
+
+**Types:**
+- interfaces for public contracts (`Client`, `Collection`, `EmbeddingFunction`, `RerankingFunction`)
+- request/response structs tend to be package-local and JSON-oriented
+- op structs capture option state before execution (`CreateCollectionOp`, `GetCollectionOp`)
+
+## Code Style
+
+**Formatting:**
+- `gofmt` baseline
+- `gci` import ordering via `.golangci.yml`
+- standard Go comment and spacing conventions
+
+**Linting:**
+- `golangci-lint` is the canonical linter entry point
+- repo enables `dupword`, `ginkgolinter`, `gocritic`, `mirror`, and full `staticcheck`
+- examples are excluded from linting/formatting enforcement
+
+## Import Organization
+
+**Order:**
+1. Standard library
+2. Third-party packages
+3. Repository-local imports with `github.com/amikos-tech/chroma-go/...`
+
+**Grouping:**
+- blank lines between groups
+- import order is enforced by `gci`
+
+## Error Handling
+
+**Patterns:**
+- return errors instead of panicking in runtime paths
+- wrap errors with context using `github.com/pkg/errors`
+- validate inputs early, especially in option setters and request-prep methods
+
+**Error Types:**
+- most code uses wrapped generic errors rather than custom error types
+- validation messages are direct and user-readable
+- nil/empty/invalid state checks are common before I/O
+
+## Logging
+
+**Framework:**
+- logger abstraction in `pkg/logger`
+- Zap bridge support exists for structured logging use cases
+
+**Patterns:**
+- logging is injected/configurable rather than hard-coded across the API surface
+- tests often use quiet mocks or test loggers instead of production logging
+
+## Comments
+
+**When to Comment:**
+- exported API surfaces are documented heavily with Go doc comments and examples
+- comments explain behavior, compatibility, or API caveats rather than trivial code mechanics
+- deprecations are explicitly documented in comments
+
+**TODO Comments:**
+- plain `// TODO ...` comments are used for follow-ups and gaps
+- there are also explicit `Deprecated:` doc comments across compatibility layers
+
+## Function Design
+
+**Size:**
+- public surface files are broad, but behavior is still decomposed into option setters, helper methods, and provider-specific types
+
+**Parameters:**
+- functional options are preferred over large parameter lists
+- context is threaded through nearly all I/O-facing methods
+
+**Return Values:**
+- constructors usually return `(*Type, error)` or `(Interface, error)`
+- collection and provider methods generally return typed results plus `error`
+
+## Module Design
+
+**Exports:**
+- public APIs live in top-level package files with exported interfaces/types
+- provider packages expose their own constructors/options directly
+
+**Patterns Reused Across Repo:**
+- functional options
+- interface-driven provider abstraction
+- build-tag partitioned tests
+- env-var-backed config persistence for remote providers
+
+## Project-Specific Guidance
+
+- Prefer V2 API changes in `pkg/api/v2/`
+- Add colocated tests with the correct build tags
+- Avoid `Must*` patterns and runtime panics in production code; this is explicitly called out in `CLAUDE.md`
+- When adding providers, match existing provider package layout and config round-trip behavior
+
+---
+
+*Convention analysis: 2026-03-18*
+*Update when lint rules, option patterns, or public API style changes*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,94 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-18
+
+## APIs & External Services
+
+**Chroma Server / Cloud:**
+- Chroma HTTP API - primary remote backend for collection/database operations
+  - Client code: `pkg/api/v2/client.go`, `pkg/api/v2/client_http.go`, `pkg/api/v2/client_cloud.go`
+  - Test/development runtime: Docker + GHCR images in `pkg/api/v2/*integration_test.go` and `.github/workflows/go.yml`
+  - Cloud auth: `CHROMA_API_KEY`, `CHROMA_TENANT`, `CHROMA_DATABASE`
+
+**Embedding Providers:**
+- OpenAI, Cohere, HuggingFace, Google Gemini, Jina, Mistral, Nomic, Ollama, Cloudflare, Together, Voyage, Roboflow, Amazon Bedrock, Baseten, Morph, Perplexity, Chroma Cloud, and local/default providers
+  - Implementations live in `pkg/embeddings/*`
+  - Auth is almost entirely env-var based and provider-specific
+  - Several providers expose task/dimension/model configuration via persisted config maps
+
+**Reranking Providers:**
+- Cohere, HuggingFace, Jina, Together
+  - Implementations in `pkg/rerankings/*`
+  - Live tests are env-gated similarly to embedding providers
+
+## Data Storage
+
+**Databases / Vector Storage:**
+- External Chroma server or Chroma Cloud - main document/vector storage target
+  - Accessed over HTTP via `pkg/api/v2`
+
+**Embedded Runtime Storage:**
+- `chroma-go-local` persistent runtime - in-process/local storage path for `NewPersistentClient`
+  - Entry points: `pkg/api/v2/client_local.go`, `pkg/api/v2/client_local_embedded.go`
+  - Runtime library path/config: `CHROMA_LIB_PATH`, `CHROMAGO_ONNX_RUNTIME_PATH`, `TOKENIZERS_LIB_PATH`
+
+**Local Artifacts / Bundles:**
+- Offline runtime bundles generated under `artifacts/`
+  - Scripts: `scripts/fetch_runtime_deps.sh`, `scripts/offline_bundle/main.go`
+
+## Authentication & Identity
+
+**Cloud / API Access:**
+- Chroma Cloud credentials via env vars and client options
+- Provider authentication typically via `WithEnvAPIKey`, `WithAPIKeyFromEnvVar`, bearer token helpers, or SDK credentials
+
+**Runtime Trust / Verification:**
+- Local runtime artifact verification includes download, checksum, and cosign-related helpers
+  - Packages: `pkg/internal/cosignutil`, `pkg/internal/downloadutil`
+
+## Monitoring & Observability
+
+**Logging:**
+- Internal logger abstraction and Zap bridge (`pkg/logger`)
+- Structured logging examples in `examples/v2/logging` and `examples/v2/logging_slog`
+
+**Docs Analytics / Site Integrations:**
+- Google Analytics and EthicalAds on the MkDocs site (`docs/mkdocs.yml`, `docs/docs/javascripts/*`)
+
+## CI/CD & Deployment
+
+**CI Pipeline:**
+- GitHub Actions
+  - Go test/lint/matrix runs: `.github/workflows/go.yml`, `.github/workflows/lint.yaml`, `.github/workflows/nightly.yml`
+  - Perf smoke/soak: `.github/workflows/perf-local.yml`
+  - Docs deploy: `.github/workflows/mkdocs.yml`
+
+**Hosting:**
+- GitHub Pages for docs site generated from MkDocs
+  - Source: `docs/docs/*.md`
+  - Deploy workflow: `.github/workflows/mkdocs.yml`
+
+## Environment Configuration
+
+**Development:**
+- Local Chroma URL via `CHROMA_URL`
+- Provider keys loaded from shell environment
+- Python venv installed from `requirements-test.txt` for cross-language tests
+
+**CI / Test:**
+- GitHub Actions secrets for cloud/API tokens and GitHub auth
+- Test matrix uses container images, build tags, and env-gated live provider tests
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None in the product/library itself
+
+**Outgoing:**
+- HTTP calls to provider APIs and Chroma deployments
+- GitHub API/release metadata access for runtime bootstrap/download flows
+
+---
+
+*Integration audit: 2026-03-18*
+*Update when adding/removing providers, cloud flows, or runtime asset sources*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,88 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-18
+
+## Languages
+
+**Primary:**
+- Go 1.24.11 - all library, client, provider, runtime, and most test code (`go.mod`, `pkg/**`, `scripts/offline_bundle/main.go`)
+
+**Secondary:**
+- Python 3 - cross-language embedding and local persistence checks (`scripts/cross_lang_ef_test.py`, `scripts/local_persistence_crosscheck.py`)
+- Shell - local server/runtime bootstrap helpers (`scripts/chroma_server.sh`, `scripts/fetch_runtime_deps.sh`)
+- Markdown + MkDocs config - product docs and examples (`docs/docs/*.md`, `docs/mkdocs.yml`)
+
+## Runtime
+
+**Environment:**
+- Go toolchain 1.24.x for build/test/library execution
+- Python virtualenv for cross-language tests (`Makefile` target `setup-python-venv`)
+- Docker for Chroma integration tests and local server workflows (`Makefile` target `server`, `.github/workflows/go.yml`)
+
+**Package Manager:**
+- Go modules
+- Lockfile: `go.sum` present
+
+## Frameworks
+
+**Core:**
+- Standard library HTTP + JSON for the SDK and provider clients
+- `github.com/pkg/errors` for wrapped errors throughout the library
+
+**Testing:**
+- `go test` with build tags
+- `gotest.tools/gotestsum` via `Makefile` for grouped test runs and JUnit output
+- `github.com/stretchr/testify` for assertions
+- `github.com/leanovate/gopter` for property-based tests
+- `github.com/testcontainers/testcontainers-go` for Chroma integration tests
+
+**Build/Dev:**
+- `golangci-lint` with `gci` import formatting (`.golangci.yml`)
+- MkDocs Material for docs publishing (`docs/mkdocs.yml`)
+- GitHub Actions for CI, smoke, nightly, docs deploy, and perf workflows (`.github/workflows/*.yml`)
+
+## Key Dependencies
+
+**Critical:**
+- `github.com/testcontainers/testcontainers-go` - integration tests against real Chroma containers
+- `github.com/amikos-tech/chroma-go-local` - embedded local runtime shim for persistent client support
+- `github.com/amikos-tech/pure-onnx` - local default embedding runtime dependency
+- `github.com/amikos-tech/pure-tokenizers` - tokenizer dependency for local/runtime workflows
+- `google.golang.org/genai` - Gemini provider support
+- `github.com/aws/aws-sdk-go-v2/.../bedrockruntime` - Amazon Bedrock embedding support
+- `go.uber.org/zap` - logging bridge support
+- `github.com/go-playground/validator/v10` - provider/config validation
+
+**Infrastructure:**
+- GitHub Container Registry images for Chroma test matrices (`.github/workflows/go.yml`)
+- GitHub releases / tokens for runtime asset resolution (`scripts/fetch_runtime_deps.sh`, `pkg/api/v2/client_local_library_download.go`)
+
+## Configuration
+
+**Environment:**
+- Heavy env-var use for provider API keys, cloud credentials, runtime asset paths, and perf toggles
+- Root `.env` exists locally, but code paths generally persist env-var names rather than secret values
+
+**Build:**
+- `go.mod`, `go.sum` - module/dependency definition
+- `Makefile` - build, lint, unit/integration/provider/perf targets
+- `.golangci.yml` - lint and import-order rules
+- `docs/mkdocs.yml` - docs site configuration
+
+## Platform Requirements
+
+**Development:**
+- Go 1.24.x
+- Python 3 for cross-language suites
+- Docker for most API integration tests
+- Optional `GITHUB_TOKEN` / `GH_TOKEN` to avoid rate limits during runtime bootstrap/download flows
+
+**Production:**
+- Primary output is a Go library consumed by other applications
+- Supports remote Chroma server/cloud deployments and embedded local runtime usage
+- Some features are platform/runtime sensitive: local runtime libraries, tokenizer artifacts, and OS-specific smoke/compile guards
+
+---
+
+*Stack analysis: 2026-03-18*
+*Update after major dependency or runtime changes*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,144 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-18
+
+## Directory Layout
+
+```text
+chroma-go/
+├── .github/workflows/    # CI, docs deploy, review, perf, nightly jobs
+├── docs/                 # MkDocs site config and end-user docs
+├── examples/v2/          # Self-contained V2 examples, many with their own go.mod
+├── pkg/api/v2/           # Main public client API, collections, schema, search, cloud/local clients
+├── pkg/commons/          # Shared HTTP/provider helper packages
+├── pkg/embeddings/       # Shared embedding contracts plus one package per provider
+├── pkg/internal/         # Internal helpers (downloads, cosign verification)
+├── pkg/logger/           # Logger abstraction and Zap bridge
+├── pkg/rerankings/       # Shared reranking API plus provider packages
+├── pkg/tokenizers/       # Tokenizer/runtime support libraries
+├── scripts/              # Runtime bootstrap, cross-language checks, local server helpers
+├── data/                 # Checked-in model/runtime data used by reranking/runtime workflows
+├── Makefile              # Canonical build/test/lint entry points
+├── README.md             # High-level feature and usage documentation
+└── CLAUDE.md             # Repo-specific working conventions
+```
+
+## Directory Purposes
+
+**`pkg/api/v2/`:**
+- Purpose: current primary user-facing API
+- Contains: client backends, collection operations, metadata, schema, ranking/search, configuration persistence
+- Key files: `client.go`, `client_http.go`, `client_cloud.go`, `client_local.go`, `collection.go`, `schema.go`, `search.go`
+- Subdirectories: none; flat but broad package
+
+**`pkg/embeddings/`:**
+- Purpose: embedding contracts and provider implementations
+- Contains: shared interfaces/registry plus subpackages like `openai`, `cohere`, `jina`, `roboflow`, `bedrock`, `default_ef`
+- Key files: `embedding.go`, `registry.go`, `secret.go`
+- Subdirectories: 20+ provider/runtime packages
+
+**`pkg/rerankings/`:**
+- Purpose: reranking abstractions and provider implementations
+- Contains: shared reranking types plus `cohere`, `hf`, `jina`, `together`
+- Key files: `reranking.go`
+
+**`docs/`:**
+- Purpose: MkDocs-powered documentation site
+- Contains: end-user docs in `docs/docs/`, site config in `docs/mkdocs.yml`, HTML overrides and assets
+- Key files: `docs/docs/client.md`, `docs/docs/embeddings.md`, `docs/docs/rerankers.md`
+
+**`examples/v2/`:**
+- Purpose: runnable examples for V2 features
+- Contains: feature-specific example modules, often with their own `go.mod`
+- Key files: `examples/v2/basic/main.go`, `examples/v2/persistent_client/main.go`, `examples/v2/search/main.go`
+
+**`scripts/`:**
+- Purpose: helper automation around runtime bootstrap and cross-language verification
+- Contains: shell scripts, Python tests, Go-based offline bundle tool
+- Key files: `scripts/fetch_runtime_deps.sh`, `scripts/cross_lang_ef_test.py`, `scripts/local_persistence_crosscheck.py`
+
+## Key File Locations
+
+**Entry Points:**
+- `pkg/api/v2/client.go` - primary client and option API
+- `pkg/api/v2/client_cloud.go` - cloud-specific entry
+- `pkg/api/v2/client_local.go` - embedded runtime entry
+- `scripts/offline_bundle/main.go` - offline dependency bundle generator
+
+**Configuration:**
+- `go.mod` - module and dependency versions
+- `.golangci.yml` - lint and formatting rules
+- `Makefile` - build/test commands
+- `docs/mkdocs.yml` - docs site build config
+
+**Core Logic:**
+- `pkg/api/v2/*.go` - API surface and operation orchestration
+- `pkg/embeddings/*.go` + provider subdirs - embedding contracts and implementations
+- `pkg/rerankings/*.go` + provider subdirs - reranking functionality
+
+**Testing:**
+- Adjacent `*_test.go` files throughout `pkg/`
+- Cross-language helpers in `scripts/`
+- Workflow-level validation in `.github/workflows/`
+
+**Documentation:**
+- `README.md` - overview
+- `docs/docs/*.md` - canonical docs pages
+- `docs/go-examples/README.md` - example index
+
+## Naming Conventions
+
+**Files:**
+- lowercase Go filenames, usually domain-oriented (`client_local.go`, `configuration.go`, `roboflow.go`)
+- tests colocated as `*_test.go`
+- major docs/config files in uppercase or standard project names (`README.md`, `CLAUDE.md`, `Makefile`)
+
+**Directories:**
+- lowercase package/provider names (`pkg/embeddings/openai`, `pkg/rerankings/jina`)
+- versioned examples under `examples/v2/*`
+
+**Special Patterns:**
+- provider packages usually contain `option.go`, main implementation file, and tests
+- examples frequently carry standalone module files (`go.mod`, `go.sum`) to isolate usage
+
+## Where to Add New Code
+
+**New API feature:**
+- Primary code: `pkg/api/v2/`
+- Tests: colocated `pkg/api/v2/*_test.go`
+- Docs/examples: `docs/docs/*.md`, `examples/v2/`
+
+**New embedding provider or shared embedding capability:**
+- Shared contract/registry: `pkg/embeddings/embedding.go`, `pkg/embeddings/registry.go`
+- Provider-specific implementation: `pkg/embeddings/<provider>/`
+- Persistence/auto-wire changes: `pkg/api/v2/configuration.go`, schema/config tests
+
+**New reranker:**
+- Implementation: `pkg/rerankings/<provider>/`
+- Shared abstractions: `pkg/rerankings/reranking.go`
+
+**Runtime/bootstrap helpers:**
+- Internal helpers: `pkg/internal/`
+- User-facing scripts/tooling: `scripts/`
+
+## Special Directories
+
+**`data/`:**
+- Purpose: bundled model/runtime data used by some local/test workflows
+- Source: checked-in artifacts, not generated during normal package builds
+- Committed: Yes
+
+**`artifacts/`:**
+- Purpose: generated offline runtime bundles and perf outputs
+- Source: test/perf/bootstrap commands
+- Committed: typically no
+
+**`examples/v2/*`:**
+- Purpose: isolated example modules
+- Source: maintained examples, not generated
+- Committed: Yes
+
+---
+
+*Structure analysis: 2026-03-18*
+*Update when package layout or example/docs organization changes*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,125 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-18
+
+## Test Framework
+
+**Runner:**
+- `go test` is the underlying runner
+- `gotestsum` is the standard wrapper for grouped runs and JUnit output (`Makefile`)
+
+**Assertion Library:**
+- `github.com/stretchr/testify/require` is heavily used
+- `assert` appears in some provider/config tests
+- `gopter` is used for property-based tests in parts of `pkg/api/v2`
+
+**Run Commands:**
+```bash
+make test                 # V2 API suite (basicv2)
+make test-cloud           # Cloud integration suite
+make test-ef              # Embedding provider suites
+make test-rf              # Reranking suites
+make test-crosslang       # Go + Python cross-language checks
+make test-local-load-smoke
+make lint
+```
+
+## Test File Organization
+
+**Location:**
+- Tests are colocated with the code they cover (`pkg/api/v2/*_test.go`, `pkg/embeddings/<provider>/*_test.go`)
+- Cross-language helper logic lives in `scripts/`
+- CI orchestration lives in `.github/workflows/`
+
+**Naming:**
+- standard `*_test.go`
+- some suites use specialized names like `*_integration_test.go`, `*_perf_helpers_test.go`, `*_crosslang_integration_test.go`
+
+**Structure:**
+- package-level unit tests around request validation, serialization, and client behavior
+- integration tests for HTTP/cloud/runtime behavior
+- provider-specific tests often include both config-roundtrip tests and env-gated live API tests
+
+## Test Structure
+
+**Patterns:**
+- `t.Run(...)` subtests are common
+- `httptest.NewServer(...)` is used heavily for HTTP client unit tests
+- arrange/act/assert is visible even when not labeled
+- `t.Setenv(...)` is used for env-sensitive flows
+
+**Build Tags:**
+- `basicv2` - core V2 API tests
+- `cloud` - cloud-enabled tests
+- `ef` - embedding provider tests
+- `rf` - reranking provider tests
+- `crosslang` - Go/Python parity checks
+- `soak` - local runtime performance suites
+
+## Mocking
+
+**Patterns:**
+- stdlib `httptest` replaces remote APIs for most client/provider unit tests
+- lightweight mock structs are preferred over full mocking frameworks
+- testcontainers are used instead of mocks for many integration cases
+
+**What Gets Mocked:**
+- HTTP endpoints
+- credential providers
+- env-var based configuration
+- selected local runtime dependencies in focused tests
+
+## Fixtures and Factories
+
+**Test Data:**
+- inline fixtures are common in provider tests
+- property-based generators are used for some V2 model tests (`gopter`)
+- checked-in runtime/model data exists under `data/` for some local flows
+
+## Coverage
+
+**Current Shape:**
+- coverage artifacts are produced into repo-root files like `coverage.out`, `coverage-ef.out`, `coverage-rf.out`, `coverage-crosslang.out`
+- JUnit XML files are also emitted into the repo root
+
+**CI Coverage Strategy:**
+- broad matrix across lint, Windows compile guard, cross-platform smoke, API versions, cloud, EF, RF, cross-language, and perf workflows
+- many live provider tests are optional/env-gated rather than always-on
+
+## Test Types
+
+**Unit Tests:**
+- validation, serialization, option behavior, registry/config round-trips
+- examples: `pkg/api/v2/client_http_test.go`, `pkg/embeddings/registry_test.go`
+
+**Integration Tests:**
+- real Chroma containers via testcontainers
+- embedded runtime tests for persistent/local client
+- live provider tests when credentials are available
+
+**Cross-Language Tests:**
+- Go/Python parity and persistence checks via Python helpers in `scripts/`
+
+**Performance Tests:**
+- smoke and soak suites around local persistent runtime
+- outputs written to `artifacts/perf/*`
+
+## Common Patterns
+
+**Async / External Dependency Gating:**
+- `t.Skip(...)` is used frequently when credentials, runtimes, or platform support are missing
+- Windows/platform-specific skips exist for filesystem permission and runtime artifact tests
+
+**Compatibility Testing:**
+- CI runs against multiple Chroma versions
+- tests explicitly branch on server capability/version for some features
+
+**Practical Expectation for New Work:**
+- add colocated tests with matching build tags
+- update examples/docs if public behavior changes
+- for provider/config changes, cover `GetConfig()` and rebuild-from-config paths
+
+---
+
+*Testing analysis: 2026-03-18*
+*Update when build tags, CI matrix, or test tooling changes*


### PR DESCRIPTION
## Summary
- add the initial `.planning/codebase` scaffold for this brownfield repo
- document the current stack, integrations, architecture, structure, conventions, testing patterns, and codebase concerns
- establish shared planning context before running the rest of the GSD project init flow

## Testing
- not run (docs-only change)
