### PR TITLE
Phase 22: WithGroupBy Validation

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -30,6 +30,7 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 - ✓ Code cleanups: shared pathutil, context.Context fix, registry test cleanup — v0.4.1
 - ✓ SDK auto-wiring behavior documented across Python, JS, Rust, Go — v0.4.1
 - ✓ RrfRank arithmetic methods build correct expression trees instead of silent no-ops — v0.4.2 Phase 21
+- ✓ WithGroupBy(nil) rejects explicit nil input with a stable validation error — v0.4.2 Phase 22
 
 ## Current Milestone: v0.4.2 Bug Fixes and Robustness
 
@@ -46,7 +47,6 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 - Add Twelve Labs async embedding support (#479)
 
 ### Active
-- WithGroupBy(nil) accepted as no-op instead of error — #482
 - Embedded GetOrCreateCollection passes closed EFs to CreateCollection fallback — #493
 - Default ORT EF leaked when CreateCollection finds existing collection — #494
 - Morph EF integration test broken by upstream 404 — #465
@@ -106,4 +106,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-09 — Phase 21 (RrfRank arithmetic fix) complete*
+*Last updated: 2026-04-10 — Phase 22 (WithGroupBy validation) complete*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -39,6 +39,7 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 **Target features:**
 - Fix RrfRank arithmetic silent no-ops (#481)
 - Fix WithGroupBy(nil) silently skipping grouping (#482)
+- Normalize nil-handling across sibling V2 SearchRequestOption helpers (#503)
 - Fix embedded GetOrCreateCollection passing closed EFs (#493)
 - Fix default ORT EF leak in embedded CreateCollection (#494)
 - Fix Morph EF integration test (#465)
@@ -47,6 +48,7 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 - Add Twelve Labs async embedding support (#479)
 
 ### Active
+- Sibling V2 SearchRequestOption helpers still have inconsistent explicit-nil handling after the WithGroupBy(nil) fix — #503
 - Embedded GetOrCreateCollection passes closed EFs to CreateCollection fallback — #493
 - Default ORT EF leaked when CreateCollection finds existing collection — #494
 - Morph EF integration test broken by upstream 404 — #465

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,7 +9,7 @@
 
 - [ ] **RANK-01**: RrfRank arithmetic methods (Multiply, Sub, Add, Div, Negate) compute correct composite rank expressions instead of returning self
 - [ ] **RANK-02**: RrfRank arithmetic results produce valid JSON when marshaled
-- [ ] **GRP-01**: WithGroupBy(nil) returns a validation error instead of silently skipping grouping
+- [x] **GRP-01**: WithGroupBy(nil) returns a validation error instead of silently skipping grouping
 
 ### Embedded Client Lifecycle
 
@@ -61,7 +61,7 @@
 |-------------|-------|--------|
 | RANK-01 | Phase 21 | Pending |
 | RANK-02 | Phase 21 | Pending |
-| GRP-01 | Phase 22 | Pending |
+| GRP-01 | Phase 22 | Complete |
 | EFL-01 | Phase 23 | Pending |
 | EFL-02 | Phase 24 | Pending |
 | EFL-03 | Phase 24 | Pending |
@@ -82,4 +82,4 @@
 
 ---
 *Requirements defined: 2026-04-08*
-*Last updated: 2026-04-08 after roadmap creation*
+*Last updated: 2026-04-10 after Phase 22 completion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -10,6 +10,7 @@
 - [ ] **RANK-01**: RrfRank arithmetic methods (Multiply, Sub, Add, Div, Negate) compute correct composite rank expressions instead of returning self
 - [ ] **RANK-02**: RrfRank arithmetic results produce valid JSON when marshaled
 - [x] **GRP-01**: WithGroupBy(nil) returns a validation error instead of silently skipping grouping
+- [ ] **OPT-01**: V2 SearchRequestOption helpers use a documented and consistent explicit-nil contract instead of mixing silent omission with validation errors
 
 ### Embedded Client Lifecycle
 
@@ -62,6 +63,7 @@
 | RANK-01 | Phase 21 | Pending |
 | RANK-02 | Phase 21 | Pending |
 | GRP-01 | Phase 22 | Complete |
+| OPT-01 | Phase 30 | Pending |
 | EFL-01 | Phase 23 | Pending |
 | EFL-02 | Phase 24 | Pending |
 | EFL-03 | Phase 24 | Pending |
@@ -76,8 +78,8 @@
 | MORPH-01 | Phase 28 | Pending |
 
 **Coverage:**
-- v1 requirements: 15 total
-- Mapped to phases: 15
+- v1 requirements: 16 total
+- Mapped to phases: 16
 - Unmapped: 0
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Milestones
 
 - ✅ **v0.4.1 Provider-Neutral Multimodal Foundations** — Phases 1-20 (shipped 2026-04-08)
-- 🚧 **v0.4.2 Bug Fixes and Robustness** — Phases 21-29 (in progress)
+- 🚧 **v0.4.2 Bug Fixes and Robustness** — Phases 21-30 (in progress)
 
 ## Phases
 
@@ -31,6 +31,7 @@ See: [v0.4.1 Archived Roadmap](milestones/v0.4.1-ROADMAP.md)
 - [ ] **Phase 27: Download Stack Consolidation** - default_ef download code uses shared downloadutil instead of its own HTTP implementation
 - [ ] **Phase 28: Morph Test Fix** - Morph EF integration test handles upstream 404 gracefully
 - [ ] **Phase 29: Rank Expression Composition Robustness** - Reject silent footguns in rank composition (nil operands, degenerate RRF compositions)
+- [ ] **Phase 30: V2 SearchRequestOption Nil Consistency** - Normalize explicit-nil handling across sibling search option helpers to match the Phase 22 contract
 
 ## Phase Details
 
@@ -168,12 +169,26 @@ Plans:
 - [ ] 29-02: TBD — Client-side rejection of degenerate RRF compositions (#501)
 - [ ] 29-03: TBD — Result-shape validation in `Search` response handling (#500)
 
+### Phase 30: V2 SearchRequestOption Nil Consistency
+**Goal**: Normalize explicit-nil handling across sibling V2 SearchRequestOption helpers so callers get a consistent contract instead of a mix of silent omission and validation errors
+**Depends on**: Phase 22
+**Requirements**: OPT-01
+**Issues**: amikos-tech/chroma-go#503
+**Success Criteria** (what must be TRUE):
+  1. The nil-handling contract for sibling SearchRequestOption helpers in `pkg/api/v2/search.go` is explicitly defined and tested
+  2. Options that should reject explicit nil inputs fail with clear validation errors instead of silently degrading caller intent
+  3. Any options intentionally left permissive are documented and covered by tests so the API behavior is consistent and discoverable
+**Plans**: TBD
+
+Plans:
+- [ ] 30-01: TBD — Audit sibling SearchRequestOption helpers and pin a consistent explicit-nil contract (#503)
+
 ## Progress
 
 **Execution Order:**
-Phases execute in numeric order: 21 -> 22 -> 23 -> 24 -> ... -> 29.
+Phases execute in numeric order: 21 -> 22 -> 23 -> 24 -> ... -> 30.
 Phases 21, 22, 25, 27, 28 are independent and may execute in any order relative to each other.
-Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on Phase 21.
+Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on Phase 21. Phase 30 depends on Phase 22.
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
@@ -186,3 +201,4 @@ Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on 
 | 27. Download Stack Consolidation | v0.4.2 | 0/0 | Not started | - |
 | 28. Morph Test Fix | v0.4.2 | 0/0 | Not started | - |
 | 29. Rank Expression Composition Robustness | v0.4.2 | 0/3 | Not started | - |
+| 30. V2 SearchRequestOption Nil Consistency | v0.4.2 | 0/0 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -23,7 +23,7 @@ See: [v0.4.1 Archived Roadmap](milestones/v0.4.1-ROADMAP.md)
 - Decimal phases (21.1, 21.2): Urgent insertions (marked with INSERTED)
 
 - [x] **Phase 21: RrfRank Arithmetic Fix** - RrfRank arithmetic methods compute correct results instead of silently returning self (completed 2026-04-09)
-- [ ] **Phase 22: WithGroupBy Validation** - WithGroupBy(nil) returns an error instead of silently skipping grouping
+- [x] **Phase 22: WithGroupBy Validation** - WithGroupBy(nil) returns an error instead of silently skipping grouping (completed 2026-04-10)
 - [ ] **Phase 23: ORT EF Leak Fix** - Default ORT EF is properly closed when CreateCollection finds an existing collection
 - [ ] **Phase 24: GetOrCreateCollection EF Safety** - GetOrCreateCollection does not pass closed EFs to CreateCollection fallback
 - [ ] **Phase 25: Error Body Truncation** - Embedding provider error messages truncate raw HTTP bodies to safe display lengths
@@ -70,10 +70,10 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. Passing nil to WithGroupBy returns a validation error before the request is sent
   2. Non-nil WithGroupBy calls continue to work as before
-**Plans**: TBD
+**Plans**: 1 plan
 
 Plans:
-- [ ] 22-01: TBD
+- [x] 22-01-PLAN.md — Validate `WithGroupBy(nil)` fail-fast behavior and pin direct/request-construction regressions
 
 ### Phase 23: ORT EF Leak Fix
 **Goal**: Default ORT embedding function is properly cleaned up when CreateCollection encounters an existing collection
@@ -178,7 +178,7 @@ Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 21. RrfRank Arithmetic Fix | v0.4.2 | 1/1 | Complete    | 2026-04-09 |
-| 22. WithGroupBy Validation | v0.4.2 | 0/0 | Not started | - |
+| 22. WithGroupBy Validation | v0.4.2 | 1/1 | Complete    | 2026-04-10 |
 | 23. ORT EF Leak Fix | v0.4.2 | 0/0 | Not started | - |
 | 24. GetOrCreateCollection EF Safety | v0.4.2 | 0/0 | Not started | - |
 | 25. Error Body Truncation | v0.4.2 | 0/0 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,40 +3,40 @@ gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
 status: executing
-stopped_at: Phase 22 context gathered
-last_updated: "2026-04-10T04:25:12.578Z"
-last_activity: 2026-04-10 -- Phase 22 planning complete
+stopped_at: Phase 22 complete
+last_updated: "2026-04-10T04:53:49Z"
+last_activity: 2026-04-10 -- Phase 22 complete
 progress:
   total_phases: 10
-  completed_phases: 2
+  completed_phases: 3
   total_plans: 4
-  completed_plans: 3
-  percent: 75
+  completed_plans: 4
+  percent: 100
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-04-08)
+See: .planning/PROJECT.md (updated 2026-04-10)
 
 **Core value:** Go applications can use Chroma and embedding providers through a stable, portable API that minimizes provider-specific friction.
-**Current focus:** Phase 21.1 — rrf-cloud-integration-test-coverage-including-arithmetic-com
+**Current focus:** Phase 23 — ort-ef-leak-fix
 
 ## Current Position
 
-Phase: 22
+Phase: 23
 Plan: Not started
-Status: Ready to execute
-Last activity: 2026-04-10 -- Phase 22 planning complete
+Status: Ready to discuss or plan Phase 23
+Last activity: 2026-04-10 -- Phase 22 complete
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
 **Velocity:**
 
-- Total plans completed: 3
+- Total plans completed: 4
 - Average duration: --
 - Total execution time: 0 hours
 
@@ -56,5 +56,5 @@ Decisions are logged in PROJECT.md Key Decisions table.
 
 ## Session
 
-**Last Date:** 2026-04-09T20:22:32.921Z
-**Stopped At:** Phase 22 context gathered
+**Last Date:** 2026-04-10T04:53:49Z
+**Stopped At:** Phase 22 complete

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,11 @@ gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
 status: executing
-stopped_at: Phase 21.1 context gathered
-last_updated: "2026-04-09T14:32:02.308Z"
+stopped_at: Phase 22 context gathered
+last_updated: "2026-04-09T20:22:32.924Z"
 last_activity: 2026-04-09
 progress:
-  total_phases: 9
+  total_phases: 10
   completed_phases: 2
   total_plans: 3
   completed_plans: 3
@@ -56,5 +56,5 @@ Decisions are logged in PROJECT.md Key Decisions table.
 
 ## Session
 
-**Last Date:** 2026-04-09T11:41:08.829Z
-**Stopped At:** Phase 21.1 context gathered
+**Last Date:** 2026-04-09T20:22:32.921Z
+**Stopped At:** Phase 22 context gathered

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: executing
+status: Ready to discuss or plan Phase 23
 stopped_at: Phase 22 complete
-last_updated: "2026-04-10T04:53:49Z"
-last_activity: 2026-04-10 -- Phase 22 complete
+last_updated: "2026-04-10T05:14:10.449Z"
+last_activity: "2026-04-10 -- Phase 22 shipped — PR #502"
 progress:
   total_phases: 10
   completed_phases: 3
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 23
 Plan: Not started
 Status: Ready to discuss or plan Phase 23
-Last activity: 2026-04-10 -- Phase 22 complete
+Last activity: 2026-04-10 -- Phase 22 shipped — PR #502
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -49,6 +49,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 ### Roadmap Evolution
 
 - Phase 21.1 inserted after Phase 21: RRF cloud integration test coverage including arithmetic compositions (URGENT) — post-fix cloud coverage gap for Phase 21 arithmetic methods
+- Phase 30 added: V2 SearchRequestOption nil consistency — follow-up to Phase 22 / issue #503 for sibling explicit-nil contract cleanup
 
 ### Blockers/Concerns
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
 status: executing
 stopped_at: Phase 22 context gathered
-last_updated: "2026-04-09T20:22:32.924Z"
-last_activity: 2026-04-09
+last_updated: "2026-04-10T04:25:12.578Z"
+last_activity: 2026-04-10 -- Phase 22 planning complete
 progress:
   total_phases: 10
   completed_phases: 2
-  total_plans: 3
+  total_plans: 4
   completed_plans: 3
-  percent: 100
+  percent: 75
 ---
 
 # Project State
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-08)
 
 Phase: 22
 Plan: Not started
-Status: Executing Phase 21.1
-Last activity: 2026-04-09
+Status: Ready to execute
+Last activity: 2026-04-10 -- Phase 22 planning complete
 
 Progress: [░░░░░░░░░░] 0%
 

--- a/.planning/phases/22-withgroupby-validation/22-01-PLAN.md
+++ b/.planning/phases/22-withgroupby-validation/22-01-PLAN.md
@@ -1,0 +1,286 @@
+---
+phase: 22-withgroupby-validation
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/search.go
+  - pkg/api/v2/groupby_test.go
+autonomous: true
+requirements:
+  - GRP-01
+
+must_haves:
+  truths:
+    - "A caller that explicitly passes `WithGroupBy(nil)` gets the exact validation error `groupBy cannot be nil` before any search request is appended or sent"
+    - "A caller that wants no grouping still gets that behavior by omitting `WithGroupBy(...)` entirely"
+    - "A caller that passes a valid non-nil `GroupBy` still gets grouped search requests with `req.GroupBy` populated unchanged"
+    - "A caller that passes an invalid non-nil `GroupBy` still receives the existing validation errors from `(*GroupBy).Validate()`"
+    - "`NewSearchRequest(..., WithGroupBy(nil))` fails before a partial search request is appended to `SearchQuery.Searches`"
+    - "`pkg/api/v2/groupby_test.go` pins the exact nil-error contract while keeping valid non-nil coverage in place"
+  artifacts:
+    - path: "pkg/api/v2/search.go"
+      provides: "Fail-fast nil validation for WithGroupBy"
+      contains: "groupBy cannot be nil"
+    - path: "pkg/api/v2/groupby_test.go"
+      provides: "Exact-error regression coverage for nil and non-nil WithGroupBy behavior"
+      contains: "groupBy cannot be nil"
+  key_links:
+    - from: "pkg/api/v2/search.go groupByOption.ApplyToSearchRequest"
+      to: "pkg/api/v2/groupby_test.go TestWithGroupBy"
+      via: "Exact nil-error contract for explicit WithGroupBy(nil)"
+      pattern: "groupBy cannot be nil"
+    - from: "pkg/api/v2/search.go NewSearchRequest option application"
+      to: "pkg/api/v2/groupby_test.go TestSearchRequestWithGroupBy"
+      via: "Nil groupby request-construction regression"
+      pattern: "WithGroupBy\\(nil\\)"
+---
+
+<objective>
+Fix Phase 22 by making `WithGroupBy(nil)` fail fast with a stable validation error instead of silently omitting grouping. Keep omission semantics unchanged for callers that do not pass `WithGroupBy(...)`, preserve valid non-nil `GroupBy` behavior and existing non-nil validation semantics, and add colocated tests that pin both the direct option path and the higher-level request-construction path.
+
+Purpose: the current implementation in `pkg/api/v2/search.go` treats an explicit nil `GroupBy` as success, which silently changes caller intent and violates `GRP-01`. The repair must stay tightly scoped to `pkg/api/v2/search.go` and `pkg/api/v2/groupby_test.go`.
+
+Output: updated `WithGroupBy` nil handling, exact-error regression tests, request-construction regression coverage, and a green V2 test/lint pass.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/22-withgroupby-validation/22-CONTEXT.md
+@.planning/phases/22-withgroupby-validation/22-RESEARCH.md
+@.planning/phases/22-withgroupby-validation/22-VALIDATION.md
+@pkg/api/v2/search.go
+@pkg/api/v2/groupby.go
+@pkg/api/v2/groupby_test.go
+@CLAUDE.md
+
+<interfaces>
+From `pkg/api/v2/search.go` (current buggy behavior):
+```go
+func (o *groupByOption) ApplyToSearchRequest(req *SearchRequest) error {
+	if o.groupBy == nil {
+		return nil
+	}
+	if err := o.groupBy.Validate(); err != nil {
+		return err
+	}
+	req.GroupBy = o.groupBy
+	return nil
+}
+```
+
+From `pkg/api/v2/groupby.go` (existing non-nil validation to preserve):
+```go
+func (g *GroupBy) Validate() error {
+	if g.Aggregate == nil {
+		return errors.New("aggregate is required")
+	}
+	if err := g.Aggregate.Validate(); err != nil {
+		return errors.Wrap(err, "invalid aggregate")
+	}
+	if len(g.Keys) == 0 {
+		return errors.New("at least one key is required")
+	}
+	return nil
+}
+```
+
+From `pkg/api/v2/groupby_test.go` (current nil-no-op contract to replace):
+```go
+t.Run("nil groupby", func(t *testing.T) {
+	req := &SearchRequest{}
+	err := WithGroupBy(nil).ApplyToSearchRequest(req)
+	require.NoError(t, err)
+	require.Nil(t, req.GroupBy)
+})
+```
+
+From `pkg/api/v2/search.go` (`NewSearchRequest` applies each option before appending):
+```go
+func NewSearchRequest(opts ...SearchRequestOption) SearchCollectionOption {
+	return func(update *SearchQuery) error {
+		search := &SearchRequest{}
+		for _, opt := range opts {
+			if err := opt.ApplyToSearchRequest(search); err != nil {
+				return err
+			}
+		}
+		update.Searches = append(update.Searches, *search)
+		return nil
+	}
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Replace nil-no-op behavior with fail-fast validation and pin it with direct + request-construction tests</name>
+  <files>pkg/api/v2/search.go, pkg/api/v2/groupby_test.go</files>
+  <read_first>
+    - pkg/api/v2/search.go (read the current `groupByOption.ApplyToSearchRequest` implementation and `NewSearchRequest` option loop)
+    - pkg/api/v2/groupby.go (preserve existing non-nil `GroupBy.Validate()` behavior)
+    - pkg/api/v2/groupby_test.go (replace the current nil-no-op subtest and extend request-construction coverage)
+    - .planning/phases/22-withgroupby-validation/22-CONTEXT.md (locked nil-handling and exact-error contract)
+    - .planning/phases/22-withgroupby-validation/22-RESEARCH.md (recommended exact message and regression scope)
+  </read_first>
+  <behavior>
+    - `WithGroupBy(nil).ApplyToSearchRequest(req)` returns `groupBy cannot be nil` and leaves `req.GroupBy` nil
+    - `NewSearchRequest(..., WithGroupBy(nil))` returns the same exact error and leaves `SearchQuery.Searches` length 0
+    - Omitting `WithGroupBy(...)` remains the only way to request no grouping
+    - Valid non-nil `GroupBy` values still apply successfully and invalid non-nil values still fail through `(*GroupBy).Validate()`
+  </behavior>
+  <action>
+Addresses review concern: make the RED confirmation explicit and keep the "omit the option for no grouping" rule visible without broadening scope.
+
+**Step 1 (RED): update tests first in `pkg/api/v2/groupby_test.go`, and do not edit `pkg/api/v2/search.go` until the focused test command fails.**
+
+Replace the existing `TestWithGroupBy` nil subtest so it asserts the exact error string and preserves `req.GroupBy == nil` per D-01, D-03, and D-04:
+
+```go
+t.Run("nil groupby returns exact validation error", func(t *testing.T) {
+	req := &SearchRequest{}
+	err := WithGroupBy(nil).ApplyToSearchRequest(req)
+	require.EqualError(t, err, "groupBy cannot be nil")
+	require.Nil(t, req.GroupBy)
+})
+```
+
+Keep the existing passing non-nil subtest and invalid non-nil subtests intact per D-06.
+
+Add a higher-level regression under `TestSearchRequestWithGroupBy` that proves `NewSearchRequest(...)` fails before append and that explicit nil is not treated as omission:
+
+```go
+t.Run("search with nil groupby fails before append", func(t *testing.T) {
+	sq := &SearchQuery{}
+
+	opt := NewSearchRequest(
+		WithKnnRank(KnnQueryText("machine learning")),
+		WithGroupBy(nil),
+	)
+
+	err := opt(sq)
+	require.EqualError(t, err, "groupBy cannot be nil")
+	require.Len(t, sq.Searches, 0)
+})
+```
+
+Do not add a new sentinel, fallback, or alternate branch that treats `WithGroupBy(nil)` as "no grouping"; per D-02, callers request no grouping by omitting `WithGroupBy(...)` entirely.
+
+Run the focused tests and confirm RED before the implementation change: the command must exit non-zero because the new exact-error assertions fail against the current silent no-op behavior.
+
+```bash
+go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...
+```
+
+**Step 2 (GREEN): update `pkg/api/v2/search.go`.**
+
+Change only the nil branch in `groupByOption.ApplyToSearchRequest` to the exact line below per D-01, D-03, and D-04:
+
+```go
+if o.groupBy == nil {
+	return errors.New("groupBy cannot be nil")
+}
+```
+
+Leave the non-nil validation line `if err := o.groupBy.Validate(); err != nil {` and the assignment `req.GroupBy = o.groupBy` unchanged per D-06. Do not modify `pkg/api/v2/groupby.go` and do not touch docs/examples in this phase per D-05.
+
+**Step 3 (GREEN verify):** re-run the focused tests until they pass:
+
+```bash
+go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...
+```
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/GolandProjects/chroma-go && go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pkg/api/v2/search.go` contains `return errors.New("groupBy cannot be nil")` inside `groupByOption.ApplyToSearchRequest`
+    - `pkg/api/v2/search.go` still validates non-nil values with `if err := o.groupBy.Validate(); err != nil {`
+    - `pkg/api/v2/groupby_test.go` contains a nil subtest using `require.EqualError(t, err, "groupBy cannot be nil")`
+    - `pkg/api/v2/groupby_test.go` contains a request-construction regression with `WithGroupBy(nil)` and `require.Len(t, sq.Searches, 0)`
+    - `pkg/api/v2/groupby_test.go` still contains the passing valid non-nil `WithGroupBy(groupBy).ApplyToSearchRequest(req)` coverage
+    - `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` exits 0
+  </acceptance_criteria>
+  <done>Explicit `WithGroupBy(nil)` is rejected deterministically before request append/send, omission remains the way to request no grouping, and tests pin both the direct option path and the composed `NewSearchRequest(...)` path.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Run broader V2 regressions and lint</name>
+  <files>pkg/api/v2/search.go, pkg/api/v2/groupby_test.go</files>
+  <read_first>
+    - pkg/api/v2/search.go (confirm only the nil branch changed)
+    - pkg/api/v2/groupby_test.go (confirm valid non-nil and invalid non-nil tests remain present)
+    - .planning/phases/22-withgroupby-validation/22-VALIDATION.md (use the quick/full verification contract)
+    - .planning/phases/22-withgroupby-validation/22-CONTEXT.md (keep scope bounded to code-and-tests only per D-05)
+  </read_first>
+  <action>
+Addresses review concern: preserve the narrow blast radius and catch any internal callers that previously relied on `WithGroupBy(nil)` being silently accepted.
+
+Run the broader V2 test suite and lint after the focused fix is green:
+
+```bash
+make test
+make lint
+```
+
+If `make test` surfaces regressions in `pkg/api/v2/groupby_test.go` or nearby V2 search tests, fix only issues caused by the nil-contract change. Do not expand scope into unrelated search or group-by redesign work, do not add docs/example updates, and do not audit other `WithX` options in this phase.
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/GolandProjects/chroma-go && make test && make lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - `make test` exits 0
+    - `make lint` exits 0
+    - Existing valid non-nil `TestWithGroupBy` behavior still passes
+    - Existing invalid non-nil `GroupBy` validation tests still pass without changing their expected error families
+  </acceptance_criteria>
+  <done>The phase fix is regression-safe across the V2 suite and lint-clean.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller option input -> request construction | Public SDK callers provide `SearchRequestOption`s that the client converts into a request payload |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-22-01 | T (Tampering) | `WithGroupBy(nil)` option handling | mitigate | Reject explicit nil with `groupBy cannot be nil` before request append/send so caller intent cannot be silently downgraded |
+| T-22-02 | D (Denial of Service) | search request construction | accept | No new recursion, allocation, or I/O path is added; change is a constant-time validation branch |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` passes
+2. `make test` passes
+3. `make lint` passes
+4. `pkg/api/v2/search.go` contains the exact nil-error string `groupBy cannot be nil`
+5. `pkg/api/v2/groupby_test.go` asserts the exact nil-error string with `require.EqualError`
+6. The request-construction regression proves `sq.Searches` remains length 0 when `WithGroupBy(nil)` is used
+</verification>
+
+<success_criteria>
+- Explicit `WithGroupBy(nil)` returns a validation error before the request is sent (GRP-01)
+- Omitting `WithGroupBy(...)` remains the only way to mean "no grouping"
+- Valid non-nil `GroupBy` calls continue to work as before
+- The nil contract is pinned by exact-error unit tests and a `NewSearchRequest(...)` regression test
+- V2 tests and lint stay green
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/22-withgroupby-validation/22-01-SUMMARY.md`
+</output>

--- a/.planning/phases/22-withgroupby-validation/22-01-SUMMARY.md
+++ b/.planning/phases/22-withgroupby-validation/22-01-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 22-withgroupby-validation
+plan: 01
+subsystem: api
+tags: [go, v2, search, groupby, validation]
+requires: []
+provides:
+  - fail-fast nil validation for WithGroupBy during search request construction
+  - exact regression coverage for direct and NewSearchRequest WithGroupBy(nil) paths
+affects: [search, groupby, validation]
+tech-stack:
+  added: []
+  patterns: [fail-fast option validation, colocated v2 regression tests]
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/search.go
+    - pkg/api/v2/groupby_test.go
+key-decisions:
+  - "Kept nil handling in groupByOption.ApplyToSearchRequest with a direct errors.New(\"groupBy cannot be nil\") message."
+  - "Pinned both the direct option path and the composed NewSearchRequest path without changing non-nil GroupBy validation."
+patterns-established:
+  - "Explicit nil option input is rejected at ApplyToSearchRequest before request mutation or append."
+  - "Nil-contract bug fixes in pkg/api/v2 keep valid and invalid non-nil coverage in the same colocated test file."
+requirements-completed: [GRP-01]
+duration: 5m
+completed: 2026-04-10
+---
+
+# Phase 22 Plan 01: WithGroupBy Validation Summary
+
+**WithGroupBy(nil) now fails fast with a stable validation error before search requests are appended or sent.**
+
+## Performance
+
+- **Duration:** 5m
+- **Started:** 2026-04-10T04:35:20Z
+- **Completed:** 2026-04-10T04:40:17Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Replaced the silent nil no-op in `groupByOption.ApplyToSearchRequest` with the exact error `groupBy cannot be nil`.
+- Added regression coverage for both direct `WithGroupBy(nil)` application and `NewSearchRequest(..., WithGroupBy(nil))` fail-before-append behavior.
+- Preserved existing valid and invalid non-nil `GroupBy` behavior and cleared the focused, full, and lint verification commands.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Replace nil-no-op behavior with fail-fast validation and pin it with direct + request-construction tests** - `40db705` (test), `508c19a` (feat)
+2. **Task 2: Run broader V2 regressions and lint** - `3525b36` (test)
+
+## Files Created/Modified
+- `pkg/api/v2/search.go` - rejects explicit nil `WithGroupBy` input before request mutation.
+- `pkg/api/v2/groupby_test.go` - asserts the exact nil error and the no-append regression while retaining non-nil coverage.
+
+## Decisions Made
+- Kept the nil error as a direct string in `pkg/api/v2/search.go` instead of introducing a new exported sentinel, matching existing repo validation style.
+- Left `pkg/api/v2/groupby.go` unchanged so non-nil validation continues to flow through `(*GroupBy).Validate()` exactly as before.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Phase 22's `GRP-01` contract is implemented and regression-covered.
+- No blockers were found for subsequent v0.4.2 bug-fix phases.
+
+## Verification Evidence
+
+- `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` -> failed in RED, then passed after the implementation change.
+- `make test` -> passed (`DONE 1729 tests, 7 skipped in 30.110s`).
+- `make lint` -> passed (`0 issues.`).
+
+## Self-Check: PASSED
+
+- Verified `.planning/phases/22-withgroupby-validation/22-01-SUMMARY.md` exists on disk.
+- Verified task commits `40db705`, `508c19a`, and `3525b36` exist in git history.

--- a/.planning/phases/22-withgroupby-validation/22-CONTEXT.md
+++ b/.planning/phases/22-withgroupby-validation/22-CONTEXT.md
@@ -1,0 +1,107 @@
+# Phase 22: WithGroupBy Validation - Context
+
+**Gathered:** 2026-04-09
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Fix `WithGroupBy` so explicitly passing `nil` returns a clear validation error during request construction instead of silently omitting grouping. Keep existing non-nil `GroupBy` behavior and search request serialization unchanged.
+
+**In scope:**
+- Fail fast when callers explicitly invoke `WithGroupBy(nil)`
+- Return a nil-specific validation error before any request is sent
+- Preserve current behavior for valid non-nil `GroupBy` values
+- Add/update colocated V2 tests for the new contract
+
+**Out of scope:**
+- Broader redesign of search option nil-handling semantics
+- Any change to valid `GroupBy` JSON shape or aggregate/key validation rules
+- Docs/examples updates for group-by behavior in this phase
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Nil handling contract
+- **D-01:** `WithGroupBy(nil)` is invalid and must fail fast during request construction/application; it is no longer treated as a silent no-op.
+- **D-02:** Callers who want "no grouping" must omit the `WithGroupBy(...)` option entirely rather than passing `nil`.
+
+### Error contract
+- **D-03:** The nil failure must use a stable, nil-specific validation message so tests can assert exact text.
+- **D-04:** The error should be returned from the option application path before any search request can be marshaled or sent.
+
+### Scope and verification
+- **D-05:** Phase 22 stays code-and-tests only; no docs/examples update is required for this bug fix.
+- **D-06:** Existing valid non-nil `GroupBy` flows must remain unchanged, so regression coverage should include both the new nil-error path and a passing non-nil path.
+
+### the agent's Discretion
+- Exact nil-specific error wording, as long as it is stable and follows existing repo style for validation errors
+- Whether to introduce a dedicated exported error constant or keep the stable message as an unexported direct error
+- Exact unit-test structure in `groupby_test.go`
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Milestone scope
+- `.planning/ROADMAP.md` — Phase 22 goal, requirement mapping, and success criteria
+- `.planning/REQUIREMENTS.md` — `GRP-01` requires `WithGroupBy(nil)` to return a validation error instead of silently skipping grouping
+- `.planning/PROJECT.md` — v0.4.2 milestone context and issue `#482` bug statement
+
+### Implementation targets
+- `pkg/api/v2/search.go` — `WithGroupBy` and `groupByOption.ApplyToSearchRequest` currently treat nil as a no-op
+- `pkg/api/v2/groupby.go` — existing `GroupBy.Validate()` behavior for non-nil values
+- `pkg/api/v2/groupby_test.go` — current `TestWithGroupBy` coverage, including the nil-no-op case to replace
+
+### Repo conventions
+- `.planning/codebase/CONVENTIONS.md` — repo style for early validation and direct `"X cannot be nil"` error messages
+- `.planning/codebase/TESTING.md` — colocated V2 tests, `require`-based assertions, and build-tag expectations
+- `CLAUDE.md` — V2-first changes and colocated-test expectations
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `(*GroupBy).Validate()` in `pkg/api/v2/groupby.go` already enforces non-nil aggregate and required keys for valid group-by values
+- `TestWithGroupBy` and `TestSearchRequestWithGroupBy` in `pkg/api/v2/groupby_test.go` already cover valid and invalid non-nil cases and provide the natural place for nil-contract tests
+
+### Established Patterns
+- Search option validation happens in `ApplyToSearchRequest` before request marshaling/sending
+- The repo commonly uses direct nil-validation messages like `"tenant cannot be nil"` and `"database cannot be nil"`
+- Public V2 bug fixes are tested with colocated unit tests under `pkg/api/v2/*_test.go`
+
+### Integration Points
+- `pkg/api/v2/search.go`: change the nil branch in `groupByOption.ApplyToSearchRequest`
+- `pkg/api/v2/groupby_test.go`: replace the existing nil-no-op expectation with fail-fast error assertions and keep a passing valid case
+- Any regression test that builds a `SearchRequest` through `NewSearchRequest(...)` should continue to pass for non-nil `GroupBy`
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Best DX is explicit failure: "fail and fail fast, clear message and invariants enforced right away."
+- The nil case should be treated as programmer error, not as shorthand for "skip grouping."
+- No specific doc wording requested because this phase is intentionally code+tests only.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Public docs/examples note that `WithGroupBy(nil)` is invalid — intentionally deferred because this phase is code+tests only
+- Broader audit of other option setters that may still treat explicit `nil` as a no-op — separate consistency phase if needed
+
+</deferred>
+
+---
+
+*Phase: 22-withgroupby-validation*
+*Context gathered: 2026-04-09*

--- a/.planning/phases/22-withgroupby-validation/22-DISCUSSION-LOG.md
+++ b/.planning/phases/22-withgroupby-validation/22-DISCUSSION-LOG.md
@@ -1,0 +1,64 @@
+# Phase 22: WithGroupBy Validation - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-09
+**Phase:** 22-WithGroupBy Validation
+**Areas discussed:** Nil contract, Error message strictness, Docs surface
+
+---
+
+## Nil contract
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Fail fast with clear error *(Recommended)* | Treat explicit `WithGroupBy(nil)` as invalid and return an error before request construction completes. Omit the option entirely to skip grouping. | ✓ |
+| Backward-compatible no-op | Keep current behavior where `WithGroupBy(nil)` silently does nothing. | |
+| Normalize nil internally | Accept nil and silently translate it into "no grouping" or an empty internal value. | |
+
+**User's choice:** Fail fast with clear error
+**Notes:** User explicitly preferred the better DX: fail fast, keep invariants enforced immediately, and avoid silent behavior.
+
+---
+
+## Error message strictness
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Stable exact nil-specific message *(Recommended)* | Choose one clear nil-validation message and assert it exactly in tests so the contract stays stable. | ✓ |
+| Any clear validation error | Only require that an error occurs and roughly mentions nil/invalid input. | |
+| Bubble generic validation error | Let implementation details determine message shape without locking exact text. | |
+
+**User's choice:** Stable exact nil-specific message
+**Notes:** User did not require a specific string in discussion, but did require message stability for tests and caller expectations.
+
+---
+
+## Docs surface
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Code+tests only *(Recommended)* | Keep this phase bounded to implementation and tests; no docs/examples updates. | ✓ |
+| Add short docs note | Update group-by docs with a one-line nil-invalid note. | |
+| Full docs sweep | Review all search/group-by docs and examples for nil-contract messaging. | |
+
+**User's choice:** Code+tests only
+**Notes:** User kept scope tightly bounded to the bug fix and regression coverage.
+
+---
+
+## the agent's Discretion
+
+- Exact nil-specific message wording, as long as it stays stable and repo-consistent
+- Whether the stable error is represented by a direct error or a dedicated exported sentinel
+- Exact test naming and organization in `groupby_test.go`
+
+## Deferred Ideas
+
+1. Docs/examples note for invalid nil usage — deferred to keep Phase 22 code+tests only
+2. Broader nil-handling consistency audit across other option setters — potential future cleanup phase
+
+---
+
+*Discussion log generated: 2026-04-09*

--- a/.planning/phases/22-withgroupby-validation/22-RESEARCH.md
+++ b/.planning/phases/22-withgroupby-validation/22-RESEARCH.md
@@ -1,0 +1,185 @@
+# Phase 22: WithGroupBy Validation - Research
+
+**Researched:** 2026-04-09
+**Domain:** Go V2 Search API option validation and request construction
+**Confidence:** HIGH (phase is localized to one option path and colocated tests)
+
+## Summary
+
+Phase 22 is a narrow contract fix in `pkg/api/v2/search.go`. Today, `groupByOption.ApplyToSearchRequest` returns `nil` when `o.groupBy == nil`, which silently turns an explicit `WithGroupBy(nil)` call into "omit grouping." That behavior violates `GRP-01` and the phase goal.
+
+The implementation change should stay small:
+- change the nil branch in `groupByOption.ApplyToSearchRequest` from silent success to a deterministic validation error
+- keep non-nil validation delegated to `(*GroupBy).Validate()`
+- update `pkg/api/v2/groupby_test.go` so the nil path asserts the exact stable error string and valid non-nil behavior still passes
+- add one higher-level regression that proves `NewSearchRequest(..., WithGroupBy(nil))` fails before the search request is appended or sent
+
+`pkg/api/v2/groupby.go` already enforces non-nil aggregate and required keys for valid `GroupBy` instances and does not need semantic changes for this phase.
+
+**Primary recommendation:** Use a direct nil-validation message consistent with existing repo style, specifically `groupBy cannot be nil`, and keep the entire fix within `pkg/api/v2/search.go` and `pkg/api/v2/groupby_test.go`.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01:** `WithGroupBy(nil)` is invalid and must fail fast during request construction/application; it is no longer treated as a silent no-op.
+- **D-02:** Callers who want "no grouping" must omit the `WithGroupBy(...)` option entirely rather than passing `nil`.
+- **D-03:** The nil failure must use a stable, nil-specific validation message so tests can assert exact text.
+- **D-04:** The error should be returned from the option application path before any search request can be marshaled or sent.
+- **D-05:** Phase 22 stays code-and-tests only; no docs/examples update is required.
+- **D-06:** Existing valid non-nil `GroupBy` flows must remain unchanged.
+
+### Claude's Discretion
+- Exact nil-specific message text, as long as it is stable and matches repo style
+- Whether to keep the nil error as a direct `errors.New(...)` string or promote it to a package-level variable
+- Exact unit-test structure inside `groupby_test.go`
+
+### Deferred Ideas (OUT OF SCOPE)
+- Broader audit of other option setters that may still treat explicit `nil` as a no-op
+- Any redesign of `GroupBy` JSON shape or aggregate validation
+- Docs/examples updates
+</user_constraints>
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|-----------------|
+| GRP-01 | `WithGroupBy(nil)` returns a validation error instead of silently skipping grouping | Direct nil guard in `groupByOption.ApplyToSearchRequest`, exact-error regression test, and request-construction regression test |
+
+## Project Constraints
+
+| Constraint | Source | Impact on This Phase |
+|-----------|--------|----------------------|
+| New work targets V2 API | `CLAUDE.md` | All changes stay in `pkg/api/v2/` |
+| Library code should fail with errors, not panic | `CLAUDE.md` | Use early validation in the option path; no runtime panics |
+| Validation messages are direct and user-readable | `.planning/codebase/CONVENTIONS.md` | Prefer a simple stable string such as `groupBy cannot be nil` |
+| Colocated tests with existing build tags | `.planning/codebase/TESTING.md`, `CLAUDE.md` | Keep changes in `pkg/api/v2/groupby_test.go` under `//go:build basicv2 && !cloud` |
+| `require` assertions are standard | `.planning/codebase/TESTING.md` | Use `require.EqualError`, `require.NoError`, `require.Nil`, `require.Len` |
+
+## Standard Stack
+
+No new dependencies are needed.
+
+| Package | Purpose | Status |
+|---------|---------|--------|
+| `github.com/pkg/errors` | direct validation error in `search.go` | already imported |
+| `github.com/stretchr/testify/require` | exact error and regression assertions | already used in `groupby_test.go` |
+| Go stdlib `encoding/json` | existing request serialization checks | already used in `groupby_test.go` |
+
+## Architecture Patterns
+
+### Recommended File Layout
+
+```
+pkg/api/v2/
+├── search.go         # change WithGroupBy nil handling
+└── groupby_test.go   # replace nil-no-op test and add request-construction regression
+```
+
+### Pattern 1: Fail fast in the option application path
+
+The existing option path is already the correct validation boundary. Keep the nil guard in `groupByOption.ApplyToSearchRequest`, but make it return an error instead of silently succeeding.
+
+```go
+// Source: pkg/api/v2/search.go:631-642 (update nil branch only)
+func (o *groupByOption) ApplyToSearchRequest(req *SearchRequest) error {
+	if o.groupBy == nil {
+		return errors.New("groupBy cannot be nil")
+	}
+	if err := o.groupBy.Validate(); err != nil {
+		return err
+	}
+	req.GroupBy = o.groupBy
+	return nil
+}
+```
+
+Why here:
+- it satisfies D-04 because the error happens before request serialization or network I/O
+- it preserves valid `GroupBy` validation through the existing `Validate()` method
+- it keeps omission semantics intact for callers who simply do not supply the option
+
+### Pattern 2: Preserve valid non-nil behavior unchanged
+
+`(*GroupBy).Validate()` in `pkg/api/v2/groupby.go` already enforces:
+- aggregate is required
+- aggregate itself validates
+- at least one grouping key is required
+
+Do not move nil-handling into `GroupBy.Validate()` or `MarshalJSON()`. That would shift the failure later than required and would not distinguish "explicit nil option passed" from "no option provided."
+
+### Pattern 3: Test both the direct option path and the request-construction path
+
+The current nil test only checks `WithGroupBy(nil).ApplyToSearchRequest(req)`. Phase 22 should also pin the higher-level contract that `NewSearchRequest(...)` fails before it appends a search.
+
+Recommended coverage:
+- `TestWithGroupBy/nil groupby returns exact validation error`
+  - `err := WithGroupBy(nil).ApplyToSearchRequest(req)`
+  - assert `require.EqualError(t, err, "groupBy cannot be nil")`
+  - assert `require.Nil(t, req.GroupBy)`
+- keep `apply valid groupby to search request`
+- keep invalid non-nil cases unchanged
+- add `TestSearchRequestWithGroupBy/search with nil groupby fails before append`
+  - build a `SearchQuery{}`
+  - call `NewSearchRequest(WithKnnRank(...), WithGroupBy(nil))`
+  - assert error text is exact
+  - assert `require.Len(t, sq.Searches, 0)`
+
+### Pattern 4: Keep omission semantics by omission, not nil
+
+Because `SearchRequest.GroupBy` is tagged `json:"group_by,omitempty"`, callers who want no grouping already get the correct behavior by not adding `WithGroupBy(...)`. The phase should not add any alternate sentinel behavior for nil.
+
+## Common Pitfalls
+
+### Pitfall 1: Returning the nil error too late
+If the nil error is raised from `MarshalJSON()` or a collection method, the contract "before the request is sent" is weaker and easier to regress. Keep the check in `ApplyToSearchRequest`.
+
+### Pitfall 2: Using a fuzzy error assertion
+The context explicitly asks for a stable nil-specific message. Prefer `require.EqualError` over `require.Contains` so the contract is pinned exactly.
+
+### Pitfall 3: Forgetting the higher-level request regression
+Only testing `ApplyToSearchRequest` leaves the `NewSearchRequest(...)` composition path unpinned. Add one request-construction regression so a future refactor cannot accidentally swallow the error while still leaving the direct unit test green.
+
+### Pitfall 4: Modifying `groupby.go` unnecessarily
+This phase is not a redesign of `GroupBy`. Changing constructor or JSON behavior would expand scope without helping `GRP-01`.
+
+## Threat Model Notes
+
+This phase does not introduce a new trust boundary, external input channel, or privileged operation. The relevant defect is correctness and safety of client-side request construction:
+- **Threat:** explicit programmer input (`WithGroupBy(nil)`) is silently downgraded into omitted grouping, causing unexpected query semantics
+- **Severity:** low correctness / DX issue, not a security exploit
+- **Mitigation:** deterministic fail-fast validation in the option application path with a stable message
+
+No high-severity threats are introduced or required to be mitigated beyond the fail-fast validation behavior above.
+
+## Validation Architecture
+
+### Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| Framework | `go test` |
+| Config file | `Makefile` and existing `basicv2` build tag |
+| Quick run command | `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` |
+| Full suite command | `make test` |
+| Lint command | `make lint` |
+| Estimated runtime | quick run ~5s, full suite depends on local cache but typically short for V2-only scope |
+
+### Verification Strategy
+
+- Run the focused V2 tests after the implementation change to prove the nil-contract change without waiting on the full suite.
+- Run `make test` before closing the phase to confirm no broader V2 regressions.
+- Run `make lint` before phase completion because the repo treats lint as a standard pre-ship guard.
+- No manual-only verification is required; the behavior is fully automatable with unit tests.
+
+### Required Assertions
+
+- Exact error string for explicit nil input: `groupBy cannot be nil`
+- `req.GroupBy` remains `nil` on the error path
+- Non-nil valid `GroupBy` still applies successfully
+- Non-nil invalid `GroupBy` still returns the existing validation errors
+- `NewSearchRequest(..., WithGroupBy(nil))` returns the error before any search is appended
+
+---
+
+_Research synthesized locally on 2026-04-09 after GSD researcher subagents stalled in this session._

--- a/.planning/phases/22-withgroupby-validation/22-REVIEW.md
+++ b/.planning/phases/22-withgroupby-validation/22-REVIEW.md
@@ -1,0 +1,63 @@
+---
+phase: 22-withgroupby-validation
+reviewed: 2026-04-10T04:45:37Z
+depth: standard
+files_reviewed: 2
+files_reviewed_list:
+  - pkg/api/v2/search.go
+  - pkg/api/v2/groupby_test.go
+findings:
+  critical: 0
+  warning: 1
+  info: 0
+  total: 1
+status: issues_found
+---
+
+# Phase 22: Code Review Report
+
+**Reviewed:** 2026-04-10T04:45:37Z
+**Depth:** standard
+**Files Reviewed:** 2
+**Status:** issues_found
+
+## Summary
+
+Reviewed the `WithGroupBy` nil-validation change in `pkg/api/v2/search.go` and the new coverage in `pkg/api/v2/groupby_test.go`. The targeted tests pass locally, but the phase changes the behavior of a public option from a no-op to a hard error, which is a compatibility regression for callers that build option lists with an optional `*GroupBy`.
+
+Targeted verification:
+
+```bash
+go test -tags=basicv2 ./pkg/api/v2 -run 'Test(MinK|MaxK|GroupBy|WithGroupBy|SearchRequestWithGroupBy)$'
+```
+
+Passed locally.
+
+## Warnings
+
+### WR-01: `WithGroupBy(nil)` is now a breaking API change
+
+**File:** `pkg/api/v2/search.go:635-638`
+**Issue:** Prior to this phase, passing `WithGroupBy(nil)` was effectively a no-op because `ApplyToSearchRequest` returned `nil` without mutating the request. The new branch now returns `groupBy cannot be nil`, and the updated tests lock that behavior in. That breaks any existing caller that conditionally threads a `*GroupBy` through an option list and uses `nil` to mean "no grouping". For a public functional-option API, that is a behavior regression rather than a pure validation improvement.
+**Fix:**
+
+```go
+func (o *groupByOption) ApplyToSearchRequest(req *SearchRequest) error {
+	if o.groupBy == nil {
+		return nil
+	}
+	if err := o.groupBy.Validate(); err != nil {
+		return err
+	}
+	req.GroupBy = o.groupBy
+	return nil
+}
+```
+
+If strict rejection of explicit `nil` is required, ship it as a documented breaking change (or under a new strict helper) instead of changing the existing option semantics in place.
+
+---
+
+_Reviewed: 2026-04-10T04:45:37Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/22-withgroupby-validation/22-REVIEWS.md
+++ b/.planning/phases/22-withgroupby-validation/22-REVIEWS.md
@@ -1,0 +1,105 @@
+---
+phase: 22
+reviewers: [gemini, claude]
+reviewed_at: 2026-04-10T04:09:27Z
+plans_reviewed: [22-01-PLAN.md]
+---
+
+# Cross-AI Plan Review — Phase 22
+
+## Gemini Review
+
+# Phase 22 Plan Review: WithGroupBy Validation
+
+## Summary
+The plan for Phase 22 is a well-scoped and surgical fix for issue #482. It correctly identifies the failure point in `groupByOption.ApplyToSearchRequest` and proposes a fail-fast validation approach. The inclusion of both direct unit tests and higher-level request-construction regression tests ensures the fix is robust against future refactoring of the option application logic.
+
+## Strengths
+*   **TDD-First Approach:** The plan explicitly calls for updating tests to a "RED" state before applying the fix, ensuring the tests actually catch the defect.
+*   **Multi-Level Verification:** By testing both the `ApplyToSearchRequest` method directly and the `NewSearchRequest` composition path, the plan provides defense-in-depth against silent failures.
+*   **Adherence to Conventions:** The choice of error message (`"groupBy cannot be nil"`) and the use of `require.EqualError` perfectly align with the project's established standards for early validation.
+*   **Minimal Surface Area:** The implementation is contained within two files and avoids unnecessary changes to the `GroupBy` struct or its internal validation logic, staying strictly focused on the option contract.
+
+## Concerns
+*   **Error Equality vs. Wrapping (LOW):** The plan uses `errors.New("groupBy cannot be nil")`. While consistent with local patterns, if the project moves toward structured error types in the future, this might need refactoring. For now, it is appropriate given the current `CONVENTIONS.md`.
+*   **Build Tag Coverage (LOW):** The plan assumes the tests will run under `basicv2`. Since `groupby_test.go` already has this tag, the risk is minimal, but the implementation should be careful not to introduce dependencies that break this segregation.
+
+## Suggestions
+*   **Standardized Error (Optional):** If `groupBy cannot be nil` is expected to be a common failure point for programmatic consumers, consider if a package-level `ErrNilGroupBy` would be beneficial. However, for a simple validation guard, the direct string approach is likely sufficient for this SDK.
+*   **Check other options (Audit):** While out of scope for *this* phase, a future task should audit other `WithX` options to ensure they don't also silently swallow `nil` when they shouldn't.
+
+## Risk Assessment: LOW
+The plan addresses a specific, isolated bug with clear requirements and proven testing patterns. The risk of regression is extremely low due to the focused nature of the change and the comprehensive automated validation steps.
+
+---
+
+## Claude Review
+
+# Phase 22 Plan Review: WithGroupBy Validation
+
+## Summary
+
+This is a well-scoped, low-risk plan for a narrow contract fix. The two-task structure (focused fix + broad regression) is appropriate for the change size. The TDD approach (red-green) is sound, and the plan correctly identifies both the direct option path and the composed `NewSearchRequest` path as needing coverage. The plan does exactly what GRP-01 requires and nothing more.
+
+## Strengths
+
+- **Minimal blast radius**: Only two files modified (`search.go`, `groupby_test.go`), zero changes to `groupby.go` — correctly preserves existing `Validate()` semantics
+- **TDD discipline**: Tests written first (RED), then implementation (GREEN) — this ensures the test actually catches the bug before the fix lands
+- **Two-level test coverage**: Both the direct `ApplyToSearchRequest` path and the composed `NewSearchRequest(...)` path are pinned, preventing future refactors from silently swallowing the error at either level
+- **Exact-error assertions**: Using `require.EqualError` instead of `require.Contains` pins the contract tightly per D-03
+- **Scope discipline**: No changes to `groupby.go`, no docs updates, no broader nil-audit — stays within phase boundary
+- **Error placement is correct**: The nil check in `ApplyToSearchRequest` fires before `req.GroupBy` is mutated and before `SearchQuery.Searches` is appended — satisfying D-04
+
+## Concerns
+
+- **LOW — No explicit test that `req.GroupBy` stays nil in the request-construction regression**: Task 1's `TestSearchRequestWithGroupBy/"search with nil groupby fails before append"` asserts `sq.Searches` length is 0 but doesn't explicitly verify the `SearchRequest` wasn't partially mutated. This is implicitly true (the request is local and discarded on error), but an explicit assertion would be marginally stronger. Not worth blocking on — the direct-path test already covers `require.Nil(t, req.GroupBy)`.
+
+- **LOW — `errors.New` vs `errors.Errorf` consistency**: The plan uses `errors.New("groupBy cannot be nil")` from `github.com/pkg/errors`, which is consistent with `groupby.go`'s existing pattern (`errors.New("aggregate is required")`). No issue, just noting the consistency is good.
+
+- **LOW — No explicit negative test for "omit WithGroupBy entirely"**: The plan relies on existing tests to cover the "no WithGroupBy option at all" path. This is fine because that path is already exercised by other `TestSearchRequestWithGroupBy` subtests that don't include `WithGroupBy`, but a one-liner comment in the plan acknowledging this would improve clarity.
+
+## Suggestions
+
+- **Consider adding a brief comment in the test explaining *why* nil is invalid**: Something like `// WithGroupBy(nil) is a programmer error; omit the option for "no grouping"`. This helps future contributors understand the design intent without reading CONTEXT.md. That said, the user's CLAUDE.md says "Do not leave too many or too verbose comments" — so this is discretionary.
+
+- **Task 1 step ordering could be tighter**: The plan says "Run the focused tests and expect failure before the implementation change" — this is correct TDD but the bash command appears *between* the test changes and the implementation changes. In practice the executor will handle this, but explicitly labeling it as "confirm RED" would be clearer.
+
+- **The plan could note that `errors` is already imported in `search.go`**: The research doc mentions it, but the plan's Task 1 action block doesn't. An executor agent unfamiliar with the file might waste a step checking. Minor.
+
+## Risk Assessment
+
+**LOW**
+
+Justification:
+- Single-line production code change (`return nil` → `return errors.New(...)`)
+- No new dependencies, no new files, no API surface changes beyond tightening a nil contract
+- Both verification levels (focused + full suite) are automated
+- The change is strictly additive in terms of validation — it rejects input that was previously silently accepted, which is a safe direction for a bug fix
+- No concurrency, no I/O, no allocation changes — constant-time validation branch
+- The existing test structure already has the right subtests; only one needs replacement and one needs addition
+
+The only realistic failure mode is a downstream caller in the repo's own test suite that intentionally passes `WithGroupBy(nil)` expecting success — and the plan's Task 2 (`make test`) would catch that immediately.
+
+---
+
+## Consensus Summary
+
+Both reviewers consider the phase plan well-scoped, low-risk, and correctly aligned to `GRP-01`. Neither review surfaced a blocking gap or redesign request.
+
+### Agreed Strengths
+
+- The plan keeps the blast radius tight by limiting the implementation to `pkg/api/v2/search.go` and `pkg/api/v2/groupby_test.go`, while preserving existing non-nil `GroupBy` validation behavior.
+- The RED -> GREEN structure is appropriate for this bug fix and is strengthened by testing both the direct `ApplyToSearchRequest` path and the composed `NewSearchRequest(...)` path.
+- The exact error contract `groupBy cannot be nil` fits existing repo validation conventions and makes the regression easy to pin with `require.EqualError`.
+
+### Agreed Concerns
+
+- No shared medium- or high-severity concerns were raised. The only overlap was low-priority future-facing guidance around error-contract standardization and broader consistency across other `WithX` options.
+- If the SDK later formalizes reusable validation errors, this nil-contract may be a candidate for a package-level sentinel instead of a direct string, but both reviewers consider the current string-based approach acceptable for this phase.
+- A broader audit of other option setters that may silently swallow explicit `nil` would be worthwhile as separate follow-up work, but both reviews treat that as out of scope here.
+
+### Divergent Views
+
+- Gemini called out build-tag segregation as a minor execution concern; Claude did not.
+- Claude suggested marginally stronger clarity around the request-construction regression and plan wording, including an explicit note about omitting `WithGroupBy` entirely and tighter labeling of the RED verification step; Gemini did not raise those points.
+- Claude suggested a small explanatory test comment might help future maintainers, while Gemini stayed focused on contract and architecture concerns.

--- a/.planning/phases/22-withgroupby-validation/22-VALIDATION.md
+++ b/.planning/phases/22-withgroupby-validation/22-VALIDATION.md
@@ -1,0 +1,69 @@
+---
+phase: 22
+slug: withgroupby-validation
+status: draft
+nyquist_compliant: false
+wave_0_complete: true
+created: 2026-04-09
+---
+
+# Phase 22 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | `go test` |
+| **Config file** | `Makefile` / existing `basicv2` build tag |
+| **Quick run command** | `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` |
+| **Full suite command** | `make test` |
+| **Estimated runtime** | ~5s focused / longer for full V2 suite |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...`
+- **After every plan wave:** Run `make test`
+- **Before `/gsd-verify-work`:** `make test` and `make lint` must be green
+- **Max feedback latency:** 30 seconds for focused feedback
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 22-01-01 | 01 | 1 | GRP-01 | T-22-01 / — | Explicit `WithGroupBy(nil)` is rejected before request mutation or send | unit | `go test -tags=basicv2 -run TestWithGroupBy ./pkg/api/v2/...` | ✅ | ⬜ pending |
+| 22-01-02 | 01 | 1 | GRP-01 | T-22-01 / — | `NewSearchRequest(..., WithGroupBy(nil))` returns the same validation error and appends no search | unit | `go test -tags=basicv2 -run TestSearchRequestWithGroupBy ./pkg/api/v2/...` | ✅ | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+Existing infrastructure covers all phase requirements.
+
+---
+
+## Manual-Only Verifications
+
+All phase behaviors have automated verification.
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/22-withgroupby-validation/22-VERIFICATION.md
+++ b/.planning/phases/22-withgroupby-validation/22-VERIFICATION.md
@@ -1,0 +1,82 @@
+---
+phase: 22-withgroupby-validation
+verified: 2026-04-10T04:51:04Z
+status: passed
+score: 6/6 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 22: WithGroupBy Validation Verification Report
+
+**Phase Goal:** WithGroupBy rejects nil input with a clear error  
+**Verified:** 2026-04-10T04:51:04Z  
+**Status:** passed  
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Passing nil to `WithGroupBy` returns a validation error before the request is sent | ✓ VERIFIED | `pkg/api/v2/search.go:635-643` now rejects `nil` immediately; uncached `go test -count=1 -tags=basicv2 -run 'TestWithGroupBy\|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` passed. |
+| 2 | Non-nil `WithGroupBy` calls continue to work as before | ✓ VERIFIED | Valid non-nil values still flow through `o.groupBy.Validate()` and `req.GroupBy = o.groupBy` in `pkg/api/v2/search.go:639-642`; valid direct and full-search coverage pass in `pkg/api/v2/groupby_test.go:183-190` and `pkg/api/v2/groupby_test.go:240-275`. |
+| 3 | Explicit `WithGroupBy(nil)` returns the exact error `groupBy cannot be nil` before any request append | ✓ VERIFIED | Exact string is emitted at `pkg/api/v2/search.go:636-638` and asserted directly at `pkg/api/v2/groupby_test.go:193-197` and `pkg/api/v2/groupby_test.go:290-300`. |
+| 4 | Omitting `WithGroupBy(...)` remains the way to request no grouping | ✓ VERIFIED | `NewSearchRequest` only applies provided options in `pkg/api/v2/search.go:658-666`; if `WithGroupBy` is omitted, no `groupByOption` runs and `SearchRequest.GroupBy` remains nil. |
+| 5 | `NewSearchRequest(..., WithGroupBy(nil))` fails before appending a partial request to `SearchQuery.Searches` | ✓ VERIFIED | `NewSearchRequest` returns on option error before `append` in `pkg/api/v2/search.go:661-666`; `pkg/api/v2/groupby_test.go:290-300` asserts the exact nil error and `require.Len(t, sq.Searches, 0)`. |
+| 6 | `pkg/api/v2/groupby_test.go` pins the nil-error contract while keeping valid non-nil coverage in place | ✓ VERIFIED | `pkg/api/v2/groupby_test.go:182-215` covers direct valid/nil/invalid option application, and `pkg/api/v2/groupby_test.go:240-300` covers valid request construction plus nil fail-before-append. |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `pkg/api/v2/search.go` | Fail-fast nil validation for `WithGroupBy` | ✓ VERIFIED | File exists and is substantive (940 lines). `groupByOption.ApplyToSearchRequest` rejects `nil` with `groupBy cannot be nil` at `pkg/api/v2/search.go:635-638`, preserves non-nil validation at `pkg/api/v2/search.go:639-640`, and appends only after successful option application at `pkg/api/v2/search.go:658-666`. |
+| `pkg/api/v2/groupby_test.go` | Exact-error regression coverage for nil and non-nil `WithGroupBy` behavior | ✓ VERIFIED | File exists and is substantive (302 lines). Direct nil-error coverage is at `pkg/api/v2/groupby_test.go:193-197`; request-construction nil/no-append coverage is at `pkg/api/v2/groupby_test.go:290-300`; valid non-nil coverage remains at `pkg/api/v2/groupby_test.go:183-190` and `pkg/api/v2/groupby_test.go:240-275`. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `pkg/api/v2/search.go` `groupByOption.ApplyToSearchRequest` | `pkg/api/v2/groupby_test.go` `TestWithGroupBy` | Exact nil-error contract for explicit `WithGroupBy(nil)` | WIRED | `pkg/api/v2/groupby_test.go:195-197` calls `WithGroupBy(nil).ApplyToSearchRequest(req)` and asserts `require.EqualError(t, err, "groupBy cannot be nil")`; adjacent subtests cover valid and invalid non-nil inputs. |
+| `pkg/api/v2/search.go` `NewSearchRequest` option application | `pkg/api/v2/groupby_test.go` `TestSearchRequestWithGroupBy` | Nil groupby request-construction regression | WIRED | `pkg/api/v2/groupby_test.go:293-300` constructs `NewSearchRequest(..., WithGroupBy(nil))` and asserts the exact error and zero appended searches; the valid path at `pkg/api/v2/groupby_test.go:243-275` proves successful append when `GroupBy` is non-nil and valid. |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+| --- | --- | --- | --- | --- |
+| `pkg/api/v2/search.go:635-643` | `req.GroupBy` | Caller-provided `o.groupBy`, guarded by `(*GroupBy).Validate()` in `pkg/api/v2/groupby.go:30-40` | Yes — valid non-nil `GroupBy` values are assigned unchanged; explicit nil is rejected before mutation | ✓ FLOWING |
+| `pkg/api/v2/search.go:658-666` | `SearchQuery.Searches` | Local `search` built by applying each `SearchRequestOption` in order | Yes — successful options append one request, and failing `WithGroupBy(nil)` short-circuits before append | ✓ FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Nil `WithGroupBy` is rejected in both direct and request-construction paths | `go test -count=1 -tags=basicv2 -run 'TestWithGroupBy\|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.448s` | ✓ PASS |
+| `GroupBy` validation plus `WithGroupBy` regressions still pass | `go test -count=1 -tags=basicv2 -run 'TestGroupBy\|TestWithGroupBy\|TestSearchRequestWithGroupBy' ./pkg/api/v2/...` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.628s` | ✓ PASS |
+
+Additional regression evidence: `go test -count=1 -tags=basicv2 ./pkg/api/v2/...` → `ok github.com/amikos-tech/chroma-go/pkg/api/v2 23.011s`.
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| `GRP-01` | `22-01-PLAN.md` | `WithGroupBy(nil)` returns a validation error instead of silently skipping grouping | ✓ SATISFIED | The nil branch in `pkg/api/v2/search.go:636-638` now returns `groupBy cannot be nil`, and `pkg/api/v2/groupby_test.go:193-197` plus `pkg/api/v2/groupby_test.go:290-300` assert both the direct and composed error/no-append behavior. |
+
+Orphaned requirements for Phase 22: none. `REQUIREMENTS.md` maps only `GRP-01` to Phase 22, and `22-01-PLAN.md` declares the same requirement ID.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+| --- | --- | --- | --- | --- |
+| `pkg/api/v2/groupby_test.go` | 278 | Invalid request-path regression uses generic `require.Error` instead of pinning the exact passthrough error | ℹ️ Info | This does not block the phase because `pkg/api/v2/search.go:639-640` still returns `(*GroupBy).Validate()` errors unchanged, but the request-path test is broader than the direct nil-error contract. |
+
+### Gaps Summary
+
+No blocking gaps found. The roadmap success criteria and the plan’s must-haves are implemented in `pkg/api/v2/search.go`, exercised directly in `pkg/api/v2/groupby_test.go`, and backed by fresh uncached `basicv2` test runs. Requirement coverage is complete for `GRP-01`, and there are no orphaned requirement IDs for this phase.
+
+---
+
+_Verified: 2026-04-10T04:51:04Z_  
+_Verifier: Claude (gsd-verifier)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.4.2] - Unreleased
+
+### Changed
+
+- **Search API** - `WithGroupBy(nil)` now returns a validation error instead of silently omitting grouping. Callers that want no grouping should omit `WithGroupBy(...)` entirely.
+
 ## [v0.4.1] - 2026-03-23
 
 ### Added

--- a/pkg/api/v2/groupby_test.go
+++ b/pkg/api/v2/groupby_test.go
@@ -190,10 +190,10 @@ func TestWithGroupBy(t *testing.T) {
 		require.Equal(t, groupBy, req.GroupBy)
 	})
 
-	t.Run("nil groupby", func(t *testing.T) {
+	t.Run("nil groupby returns exact validation error", func(t *testing.T) {
 		req := &SearchRequest{}
 		err := WithGroupBy(nil).ApplyToSearchRequest(req)
-		require.NoError(t, err)
+		require.EqualError(t, err, "groupBy cannot be nil")
 		require.Nil(t, req.GroupBy)
 	})
 
@@ -285,5 +285,18 @@ func TestSearchRequestWithGroupBy(t *testing.T) {
 
 		err := opt(sq)
 		require.Error(t, err)
+	})
+
+	t.Run("search with nil groupby fails before append", func(t *testing.T) {
+		sq := &SearchQuery{}
+
+		opt := NewSearchRequest(
+			WithKnnRank(KnnQueryText("machine learning")),
+			WithGroupBy(nil),
+		)
+
+		err := opt(sq)
+		require.EqualError(t, err, "groupBy cannot be nil")
+		require.Len(t, sq.Searches, 0)
 	})
 }

--- a/pkg/api/v2/search.go
+++ b/pkg/api/v2/search.go
@@ -634,7 +634,7 @@ func WithGroupBy(groupBy *GroupBy) *groupByOption {
 
 func (o *groupByOption) ApplyToSearchRequest(req *SearchRequest) error {
 	if o.groupBy == nil {
-		return nil
+		return errors.New("groupBy cannot be nil")
 	}
 	if err := o.groupBy.Validate(); err != nil {
 		return err


### PR DESCRIPTION
## Summary

**Phase 22: WithGroupBy Validation**
**Goal:** WithGroupBy rejects nil input with a clear error
**Status:** Verified ✓

This phase fixes the V2 search contract so explicit `WithGroupBy(nil)` is rejected during request construction instead of being silently treated as omitted grouping. The change stays tightly scoped: valid non-nil `GroupBy` behavior is preserved, omitting `WithGroupBy(...)` remains the no-grouping path, and regression coverage now pins both the direct option path and the composed `NewSearchRequest(...)` path.

## Changes

### Plan 22-01: WithGroupBy Validation
WithGroupBy(nil) now fails fast with a stable validation error before search requests are appended or sent.

**Key files:**
- `pkg/api/v2/search.go`
- `pkg/api/v2/groupby_test.go`

**What changed:**
- Return the exact validation error `groupBy cannot be nil` from `groupByOption.ApplyToSearchRequest`
- Keep existing non-nil `GroupBy` validation and assignment behavior unchanged
- Add regression coverage for direct `WithGroupBy(nil)` usage and the higher-level `NewSearchRequest(..., WithGroupBy(nil))` path
- Assert that nil group-by input fails before any partial search request is appended

## Requirements Addressed

- `GRP-01`: `WithGroupBy(nil)` returns a validation error instead of silently skipping grouping

## Verification

- [x] `go test -tags=basicv2 -run 'TestWithGroupBy|TestSearchRequestWithGroupBy' ./pkg/api/v2/...`
- [x] `make test`
- [x] `make lint`
- [x] Fresh verifier spot-checks with uncached `basicv2` runs, including `go test -count=1 -tags=basicv2 ./pkg/api/v2/...`
- [x] Phase verification passed in `.planning/phases/22-withgroupby-validation/22-VERIFICATION.md` with `6/6` must-haves verified

## Key Decisions

- Explicit `WithGroupBy(nil)` is treated as programmer error; callers that want no grouping must omit the option entirely
- Kept the nil contract as a direct `groupBy cannot be nil` validation message in `pkg/api/v2/search.go`
- Left `pkg/api/v2/groupby.go` unchanged so existing non-nil validation continues to flow through `(*GroupBy).Validate()`
