### PR TITLE
Phase 23: ORT EF Leak Fix

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -31,6 +31,7 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 - ✓ SDK auto-wiring behavior documented across Python, JS, Rust, Go — v0.4.1
 - ✓ RrfRank arithmetic methods build correct expression trees instead of silent no-ops — v0.4.2 Phase 21
 - ✓ WithGroupBy(nil) rejects explicit nil input with a stable validation error — v0.4.2 Phase 22
+- ✓ Embedded `CreateCollection(..., WithIfNotExistsCreate())` closes the SDK-owned temporary default ORT EF without overriding stored collection state — v0.4.2 Phase 23
 
 ## Current Milestone: v0.4.2 Bug Fixes and Robustness
 
@@ -50,7 +51,6 @@ Go applications can use Chroma and embedding providers through a stable, portabl
 ### Active
 - Sibling V2 SearchRequestOption helpers still have inconsistent explicit-nil handling after the WithGroupBy(nil) fix — #503
 - Embedded GetOrCreateCollection passes closed EFs to CreateCollection fallback — #493
-- Default ORT EF leaked when CreateCollection finds existing collection — #494
 - Morph EF integration test broken by upstream 404 — #465
 - Raw error bodies can be arbitrarily large in provider error messages — #478
 - Release download stack has excessive duplication across providers — #412
@@ -108,4 +108,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-10 — Phase 22 (WithGroupBy validation) complete*
+*Last updated: 2026-04-11 — Phase 23 (ORT EF leak fix) complete*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -14,7 +14,7 @@
 
 ### Embedded Client Lifecycle
 
-- [ ] **EFL-01**: Default ORT EF created by PrepareAndValidateCollectionRequest is closed when CreateCollection finds an existing collection
+- [x] **EFL-01**: Default ORT EF created by PrepareAndValidateCollectionRequest is closed when CreateCollection finds an existing collection
 - [ ] **EFL-02**: GetOrCreateCollection does not pass closed EFs to CreateCollection fallback when GetCollection fails mid-build
 - [ ] **EFL-03**: Tests cover EF lifecycle under `-race` flag for concurrent GetOrCreateCollection calls
 
@@ -64,7 +64,7 @@
 | RANK-02 | Phase 21 | Pending |
 | GRP-01 | Phase 22 | Complete |
 | OPT-01 | Phase 30 | Pending |
-| EFL-01 | Phase 23 | Pending |
+| EFL-01 | Phase 23 | Complete |
 | EFL-02 | Phase 24 | Pending |
 | EFL-03 | Phase 24 | Pending |
 | ERR-01 | Phase 25 | Pending |
@@ -84,4 +84,4 @@
 
 ---
 *Requirements defined: 2026-04-08*
-*Last updated: 2026-04-10 after Phase 22 completion*
+*Last updated: 2026-04-11 after Phase 23 completion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -24,7 +24,7 @@ See: [v0.4.1 Archived Roadmap](milestones/v0.4.1-ROADMAP.md)
 
 - [x] **Phase 21: RrfRank Arithmetic Fix** - RrfRank arithmetic methods compute correct results instead of silently returning self (completed 2026-04-09)
 - [x] **Phase 22: WithGroupBy Validation** - WithGroupBy(nil) returns an error instead of silently skipping grouping (completed 2026-04-10)
-- [ ] **Phase 23: ORT EF Leak Fix** - Default ORT EF is properly closed when CreateCollection finds an existing collection
+- [x] **Phase 23: ORT EF Leak Fix** - Default ORT EF is properly closed when CreateCollection finds an existing collection (completed 2026-04-11)
 - [ ] **Phase 24: GetOrCreateCollection EF Safety** - GetOrCreateCollection does not pass closed EFs to CreateCollection fallback
 - [ ] **Phase 25: Error Body Truncation** - Embedding provider error messages truncate raw HTTP bodies to safe display lengths
 - [ ] **Phase 26: Twelve Labs Async Embedding** - Twelve Labs provider handles async task responses for long-running media
@@ -83,10 +83,10 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. When CreateCollection finds an existing collection, any default ORT EF created by PrepareAndValidateCollectionRequest is closed
   2. No ORT runtime resources remain open after CreateCollection returns in the existing-collection path
-**Plans**: TBD
+**Plans**: 1 plan
 
 Plans:
-- [ ] 23-01: TBD
+- [x] 23-01-PLAN.md — Close the temporary SDK-owned default ORT EF on the embedded existing-collection path and pin close/error/state-preservation regressions
 
 ### Phase 24: GetOrCreateCollection EF Safety
 **Goal**: GetOrCreateCollection never passes a closed EF to CreateCollection fallback
@@ -194,7 +194,7 @@ Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on 
 |-------|-----------|----------------|--------|-----------|
 | 21. RrfRank Arithmetic Fix | v0.4.2 | 1/1 | Complete    | 2026-04-09 |
 | 22. WithGroupBy Validation | v0.4.2 | 1/1 | Complete    | 2026-04-10 |
-| 23. ORT EF Leak Fix | v0.4.2 | 0/0 | Not started | - |
+| 23. ORT EF Leak Fix | v0.4.2 | 1/1 | Complete    | 2026-04-11 |
 | 24. GetOrCreateCollection EF Safety | v0.4.2 | 0/0 | Not started | - |
 | 25. Error Body Truncation | v0.4.2 | 0/0 | Not started | - |
 | 26. Twelve Labs Async Embedding | v0.4.2 | 0/0 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: Ready to discuss or plan Phase 24
+status: Phase 23 shipped -- PR #504
 stopped_at: Phase 23 complete
-last_updated: "2026-04-11T09:58:19.387Z"
-last_activity: "2026-04-11 -- Phase 23 complete"
+last_updated: "2026-04-11T16:29:46.806Z"
+last_activity: "2026-04-11 -- Phase 23 shipped -- PR #504"
 progress:
   total_phases: 11
   completed_phases: 4
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 24
 Plan: Not started
-Status: Ready to discuss or plan Phase 24
-Last activity: 2026-04-11 -- Phase 23 complete
+Status: Phase 23 shipped -- PR #504
+Last activity: 2026-04-11 -- Phase 23 shipped -- PR #504
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: Ready to discuss or plan Phase 23
-stopped_at: Phase 22 complete
-last_updated: "2026-04-10T05:14:10.449Z"
-last_activity: "2026-04-10 -- Phase 22 shipped — PR #502"
+status: Ready to discuss or plan Phase 24
+stopped_at: Phase 23 complete
+last_updated: "2026-04-11T09:58:19.387Z"
+last_activity: "2026-04-11 -- Phase 23 complete"
 progress:
-  total_phases: 10
-  completed_phases: 3
-  total_plans: 4
-  completed_plans: 4
+  total_phases: 11
+  completed_phases: 4
+  total_plans: 5
+  completed_plans: 5
   percent: 100
 ---
 
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-10)
 
 **Core value:** Go applications can use Chroma and embedding providers through a stable, portable API that minimizes provider-specific friction.
-**Current focus:** Phase 23 — ort-ef-leak-fix
+**Current focus:** Phase 24 — getorcreatecollection-ef-safety
 
 ## Current Position
 
-Phase: 23
+Phase: 24
 Plan: Not started
-Status: Ready to discuss or plan Phase 23
-Last activity: 2026-04-10 -- Phase 22 shipped — PR #502
+Status: Ready to discuss or plan Phase 24
+Last activity: 2026-04-11 -- Phase 23 complete
 
 Progress: [██████████] 100%
 
@@ -36,7 +36,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 4
+- Total plans completed: 5
 - Average duration: --
 - Total execution time: 0 hours
 
@@ -57,5 +57,5 @@ Decisions are logged in PROJECT.md Key Decisions table.
 
 ## Session
 
-**Last Date:** 2026-04-10T04:53:49Z
-**Stopped At:** Phase 22 complete
+**Last Date:** 2026-04-11T09:58:19Z
+**Stopped At:** Phase 23 complete

--- a/.planning/phases/23-ort-ef-leak-fix/23-01-PLAN.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-01-PLAN.md
@@ -1,0 +1,401 @@
+---
+phase: 23-ort-ef-leak-fix
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/client.go
+  - pkg/api/v2/client_local_embedded.go
+  - pkg/api/v2/client_local_embedded_test.go
+autonomous: true
+requirements:
+  - EFL-01
+
+must_haves:
+  truths:
+    - "`CreateCollectionOp` exposes an unexported per-op default dense EF factory seam so tests can inject a mock default EF without mutating package-global state"
+    - "`CreateCollectionOp` tracks the actual SDK-created default dense EF instance that is still current after validation, instead of relying on a bare boolean-only marker"
+    - "Embedded `CreateCollection(..., WithIfNotExistsCreate())` closes that tracked SDK-owned default EF exactly once before discarding it on the existing-collection path"
+    - "If closing that SDK-owned default EF fails, `CreateCollection` returns an error containing `error closing default embedding function for existing collection`"
+    - "Existing embedded collections still preserve their stored dense EF/contentEF and metadata; the temporary SDK-created default EF is never adopted on the existing path"
+    - "Focused `basicv2` regressions prove existing-path close, cleanup-error propagation, and no eager close on the new-collection path"
+    - "`make test` and `make lint` remain green after the Phase 23 fix"
+  artifacts:
+    - path: "pkg/api/v2/client.go"
+      provides: "Per-op default dense EF factory seam and explicit SDK-owned default EF provenance on `CreateCollectionOp`"
+      contains: "defaultDenseEFFactory"
+    - path: "pkg/api/v2/client.go"
+      provides: "Tracked current SDK-owned default dense EF instance used by embedded cleanup gating"
+      contains: "sdkOwnedDefaultDenseEF"
+    - path: "pkg/api/v2/client.go"
+      provides: "Unexported test-only CreateCollection option for factory injection"
+      contains: "withDefaultDenseEFFactoryCreate"
+    - path: "pkg/api/v2/client_local_embedded.go"
+      provides: "Existing-collection cleanup branch that closes only the still-current SDK-owned default EF"
+      contains: "error closing default embedding function for existing collection"
+    - path: "pkg/api/v2/client_local_embedded_test.go"
+      provides: "Focused `basicv2` regressions for existing-path close, close failure, and new-collection no-close behavior"
+      contains: "TestEmbeddedCreateCollection_DefaultORT"
+  key_links:
+    - from: "pkg/api/v2/client.go:NewCreateCollectionOp"
+      to: "pkg/api/v2/client.go:PrepareAndValidateCollectionRequest"
+      via: "Per-op `defaultDenseEFFactory` and tracked `sdkOwnedDefaultDenseEF` instance"
+      pattern: "defaultDenseEFFactory|sdkOwnedDefaultDenseEF"
+    - from: "pkg/api/v2/client.go:PrepareAndValidateCollectionRequest"
+      to: "pkg/api/v2/client_local_embedded.go:CreateCollection"
+      via: "Existing-path cleanup only when `req.embeddingFunction` is still the tracked SDK-created default EF"
+      pattern: "req.embeddingFunction == req.sdkOwnedDefaultDenseEF"
+    - from: "pkg/api/v2/client_local_embedded.go:CreateCollection"
+      to: "pkg/api/v2/client_local_embedded_test.go"
+      via: "Focused `basicv2` tests assert close count, cleanup error, and no eager close on the new-collection path"
+      pattern: "closeCount|error closing default embedding function for existing collection"
+---
+
+<objective>
+Fix Phase 23 by closing the temporary SDK-created default ORT dense embedding function when embedded `CreateCollection(..., WithIfNotExistsCreate())` discovers the collection already exists, while preserving Phase 20 existing-state precedence and the strict synchronous cleanup-error contract.
+
+Purpose: the current embedded existing-collection path abandons a default ORT EF created during `PrepareAndValidateCollectionRequest()` without calling `Close()`, leaking ORT runtime resources on repeated idempotent create calls.
+
+Output: a single narrow embedded-path fix using an unexported per-op default-EF factory seam, explicit current-instance provenance for the SDK-created default EF, and focused `basicv2` regressions that prove cleanup and state preservation.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/23-ort-ef-leak-fix/23-CONTEXT.md
+@.planning/phases/23-ort-ef-leak-fix/23-RESEARCH.md
+@.planning/phases/23-ort-ef-leak-fix/23-REVIEWS.md
+@.planning/phases/23-ort-ef-leak-fix/23-VALIDATION.md
+@.planning/milestones/v0.4.1-phases/20-getorcreatecollection-contentef-support/20-CONTEXT.md
+@.planning/phases/22-withgroupby-validation/22-CONTEXT.md
+@.planning/codebase/CONVENTIONS.md
+@.planning/codebase/TESTING.md
+@CLAUDE.md
+@pkg/api/v2/client.go
+@pkg/api/v2/client_local_embedded.go
+@pkg/api/v2/client_local_embedded_test.go
+@pkg/api/v2/ef_close_once_test.go
+@pkg/embeddings/ort/ort.go
+
+<interfaces>
+From `pkg/embeddings/ort/ort.go` (current constructor signature to preserve behind the seam):
+```go
+func NewDefaultEmbeddingFunction(opts ...Option) (*DefaultEmbeddingFunction, func() error, error)
+```
+
+From `pkg/api/v2/client.go` (current eager default creation and dual-contentEF promotion):
+```go
+type CreateCollectionOp struct {
+	Name                     string
+	CreateIfNotExists        bool
+	embeddingFunction        embeddings.EmbeddingFunction
+	contentEmbeddingFunction embeddings.ContentEmbeddingFunction
+	Metadata                 CollectionMetadata
+	Configuration            *CollectionConfigurationImpl
+	Schema                   *Schema
+	Database                 Database
+	disableEFConfigStorage   bool
+}
+
+func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
+	defaultedDenseEF := op.embeddingFunction == nil
+	if defaultedDenseEF {
+		ef, _, err := ort.NewDefaultEmbeddingFunction()
+		...
+		op.embeddingFunction = ef
+	}
+	...
+	if op.contentEmbeddingFunction != nil {
+		if denseEF, ok := op.contentEmbeddingFunction.(embeddings.EmbeddingFunction); ok {
+			...
+			if defaultedDenseEF {
+				if closer, ok := op.embeddingFunction.(io.Closer); ok {
+					if err := closer.Close(); err != nil { ... }
+				}
+				op.embeddingFunction = denseEF
+			}
+		}
+	}
+}
+```
+
+From `pkg/api/v2/client_local_embedded.go` (current leak site on the existing path):
+```go
+overrideEF := req.embeddingFunction
+overrideContentEF := req.contentEmbeddingFunction
+if isNewCreation {
+	overrideEF = wrapEFCloseOnce(req.embeddingFunction)
+	overrideContentEF = wrapContentEFCloseOnce(req.contentEmbeddingFunction)
+	...
+} else {
+	overrideEF = nil
+	overrideContentEF = nil
+}
+```
+
+From `pkg/api/v2/client_local_embedded_test.go` (existing Phase 20 precedence contract to keep):
+```go
+func TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState(t *testing.T) {
+	...
+	require.Same(t, initialEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+}
+```
+
+From `pkg/api/v2/ef_close_once_test.go` (reusable close-count helpers):
+```go
+type mockCloseableEF struct {
+	closeCount atomic.Int32
+}
+
+type mockFailingCloseEF struct {
+	mockCloseableEF
+	closeErr error
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Replace the global seam draft with per-op default-EF provenance and focused lifecycle regressions</name>
+  <files>pkg/api/v2/client.go, pkg/api/v2/client_local_embedded.go, pkg/api/v2/client_local_embedded_test.go</files>
+  <read_first>
+    - pkg/api/v2/client.go (read `CreateCollectionOp`, `NewCreateCollectionOp`, `PrepareAndValidateCollectionRequest`, and every `op.embeddingFunction = ...` write inside that method)
+    - pkg/api/v2/client_local_embedded.go (read embedded `CreateCollection`, especially the `isNewCreation` branch and existing-path override discard)
+    - pkg/api/v2/client_local_embedded_test.go (read `TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState` and adjacent embedded lifecycle patterns)
+    - pkg/api/v2/ef_close_once_test.go (reuse `mockCloseableEF` and `mockFailingCloseEF`; do not invent parallel close-count helpers)
+    - pkg/embeddings/ort/ort.go (preserve the default ORT factory signature behind the per-op seam)
+    - .planning/phases/23-ort-ef-leak-fix/23-CONTEXT.md (locked narrow-scope fix shape, synchronous cleanup error contract, and Phase 20 precedence carry-forward)
+    - .planning/phases/23-ort-ef-leak-fix/23-RESEARCH.md (current leak site and embedded-path ownership constraints)
+    - .planning/phases/23-ort-ef-leak-fix/23-REVIEWS.md (must address the global seam race and boolean-only provenance drift concerns)
+    - .planning/milestones/v0.4.1-phases/20-getorcreatecollection-contentef-support/20-CONTEXT.md (preserve D-03 existing-state precedence on embedded existing collections)
+  </read_first>
+  <behavior>
+    - No package-level mutable `newDefaultDenseEF` seam exists in production code after this task
+    - `CreateCollectionOp` can receive a per-op injected default dense EF factory through an unexported option used only by package-local tests
+    - `CreateCollectionOp` tracks the actual SDK-created default dense EF instance that is still current after validation and any dual-contentEF promotion
+    - Embedded `CreateCollection(..., WithIfNotExistsCreate())` closes only that tracked current SDK-created default EF on the existing path and returns an error on close failure
+    - Existing embedded collection state remains authoritative, and new-collection creation still transfers ownership of the default EF to the returned collection without eager close
+  </behavior>
+  <action>
+Addresses review concern: HIGH — do not use a package-level mutable `newDefaultDenseEF` seam because it is parallel-test race prone.
+
+Addresses review concern: HIGH — do not rely on a bare boolean ownership marker; track the actual SDK-created default EF instance and gate cleanup on whether it is still the current runtime dense EF.
+
+Keep the phase narrow per D-01, D-02, D-08, and D-09: no deferred default-EF creation refactor, no shared-flow redesign, no `GetOrCreateCollection` hardening, and no broader lifecycle work from Phase 24.
+
+**Step 1 (RED): add focused `basicv2` regressions in `pkg/api/v2/client_local_embedded_test.go`.**
+
+Write these exact tests before production edits:
+
+1. `TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDefaultAndPreservesState`
+2. `TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError`
+3. `TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDefault`
+
+Use `newCountingMemoryEmbeddedRuntime()` and `newEmbeddedClientForRuntime(t, runtime)` so the tests stay in the standard embedded `basicv2` suite.
+
+For the two existing-collection tests:
+- Create the original collection first with an explicit `initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()`.
+- Re-enter `client.CreateCollection(...)` with the same name, `WithIfNotExistsCreate()`, and NO explicit dense EF.
+- Inject the test default EF via a new unexported CreateCollection option named exactly `withDefaultDenseEFFactoryCreate(...)`.
+- The injected factory must return either `*mockCloseableEF` or `*mockFailingCloseEF` from `pkg/api/v2/ef_close_once_test.go`.
+
+Required assertions for `TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDefaultAndPreservesState`:
+- the call returns `got, err := client.CreateCollection(...)` with `err == nil`
+- `got.ID()` equals the original collection ID
+- `unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot())` is still `initialEF`
+- the temporary mock default EF `closeCount` is exactly `1`
+- the existing metadata/state remains the original state, not any temporary override
+
+Required assertions for `TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError`:
+- `client.CreateCollection(...)` returns a non-nil error
+- the error contains the exact string `error closing default embedding function for existing collection`
+- the failing mock default EF `closeCount` is exactly `1`
+
+Required assertions for `TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDefault`:
+- create a brand-new collection with NO explicit dense EF and the injected default-EF factory
+- before `got.Close()`, the injected mock default EF `closeCount` is `0`
+- `unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot())` is the injected mock default EF
+- after `got.Close()`, the mock default EF `closeCount` is `1`
+
+Run the focused suite and confirm RED; a compile failure is acceptable before the seam exists:
+```bash
+go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...
+```
+
+**Step 2 (GREEN): implement the per-op seam and explicit provenance in `pkg/api/v2/client.go`.**
+
+Make these concrete changes:
+
+1. Add an unexported factory type and field on `CreateCollectionOp`:
+```go
+type defaultDenseEFFactory func() (embeddings.EmbeddingFunction, func() error, error)
+
+type CreateCollectionOp struct {
+	...
+	defaultDenseEFFactory defaultDenseEFFactory   `json:"-"`
+	sdkOwnedDefaultDenseEF embeddings.EmbeddingFunction `json:"-"`
+}
+```
+
+2. In `NewCreateCollectionOp`, initialize `defaultDenseEFFactory` with an inline adapter that calls `ort.NewDefaultEmbeddingFunction()` and returns it as `embeddings.EmbeddingFunction`.
+
+3. Add an unexported CreateCollection option named exactly:
+```go
+func withDefaultDenseEFFactoryCreate(factory defaultDenseEFFactory) CreateCollectionOption
+```
+This helper is package-local for tests. It must reject `nil` with the exact error string `default dense EF factory cannot be nil`. Do NOT add a public `With...` option for this seam.
+
+4. At the start of `PrepareAndValidateCollectionRequest()`, clear `op.sdkOwnedDefaultDenseEF = nil` so repeated validation on the same op cannot reuse stale ownership state.
+
+5. Replace the direct `ort.NewDefaultEmbeddingFunction()` call with `op.defaultDenseEFFactory()`. When a default EF is created, set both:
+```go
+op.embeddingFunction = ef
+op.sdkOwnedDefaultDenseEF = ef
+```
+
+6. Audit every subsequent `op.embeddingFunction = ...` assignment inside `PrepareAndValidateCollectionRequest()`. In the current code the relevant replacement path is dual-interface contentEF promotion. After the temporary default is closed successfully there, set:
+```go
+op.sdkOwnedDefaultDenseEF = nil
+op.embeddingFunction = denseEF
+```
+
+Do NOT use a boolean-only marker like `sdkCreatedDefaultDenseEF bool`, and do NOT add any package-level mutable seam such as `var newDefaultDenseEF = ...`.
+
+**Step 3 (GREEN): implement the embedded existing-path cleanup in `pkg/api/v2/client_local_embedded.go`.**
+
+Inside embedded `CreateCollection`, in the `isNewCreation == false` branch and BEFORE `overrideEF = nil`, add the cleanup gate:
+```go
+if req.sdkOwnedDefaultDenseEF != nil && req.embeddingFunction == req.sdkOwnedDefaultDenseEF {
+	closer, ok := req.sdkOwnedDefaultDenseEF.(io.Closer)
+	if !ok {
+		return nil, errors.New("sdk-owned default embedding function is not closable")
+	}
+	if err := closer.Close(); err != nil {
+		return nil, errors.Wrap(err, "error closing default embedding function for existing collection")
+	}
+	req.sdkOwnedDefaultDenseEF = nil
+}
+```
+
+This gate must stay exact:
+- compare against `req.sdkOwnedDefaultDenseEF`, not a boolean-only marker
+- close only when `req.embeddingFunction` is still that tracked instance
+- preserve Phase 20 state precedence by keeping `overrideEF = nil` and `overrideContentEF = nil` after cleanup
+- return errors synchronously; do not log-and-continue
+
+**Step 4 (GREEN verify):** rerun the focused suite until it passes:
+```bash
+go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...
+```
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/GolandProjects/chroma-go && go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...</automated>
+  </verify>
+  <acceptance_criteria>
+    - `pkg/api/v2/client.go` contains `type defaultDenseEFFactory func() (embeddings.EmbeddingFunction, func() error, error)`
+    - `pkg/api/v2/client.go` contains `defaultDenseEFFactory defaultDenseEFFactory`
+    - `pkg/api/v2/client.go` contains `sdkOwnedDefaultDenseEF embeddings.EmbeddingFunction`
+    - `pkg/api/v2/client.go` contains `func withDefaultDenseEFFactoryCreate(`
+    - `pkg/api/v2/client.go` contains the exact string `default dense EF factory cannot be nil`
+    - `pkg/api/v2/client.go` does NOT contain `var newDefaultDenseEF = ort.NewDefaultEmbeddingFunction`
+    - `pkg/api/v2/client_local_embedded.go` contains `req.embeddingFunction == req.sdkOwnedDefaultDenseEF`
+    - `pkg/api/v2/client_local_embedded.go` contains the exact string `sdk-owned default embedding function is not closable`
+    - `pkg/api/v2/client_local_embedded.go` contains the exact wrapped error string `error closing default embedding function for existing collection`
+    - `pkg/api/v2/client_local_embedded_test.go` contains `TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDefaultAndPreservesState`
+    - `pkg/api/v2/client_local_embedded_test.go` contains `TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError`
+    - `pkg/api/v2/client_local_embedded_test.go` contains `TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDefault`
+    - `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` exits 0
+  </acceptance_criteria>
+  <done>The Phase 23 implementation uses a per-op default-EF seam with explicit current-instance provenance, closes only the SDK-owned temporary default EF on the embedded existing path, returns cleanup errors synchronously, and keeps Phase 20 state precedence intact.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Run full V2 and lint verification without widening the phase</name>
+  <files>pkg/api/v2/client.go, pkg/api/v2/client_local_embedded.go, pkg/api/v2/client_local_embedded_test.go</files>
+  <read_first>
+    - pkg/api/v2/client.go (confirm the only new production concepts are `defaultDenseEFFactory`, `withDefaultDenseEFFactoryCreate`, and `sdkOwnedDefaultDenseEF`)
+    - pkg/api/v2/client_local_embedded.go (confirm the only behavior change is the existing-path cleanup gate before override discard)
+    - pkg/api/v2/client_local_embedded_test.go (confirm the new tests stay in the focused `basicv2` suite and do not add ORT integration harnesses)
+    - .planning/phases/23-ort-ef-leak-fix/23-CONTEXT.md (keep scope bounded to Phase 23 only)
+    - .planning/phases/23-ort-ef-leak-fix/23-VALIDATION.md (follow the phase quick/full verification contract)
+    - CLAUDE.md (honor repo testing and lint guidance)
+  </read_first>
+  <action>
+Run the validation contract after Task 1 is green:
+```bash
+go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...
+make test
+make lint
+```
+
+If failures appear, only fix regressions caused by:
+- the new per-op `defaultDenseEFFactory` seam
+- the `sdkOwnedDefaultDenseEF` provenance tracking
+- the embedded existing-path cleanup/error branch
+
+Do NOT:
+- redesign `PrepareAndValidateCollectionRequest()` to defer default EF creation (deferred per D-08)
+- add shared-flow refactors or package-level lifecycle abstractions
+- touch `GetOrCreateCollection` fallback safety work that belongs to Phase 24
+- add ORT-native leak harnesses, env-gated integration tests, or new public API
+  </action>
+  <verify>
+    <automated>cd /Users/tazarov/GolandProjects/chroma-go && go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/... && make test && make lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` exits 0
+    - `make test` exits 0
+    - `make lint` exits 0
+    - `pkg/api/v2/client.go` still has no package-level `newDefaultDenseEF` seam
+    - `TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState` still passes unchanged as the Phase 20 precedence guard
+  </acceptance_criteria>
+  <done>The revised Phase 23 fix is fully verified in the standard `basicv2` workflow and lint-clean without broadening into Phase 24 or a larger create-flow refactor.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Request validation -> embedded create existing-path cleanup | The SDK may create a temporary runtime-owned default EF before it knows whether the embedded collection already exists |
+| SDK-owned temporary EF -> existing collection state | The SDK must distinguish its own temporary default EF from caller/state-owned EFs so cleanup does not corrupt the existing collection lifecycle |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-23-01 | D (Denial of Service) | Embedded `CreateCollection` existing path | mitigate | Close the SDK-owned temporary default ORT EF before discarding it so repeated `WithIfNotExistsCreate()` calls do not leak runtime resources |
+| T-23-02 | T (Tampering / ownership confusion) | `CreateCollectionOp` EF provenance | mitigate | Track the actual SDK-created default EF instance (`sdkOwnedDefaultDenseEF`) and only clean up when `req.embeddingFunction` is still that instance |
+| T-23-03 | I (Integrity / state precedence regression) | Embedded existing collection state | mitigate | Keep `overrideEF=nil` / `overrideContentEF=nil` after cleanup so Phase 20 state-backed EF/contentEF precedence remains authoritative |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` passes
+2. `! rg -n "var newDefaultDenseEF = ort.NewDefaultEmbeddingFunction" pkg/api/v2/client.go` confirms the rejected package-global seam is absent
+3. `make test` passes
+4. `make lint` passes
+5. `rg -n "defaultDenseEFFactory|withDefaultDenseEFFactoryCreate|sdkOwnedDefaultDenseEF" pkg/api/v2/client.go pkg/api/v2/client_local_embedded.go` shows the per-op seam and explicit provenance gate in the implementation
+</verification>
+
+<success_criteria>
+- `EFL-01` is satisfied: when embedded `CreateCollection(..., WithIfNotExistsCreate())` resolves to an existing collection, any SDK-created default ORT EF for that request is closed before return
+- The cleanup gate cannot drift out of sync with replacement paths because it uses the tracked current SDK-created default EF instance, not a bare boolean-only marker
+- Cleanup failures are returned synchronously with the exact wrapped error `error closing default embedding function for existing collection`
+- Existing embedded collections still preserve their stored EF/contentEF and metadata instead of adopting the temporary default EF
+- Verification stays in the standard `basicv2` suite with focused regressions plus repo-wide `make test` and `make lint`
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/23-ort-ef-leak-fix/23-01-SUMMARY.md`
+</output>

--- a/.planning/phases/23-ort-ef-leak-fix/23-01-SUMMARY.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-01-SUMMARY.md
@@ -1,0 +1,91 @@
+---
+phase: 23-ort-ef-leak-fix
+plan: 01
+subsystem: api
+tags: [go, v2, embedded, ort, lifecycle]
+requires: []
+provides:
+  - closes SDK-owned temporary default ORT dense embedding functions on embedded existing-collection create
+  - preserves Phase 20 existing-state EF precedence while surfacing cleanup failures synchronously
+  - adds focused basicv2 regressions for cleanup success, cleanup failure, and new-collection ownership
+affects: [embedded, create-collection, default-ef, lifecycle]
+tech-stack:
+  added: []
+  patterns: [per-op default EF factory seam, tracked SDK-owned EF provenance, focused basicv2 lifecycle regressions]
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/client.go
+    - pkg/api/v2/client_local_embedded.go
+    - pkg/api/v2/client_local_embedded_test.go
+key-decisions:
+  - "Used a per-op defaultDenseEFFactory seam instead of a package-global override so basicv2 tests can inject a mock default EF without parallel-test races."
+  - "Tracked the current SDK-owned default dense EF instance directly and only cleaned it up when the embedded existing-path still held that exact instance."
+patterns-established:
+  - "Embedded existing-collection cleanup gates compare the live runtime dense EF against tracked SDK-owned provenance before closing."
+  - "Default EF lifecycle bug fixes stay narrow: per-op seams in production, colocated basicv2 regressions, and synchronous error returns on owned cleanup paths."
+requirements-completed: [EFL-01]
+duration: 3m
+completed: 2026-04-11
+---
+
+# Phase 23 Plan 01: ORT EF Leak Fix Summary
+
+**Embedded `CreateCollection(..., WithIfNotExistsCreate())` now closes the temporary SDK-owned default ORT EF on the existing-collection path without disturbing stored collection state.**
+
+## Performance
+
+- **Duration:** 3m
+- **Started:** 2026-04-11T12:42:24+03:00
+- **Completed:** 2026-04-11T12:45:23+03:00
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Added a per-op `defaultDenseEFFactory` seam plus `sdkOwnedDefaultDenseEF` tracking on `CreateCollectionOp` so tests can inject a temporary default EF without global mutable state.
+- Closed the tracked SDK-owned default EF on the embedded existing-collection path and returned the exact wrapped cleanup error when `Close()` fails.
+- Added focused `basicv2` regressions proving cleanup on existing collections, cleanup-error propagation, and ownership transfer on the new-collection path.
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Replace the global seam draft with per-op default-EF provenance and focused lifecycle regressions** - `2b98280` (test), `8c6904c` (feat), `5358dcf` (chore)
+2. **Task 2: Run full V2 and lint verification without widening the phase** - verification rerun during phase execution; no additional source commit required
+
+## Files Created/Modified
+- `pkg/api/v2/client.go` - adds the per-op default dense EF factory seam and tracks the current SDK-owned default EF instance.
+- `pkg/api/v2/client_local_embedded.go` - closes the tracked SDK-owned default EF only on the embedded existing-collection path before discarding overrides.
+- `pkg/api/v2/client_local_embedded_test.go` - pins cleanup success, cleanup failure, and new-collection ownership behavior in the standard `basicv2` suite.
+
+## Decisions Made
+- Kept the fix narrow in the embedded existing-path instead of deferring default EF creation or refactoring shared create-flow semantics.
+- Returned cleanup failures synchronously with `error closing default embedding function for existing collection` rather than logging and continuing.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+- The initial `gsd-executor` handoff stalled without producing artifacts, so phase bookkeeping was completed manually against the already-landed Phase 23 commits and fresh verification output.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Phase 23 satisfies `EFL-01` and keeps the existing embedded collection state authoritative on idempotent create calls.
+- Phase 24 can now build on the explicit SDK-owned EF provenance without revisiting the existing-collection leak path.
+
+## Verification Evidence
+
+- `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` -> passed (`ok github.com/amikos-tech/chroma-go/pkg/api/v2`).
+- `make test` -> passed (`DONE 1732 tests, 7 skipped`).
+- `make lint` -> passed (`0 issues.`).
+
+## Self-Check: PASSED
+
+- Verified `.planning/phases/23-ort-ef-leak-fix/23-01-SUMMARY.md` exists on disk.
+- Verified task commits `2b98280`, `8c6904c`, and `5358dcf` exist in git history.

--- a/.planning/phases/23-ort-ef-leak-fix/23-CONTEXT.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-CONTEXT.md
@@ -1,0 +1,133 @@
+# Phase 23: ORT EF Leak Fix - Context
+
+**Gathered:** 2026-04-10
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Fix the embedded `CreateCollection(..., WithIfNotExistsCreate())` path so an auto-created default ORT embedding function does not leak when the target collection already exists. The phase is limited to cleanup and verification of that abandoned SDK-owned default EF on the existing-collection branch.
+
+**In scope:**
+- Detect the existing-collection path that currently drops an auto-created default ORT EF
+- Ensure the SDK-owned default ORT EF is closed before the call returns on that path
+- Add focused regression coverage proving both the close behavior and the preserved existing-collection state behavior
+- Define the synchronous error contract if that cleanup fails
+
+**Out of scope:**
+- Redesigning shared `PrepareAndValidateCollectionRequest` semantics across all client backends
+- Broader EF lifecycle hardening that belongs to Phase 24 (`GetOrCreateCollection` closed-EF safety)
+- ORT-specific native leak harnesses or env-gated integration testing beyond the narrow regression bar needed for this bug fix
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Fix shape
+- **D-01:** Phase 23 uses a narrow embedded-path fix, not a shared create-flow refactor.
+- **D-02:** The fix happens in embedded `CreateCollection` when `isNewCreation=false`: if the dense EF was auto-created by the SDK as the default ORT EF for this request, it must be explicitly closed before the temporary override is discarded.
+- **D-03:** Existing-collection EF precedence does not change. Phase 20's decision stands: existing embedded collections keep their state-backed EF/contentEF; temporary override EFs on the existing path are not adopted.
+
+### Verification style
+- **D-04:** Verification uses a mixed approach:
+  - one focused close-spy/unit regression with a seam around default EF creation
+  - one broader existing-collection lifecycle regression proving the returned collection still preserves the original EF/state and does not adopt the temporary default
+- **D-05:** Verification stays in the standard colocated `basicv2` test suite; no new ORT-specific integration or leak-detection harness is required for this phase.
+
+### Cleanup failure contract
+- **D-06:** If the SDK-owned default ORT EF cannot be closed on the existing-collection path, `CreateCollection` returns an error instead of logging and returning success.
+- **D-07:** Log-only handling is reserved for asynchronous cleanup paths like cache/state shutdown cleanup, not for this synchronous request path where the SDK still owns the temporary EF and can surface failure directly.
+
+### Scope guardrails
+- **D-08:** Phase 23 does not defer default EF creation until after the existence check. That alternative is a larger shared-flow refactor and is intentionally deferred.
+- **D-09:** Phase 23 does not introduce conditional or error-class-based cleanup behavior. A plain fail-on-cleanup-error contract is locked for this phase.
+
+### the agent's Discretion
+- Exact internal representation of the "auto-created default dense EF" marker, as long as it reliably distinguishes SDK-created default ORT EFs from caller-provided EFs and promoted dual-interface content EFs
+- Exact helper or package-level seam shape used by tests to substitute a close-counting default EF
+- Exact test naming and assertion structure, as long as the two locked verification goals above are both covered
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Milestone and requirement context
+- `.planning/ROADMAP.md` — Phase 23 goal, success criteria, and dependency boundary relative to Phase 24
+- `.planning/REQUIREMENTS.md` — `EFL-01` requirement for closing the default ORT EF on the existing-collection path
+- `.planning/PROJECT.md` — v0.4.2 milestone context and bug statement for issue `#494`
+- `.planning/STATE.md` — current project position showing Phase 23 as the active focus
+
+### Prior locked decisions to carry forward
+- `.planning/milestones/v0.4.1-phases/20-getorcreatecollection-contentef-support/20-CONTEXT.md` — Phase 20 decision `D-03` that existing embedded collections ignore new override EFs/contentEFs and preserve state-backed ones
+- `.planning/phases/22-withgroupby-validation/22-CONTEXT.md` — recent bug-fix precedent for narrow scope, stable error contract, and colocated regression coverage
+
+### Research and risk framing
+- `.planning/research/ARCHITECTURE.md` — issue `#494` root-cause analysis and the two viable fix directions
+- `.planning/research/FEATURES.md` — milestone bug inventory classifying `#494` as a narrow lifecycle bug
+- `.planning/research/PITFALLS.md` — warnings about wrapper layering, ownership, and avoiding accidental caller-EF closure during `#493/#494` work
+
+### Implementation targets
+- `pkg/api/v2/client.go` — `CreateCollectionOp` and `PrepareAndValidateCollectionRequest`, where the default ORT EF is currently auto-created
+- `pkg/api/v2/client_local_embedded.go` — embedded `CreateCollection`, `buildEmbeddedCollection`, and collection-state cleanup behavior
+- `pkg/embeddings/default_ef/default_ef.go` — default ORT EF close semantics and runtime teardown behavior
+- `pkg/api/v2/close_logging.go` — existing distinction between returned cleanup errors and log-only cleanup paths
+- `pkg/api/v2/ef_close_once.go` — close-once wrapping rules that must remain the only wrapping mechanism
+
+### Test references
+- `.planning/codebase/TESTING.md` — repo testing conventions and build-tag expectations
+- `.planning/codebase/CONVENTIONS.md` — repo error-handling convention to surface explicit failures in synchronous validation/setup paths
+- `pkg/api/v2/client_local_embedded_test.go` — existing embedded lifecycle/state tests to extend
+- `pkg/api/v2/ef_close_once_test.go` — close-counting helpers and wrapper behavior references
+- `pkg/api/v2/close_review_test.go` — cleanup error logging and ownership transfer test patterns
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `wrapEFCloseOnce` / `wrapContentEFCloseOnce` in `pkg/api/v2/ef_close_once.go`: idempotent wrapper helpers that must remain the only wrapping entry points
+- `mockCloseableEF`, `mockFailingCloseEF`, and related close-counting helpers in `pkg/api/v2/ef_close_once_test.go`: reusable test doubles for close behavior
+- Existing embedded lifecycle tests in `pkg/api/v2/client_local_embedded_test.go`: patterns for asserting preserved state, cleanup errors, and existing-collection behavior
+
+### Established Patterns
+- Embedded existing-collection paths preserve state-backed EFs instead of adopting new override EFs
+- Synchronous setup/promotion cleanup failures are returned as errors; asynchronous cache/state cleanup failures are typically logged
+- Colocated `basicv2` tests with lightweight mocks are preferred over env-gated heavyweight integration tests for narrow bug fixes
+
+### Integration Points
+- `pkg/api/v2/client.go`: mark when the dense EF was SDK-created as the temporary default ORT EF during request preparation
+- `pkg/api/v2/client_local_embedded.go`: close that temporary SDK-owned default EF on the `isNewCreation=false` path before dropping the override
+- `pkg/api/v2/client_local_embedded_test.go`: add one seam-based close regression and one existing-state regression
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The returned existing collection must remain behaviorally identical to today except that the abandoned temporary default ORT EF is no longer leaked.
+- The verification bar is intentionally split:
+  - prove the temporary default EF is closed exactly once
+  - prove the existing collection still uses its original state-backed EF rather than the temporary default
+- The recommended contract is intentionally strict: if cleanup of the SDK-created temporary EF fails, surface that failure immediately rather than hiding it behind logging.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Defer default EF creation until after the existence check — cleaner by construction, but wider shared-flow refactor than Phase 23 allows
+- Unify Phase 23 and Phase 24 into one broader embedded EF lifecycle redesign — explicitly deferred because Phase 24 already owns the closed-EF fallback bug
+- Add ORT-native or env-gated leak-detection/integration harnesses — not required for this narrow bug-fix phase
+- Introduce typed cleanup-error classes or conditional best-effort cleanup behavior — unnecessary scope for Phase 23
+
+</deferred>
+
+---
+
+*Phase: 23-ort-ef-leak-fix*
+*Context gathered: 2026-04-10*

--- a/.planning/phases/23-ort-ef-leak-fix/23-DISCUSSION-LOG.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-DISCUSSION-LOG.md
@@ -1,0 +1,64 @@
+# Phase 23: ORT EF Leak Fix - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-10
+**Phase:** 23-ort-ef-leak-fix
+**Areas discussed:** Fix shape, Verification style, Cleanup failure contract
+
+---
+
+## Fix shape
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Branch-local cleanup in embedded `CreateCollection` with an internal auto-created-default marker (Recommended) | Keep the fix local to the embedded existing-collection path. Detect that the default ORT EF was SDK-created for this request, close it, then discard the temporary override. | ✓ |
+| Defer default EF creation until after the existence check | Avoid creating the default ORT EF on the existing-collection path at all by changing shared request preparation timing. | |
+| Broader lifecycle refactor across prepare/build/create | Redesign EF ownership and creation flow more generally across the request-prep and embedded collection lifecycle. | |
+
+**User's choice:** Recommended option
+**Notes:** This keeps Phase 23 aligned with the existing Phase 20 behavior where existing embedded collections preserve their original state-backed EF/contentEF and do not adopt new overrides.
+
+---
+
+## Verification style
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Narrow close-spy/unit regression with a default-EF factory seam | Add a focused deterministic regression proving the temporary default ORT EF is closed exactly once on the existing-collection path. | |
+| Real ORT integration or leak-detection proof | Use a heavier ORT-native or leak-detection style test to prove end-to-end teardown of runtime resources. | |
+| Mixed: focused seam test plus broader existing-collection lifecycle regression (Recommended) | Pair the focused close regression with a broader behavioral regression proving the existing collection still preserves its original EF/state and does not adopt the temporary default. | ✓ |
+
+**User's choice:** Recommended option
+**Notes:** The mixed option was preferred because it fits the repo’s existing `basicv2` lifecycle-test style without expanding Phase 23 into a brittle ORT-specific integration harness.
+
+---
+
+## Cleanup failure contract
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Return an error if SDK-owned default ORT EF cleanup fails (Recommended) | Treat this as a synchronous request-path failure: if the temporary SDK-created default EF cannot be closed, `CreateCollection` must return an error. | ✓ |
+| Log cleanup failure but still return the existing collection | Preserve idempotent success semantics and rely on logging/stderr for visibility if cleanup fails. | |
+| Conditional or error-class-based behavior | Return success or failure depending on the cleanup error type or whether the error seems benign. | |
+
+**User's choice:** Recommended option
+**Notes:** The stricter contract was preferred because log-only handling in this repo is mostly reserved for asynchronous cache/state cleanup after ownership has already moved elsewhere, not for synchronous request-path cleanup of a temporary SDK-owned resource.
+
+---
+
+## Research notes that informed the decision
+
+- The leak is caused by `PrepareAndValidateCollectionRequest` eagerly creating a default ORT EF before embedded `CreateCollection` discovers the collection already exists.
+- Existing embedded collection behavior is already locked by Phase 20: on the existing-collection path, new override EFs are ignored and the state-backed EF remains authoritative.
+- The repo already separates synchronous setup/cleanup failures from asynchronous background cleanup failures:
+  - setup/promotion cleanup failures are returned
+  - cache/state shutdown cleanup failures are logged
+
+## Deferred Ideas
+
+- Refactor shared create/request-prep flow to delay default EF creation until after the existence check
+- Fold Phase 23 and Phase 24 into a unified embedded EF lifecycle redesign
+- Add an ORT-native leak harness or env-gated integration suite for this path
+- Introduce typed cleanup-error classes for conditional behavior

--- a/.planning/phases/23-ort-ef-leak-fix/23-RESEARCH.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-RESEARCH.md
@@ -1,0 +1,248 @@
+# Phase 23: ORT EF Leak Fix - Research
+
+**Researched:** 2026-04-10
+**Domain:** Embedded V2 collection creation lifecycle and default ORT embedding-function ownership
+**Confidence:** HIGH (direct code and test inspection)
+
+## Summary
+
+Phase 23 is a narrow embedded-client lifecycle fix centered on two files:
+- `pkg/api/v2/client.go`
+- `pkg/api/v2/client_local_embedded.go`
+
+Today `CreateCollectionOp.PrepareAndValidateCollectionRequest()` eagerly creates a default ORT embedding function when the caller does not provide a dense EF:
+
+```go
+defaultedDenseEF := op.embeddingFunction == nil
+if defaultedDenseEF {
+	ef, _, err := ort.NewDefaultEmbeddingFunction()
+	...
+	op.embeddingFunction = ef
+}
+```
+
+Then embedded `CreateCollection()` checks whether `get_or_create` resolved to an existing collection:
+
+```go
+overrideEF := req.embeddingFunction
+...
+if isNewCreation {
+	overrideEF = wrapEFCloseOnce(req.embeddingFunction)
+	...
+} else {
+	overrideEF = nil
+	overrideContentEF = nil
+}
+```
+
+On the `isNewCreation=false` branch, the temporary request EF is dropped before `buildEmbeddedCollection(...)` runs. If that EF is the SDK-created default ORT EF, it is leaked because nothing closes it. This directly violates `EFL-01`.
+
+**Primary recommendation:** keep the phase narrow and fix the leak in embedded `CreateCollection` itself. Add explicit provenance tracking to `CreateCollectionOp` so the embedded client can distinguish:
+- SDK-created default ORT EF that must be cleaned up on the existing-collection path
+- caller-provided dense EF that must never be closed here
+- dual-interface contentEF promotion cases where the temporary default ORT EF was already closed during validation and must not be touched again
+
+The implementation should stay scoped to:
+- `pkg/api/v2/client.go` for provenance tracking on `CreateCollectionOp`
+- `pkg/api/v2/client_local_embedded.go` for cleanup on the `isNewCreation=false` branch
+- colocated `basicv2` tests in `pkg/api/v2/client_local_embedded_test.go` (and only add a helper seam in production code if required to substitute a close-counting default EF)
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **D-01:** Phase 23 uses a narrow embedded-path fix, not a shared create-flow refactor.
+- **D-02:** The fix happens in embedded `CreateCollection` when `isNewCreation=false`: if the dense EF was auto-created by the SDK as the default ORT EF for this request, it must be explicitly closed before the temporary override is discarded.
+- **D-03:** Existing-collection EF precedence does not change. Existing embedded collections keep their state-backed EF/contentEF; temporary override EFs on the existing path are not adopted.
+- **D-04:** Verification uses two layers:
+  - one focused close-spy/unit regression around default EF creation
+  - one broader existing-collection lifecycle regression proving the returned collection still preserves original state and does not adopt the temporary default
+- **D-05:** Verification stays in the standard colocated `basicv2` suite. No ORT-native leak harness is required.
+- **D-06:** If cleanup of the SDK-owned default ORT EF fails on the existing-collection path, `CreateCollection` returns an error.
+- **D-07:** Log-only cleanup is for async/background cleanup paths, not this synchronous request path.
+- **D-08:** Do not defer default EF creation until after the existence check in this phase.
+- **D-09:** Do not introduce conditional or error-class-specific cleanup behavior. Use a plain fail-on-cleanup-error contract.
+
+### the agent's Discretion
+- Exact representation of the “SDK-created default dense EF” marker
+- Exact seam shape for tests that need a close-counting default EF
+- Exact test naming and assertion structure, as long as the two locked verification goals are covered
+
+### Deferred Ideas (OUT OF SCOPE)
+- Deferring default EF creation until after the existence check
+- Folding Phase 23 and Phase 24 into one larger lifecycle redesign
+- ORT-native/env-gated leak harnesses
+- Typed cleanup error classes or best-effort cleanup behavior
+</user_constraints>
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|-----------------|
+| EFL-01 | Default ORT EF created by `PrepareAndValidateCollectionRequest` is closed when `CreateCollection` finds an existing collection | Add request-level provenance for SDK-created default ORT EF, close it on embedded `isNewCreation=false`, and pin close/error/state-preservation regressions |
+
+## Project Constraints
+
+| Constraint | Source | Impact on This Phase |
+|-----------|--------|----------------------|
+| New work targets V2 API | `CLAUDE.md` | All production changes stay in `pkg/api/v2/` |
+| Library code should return errors, not panic | `CLAUDE.md`, `.planning/codebase/CONVENTIONS.md` | Cleanup failure must surface as a returned error, not stderr-only logging or panic |
+| Validate inputs and ownership early | `.planning/codebase/CONVENTIONS.md` | Track default-EF provenance during request preparation so embedded create can make a deterministic cleanup decision |
+| Colocated tests with matching build tags | `CLAUDE.md`, `.planning/codebase/TESTING.md` | Add/extend `basicv2` tests in `pkg/api/v2/client_local_embedded_test.go` |
+| Existing collection state must remain authoritative | Phase 20 context `D-03` | Existing embedded collection state-backed EF/contentEF must still win on the existing-collection path |
+| Close-once wrappers are the only valid wrapping entry points | `pkg/api/v2/ef_close_once.go`, Phase 23 context | Do not introduce ad hoc wrappers while fixing cleanup ownership |
+
+## Standard Stack
+
+No new dependencies are needed.
+
+| Package | Purpose | Status |
+|---------|---------|--------|
+| `github.com/pkg/errors` | wrapped error return for cleanup failure | already used across V2 client code |
+| Go stdlib `io` | detect/close closeable EFs when needed | already used in `pkg/api/v2/client.go` |
+| `github.com/stretchr/testify/require` / `assert` | close-count and existing-state regressions | already used in embedded lifecycle tests |
+
+## Architecture Patterns
+
+### Pattern 1: Track provenance, not just presence
+
+The current code only knows that `req.embeddingFunction` is non-nil after validation. That is not enough for Phase 23 because three cases collapse into the same field:
+- caller supplied a dense EF
+- SDK created default ORT EF
+- SDK created default ORT EF and then replaced it with a dual-interface contentEF during promotion
+
+The plan should explicitly preserve provenance on `CreateCollectionOp`, for example:
+- `autoCreatedDefaultDenseEF bool`
+- or an equivalent marker that remains true only when the current runtime dense EF is still the SDK-created default ORT EF
+
+That marker must be set when `ort.NewDefaultEmbeddingFunction()` succeeds and cleared if the default EF is closed/replaced during contentEF promotion.
+
+### Pattern 2: Cleanup belongs in embedded `CreateCollection` existing-path handling
+
+The embedded `CreateCollection` function already computes `isNewCreation` before deciding whether to publish runtime state. That is the correct place to perform the Phase 23 cleanup because it has all needed context:
+- whether the collection already existed
+- the final `req.embeddingFunction`
+- whether existing state should remain authoritative
+
+Recommended shape:
+- detect `!isNewCreation && req.autoCreatedDefaultDenseEF`
+- if `req.embeddingFunction` implements `io.Closer`, call `Close()` before nulling the override
+- on `Close()` error, return a wrapped error and do not return a collection
+- then continue using existing state-backed EF/contentEF unchanged
+
+This preserves D-02, D-03, D-06, and D-07 without restructuring the broader create flow.
+
+### Pattern 3: Preserve Phase 20 existing-state precedence
+
+`CreateCollection(..., WithIfNotExistsCreate(), WithEmbeddingFunctionCreate(...))` already preserves the original state-backed EF when the collection exists:
+
+```go
+require.Same(t, initialEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+```
+
+Phase 23 must keep that behavior. The leak fix is cleanup of an unused temporary SDK-owned default EF, not adoption of a new override and not any change to state precedence.
+
+### Pattern 4: Use a lightweight seam for default EF creation only if tests need it
+
+The hard part of verification is proving the SDK-created default EF was closed exactly once on the existing path without depending on real ORT runtime setup. The simplest path is a package-level creation seam in `pkg/api/v2/client.go`, for example:
+
+```go
+var newDefaultDenseEF = ort.NewDefaultEmbeddingFunction
+```
+
+Tests can temporarily replace it with a factory that returns a close-counting mock EF. This keeps the production behavior identical while allowing a fast `basicv2` regression.
+
+Do not introduce a broader factory abstraction or plumb new interfaces through the public API; that would exceed the phase boundary.
+
+### Pattern 5: Keep synchronous cleanup failures explicit
+
+The repo already distinguishes between:
+- synchronous setup/ownership failures that return errors
+- asynchronous cleanup failures that may log to stderr
+
+Phase 23 belongs to the first category. If closing the temporary SDK-owned default EF fails, the request path should fail immediately with a returned error. This matches the existing repository style and the locked context.
+
+## Recommended File Layout
+
+```text
+pkg/api/v2/
+├── client.go                       # provenance for SDK-created default ORT EF
+├── client_local_embedded.go        # cleanup on existing-collection path
+└── client_local_embedded_test.go   # close-count + existing-state regressions
+```
+
+## Common Pitfalls
+
+### Pitfall 1: Using “embeddingFunction was nil at input” as the only ownership test
+
+That signal becomes wrong when a dual-interface contentEF is promoted. `PrepareAndValidateCollectionRequest()` can create a default ORT EF, close it during promotion, and replace `op.embeddingFunction` with the contentEF-derived dense EF. A stale “input was nil” flag would make embedded `CreateCollection` think it still owns the current dense EF.
+
+**Mitigation:** track whether the current final dense EF is still the SDK-created default ORT EF after validation completes.
+
+### Pitfall 2: Closing caller-provided or state-backed EFs
+
+The existing collection path intentionally ignores new override EFs and preserves prior state. Phase 23 must not broaden that into “close any unused override EF.” The cleanup target is only the SDK-created temporary default ORT EF.
+
+**Mitigation:** gate cleanup on the explicit provenance marker, not on generic “overrideEF != nil”.
+
+### Pitfall 3: Moving default EF creation later in the flow
+
+That would be cleaner by construction, but it is a shared-flow refactor and was explicitly deferred in the phase context.
+
+**Mitigation:** stay with the existing eager creation flow and add narrow cleanup/provenance logic around it.
+
+### Pitfall 4: Hiding cleanup failure behind stderr logging
+
+`close_logging.go` patterns are used for background cleanup, cache cleanup, and panic-safe teardown. This phase is a synchronous request path where the SDK still owns the temporary EF.
+
+**Mitigation:** return a wrapped error from `CreateCollection` if the cleanup `Close()` fails.
+
+### Pitfall 5: Relying only on existing-state regression tests
+
+The current tests already prove that existing collections preserve original state, but they do not prove the temporary default ORT EF was cleaned up.
+
+**Mitigation:** add both:
+- one close-spy regression around default EF creation on the existing path
+- one existing-state regression showing original EF/state still wins after the fix
+
+## Threat Model Notes
+
+This phase does not introduce a new external trust boundary. The relevant risk is resource/lifecycle correctness inside the SDK:
+- **Threat:** repeated `CreateCollection(..., WithIfNotExistsCreate())` calls with no explicit dense EF leak ORT runtime resources when the collection already exists
+- **Impact:** process-level resource growth, hidden lifecycle bug, and nondeterministic failures over time
+- **Severity:** medium robustness risk, low direct security risk
+- **Mitigation:** deterministic cleanup of SDK-owned temporary default EF, plus regression coverage for close-exactly-once and preserved existing-state behavior
+
+No high-severity STRIDE-style threats were found. The planner should still include a concise `<threat_model>` block covering ownership confusion and resource leakage.
+
+## Validation Architecture
+
+### Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| Framework | `go test` |
+| Config file | `Makefile` / existing `basicv2` build tag |
+| Quick run command | `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` |
+| Full suite command | `make test` |
+| Lint command | `make lint` |
+| Estimated runtime | quick run ~10s, full suite depends on local cache/runtime setup |
+
+### Verification Strategy
+
+- Add a focused close-spy regression that forces `PrepareAndValidateCollectionRequest()` to create a mock default EF and proves the embedded existing-collection path closes it exactly once.
+- Add a focused failure regression proving that when the temporary SDK-owned default EF `Close()` returns an error, `CreateCollection(..., WithIfNotExistsCreate())` returns an error rather than success.
+- Keep or extend the existing existing-state regression so the returned collection still uses the original state-backed EF and metadata/content state on the existing path.
+- Run the focused `basicv2` tests after the code change, then `make test`, then `make lint`.
+
+### Required Assertions
+
+- The request-prep path records whether the final runtime dense EF is the SDK-created default ORT EF.
+- On the existing-collection path, that SDK-owned default EF is closed exactly once before the override is discarded.
+- A close failure on that cleanup path returns a non-nil error from `CreateCollection`.
+- Existing collection state still wins: the returned embedded collection uses the original stored EF/contentEF rather than the temporary default.
+- Non-existing collection creation behavior is unchanged.
+
+---
+
+_Research synthesized locally on 2026-04-10 after the dedicated researcher did not materialize an artifact in this session._

--- a/.planning/phases/23-ort-ef-leak-fix/23-REVIEW-FIX.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-REVIEW-FIX.md
@@ -1,0 +1,36 @@
+---
+phase: 23
+fixed_at: 2026-04-11T10:41:48Z
+review_path: .planning/phases/23-ort-ef-leak-fix/23-REVIEW.md
+iteration: 1
+findings_in_scope: 1
+fixed: 1
+skipped: 0
+status: all_fixed
+---
+
+# Phase 23: Code Review Fix Report
+
+**Fixed at:** 2026-04-11T10:41:48Z
+**Source review:** `.planning/phases/23-ort-ef-leak-fix/23-REVIEW.md`
+**Iteration:** 1
+
+**Summary:**
+- Findings in scope: 1
+- Fixed: 1
+- Skipped: 0
+
+## Fixed Issues
+
+### WR-01: Existing-collection cleanup still hinges on a stale preflight lookup
+
+**Status:** fixed: requires human verification
+**Files modified:** `pkg/api/v2/client_local_embedded.go`, `pkg/api/v2/client_local_embedded_test.go`
+**Commit:** `9c4eb13`
+**Applied fix:** Replaced the preflight boolean with returned-model identity checks plus existing client-owned state/cache detection, so `CreateCollection(..., WithIfNotExistsCreate())` only runs the existing-collection cleanup path when the returned model is truly the collection this client already owns. Added regressions for both a missed preflight probe against an already-owned collection and a stale-positive probe that returns a deleted collection before a replacement is created.
+
+---
+
+_Fixed: 2026-04-11T10:41:48Z_
+_Fixer: Claude (gsd-code-fixer)_
+_Iteration: 1_

--- a/.planning/phases/23-ort-ef-leak-fix/23-REVIEW.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-REVIEW.md
@@ -1,0 +1,46 @@
+---
+phase: 23-ort-ef-leak-fix
+reviewed: 2026-04-11T09:48:23Z
+depth: standard
+files_reviewed: 3
+files_reviewed_list:
+  - pkg/api/v2/client.go
+  - pkg/api/v2/client_local_embedded.go
+  - pkg/api/v2/client_local_embedded_test.go
+findings:
+  critical: 0
+  warning: 0
+  info: 0
+  total: 0
+status: clean
+---
+
+# Phase 23: Code Review Report
+
+## Summary
+
+Reviewed the Phase 23 changes in `pkg/api/v2/client.go`, `pkg/api/v2/client_local_embedded.go`, and `pkg/api/v2/client_local_embedded_test.go` covering the default ORT EF leak fix for embedded idempotent create calls.
+
+**Verdict: clean.** The implementation follows the narrow phase boundary, avoids the rejected package-global seam, preserves existing embedded collection state precedence, and adds the expected regression coverage for cleanup success, cleanup failure, and new-collection ownership.
+
+## Checks Performed
+
+- Confirmed `CreateCollectionOp` uses a per-op `defaultDenseEFFactory` seam and `sdkOwnedDefaultDenseEF` pointer tracking rather than a boolean-only provenance marker.
+- Confirmed `PrepareAndValidateCollectionRequest()` clears `sdkOwnedDefaultDenseEF` up front and nils it again when dual-interface content EF promotion replaces the temporary default.
+- Confirmed embedded `CreateCollection()` only closes the tracked SDK-owned default EF when the live runtime dense EF is still that exact instance.
+- Confirmed cleanup failures return the exact wrapped error `error closing default embedding function for existing collection`.
+- Confirmed the three focused `basicv2` regressions exercise the required cleanup, error, and ownership-transfer paths without widening the phase scope.
+
+## Notes
+
+- Targeted verification passed locally:
+
+```bash
+go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...
+```
+
+---
+
+_Reviewed: 2026-04-11T09:48:23Z_
+_Reviewer: Codex manual review_
+_Depth: standard_

--- a/.planning/phases/23-ort-ef-leak-fix/23-REVIEW.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-REVIEW.md
@@ -1,6 +1,6 @@
 ---
 phase: 23-ort-ef-leak-fix
-reviewed: 2026-04-11T09:48:23Z
+reviewed: 2026-04-11T10:14:44Z
 depth: standard
 files_reviewed: 3
 files_reviewed_list:
@@ -9,38 +9,57 @@ files_reviewed_list:
   - pkg/api/v2/client_local_embedded_test.go
 findings:
   critical: 0
-  warning: 0
+  warning: 1
   info: 0
-  total: 0
-status: clean
+  total: 1
+status: issues_found
 ---
 
 # Phase 23: Code Review Report
 
+**Reviewed:** 2026-04-11T10:14:44Z
+**Depth:** standard
+**Files Reviewed:** 3
+**Status:** issues_found
+
 ## Summary
 
-Reviewed the Phase 23 changes in `pkg/api/v2/client.go`, `pkg/api/v2/client_local_embedded.go`, and `pkg/api/v2/client_local_embedded_test.go` covering the default ORT EF leak fix for embedded idempotent create calls.
+Reviewed the Phase 23 ORT EF lifecycle change across request preparation, embedded `CreateCollection`, and the new lifecycle regressions. The steady-state existing/new paths are covered, but the cleanup decision still depends on a separate preflight lookup instead of the actual `CreateCollection` result, which leaves a race window around ownership and leak handling.
 
-**Verdict: clean.** The implementation follows the narrow phase boundary, avoids the rejected package-global seam, preserves existing embedded collection state precedence, and adds the expected regression coverage for cleanup success, cleanup failure, and new-collection ownership.
+## Warnings
 
-## Checks Performed
+### WR-01: Existing-collection cleanup still hinges on a stale preflight lookup
 
-- Confirmed `CreateCollectionOp` uses a per-op `defaultDenseEFFactory` seam and `sdkOwnedDefaultDenseEF` pointer tracking rather than a boolean-only provenance marker.
-- Confirmed `PrepareAndValidateCollectionRequest()` clears `sdkOwnedDefaultDenseEF` up front and nils it again when dual-interface content EF promotion replaces the temporary default.
-- Confirmed embedded `CreateCollection()` only closes the tracked SDK-owned default EF when the live runtime dense EF is still that exact instance.
-- Confirmed cleanup failures return the exact wrapped error `error closing default embedding function for existing collection`.
-- Confirmed the three focused `basicv2` regressions exercise the required cleanup, error, and ownership-transfer paths without widening the phase scope.
+**File:** `pkg/api/v2/client_local_embedded.go:367-421`, `pkg/api/v2/client_local_embedded_test.go:1661-1748`
+**Issue:** `CreateCollection(..., WithIfNotExistsCreate())` decides whether to preserve or close the temporary default EF from a separate `GetCollection` probe before it calls `embedded.CreateCollection`. That boolean is then treated as authoritative for the cleanup on lines 409-418. If the probe races with delete/recreate or transiently misses the existing collection, the Phase 23 fix can still do the wrong thing: an existing collection can go down the "new" branch and leak/adopt the temporary default, or a recreated collection can go down the "existing" branch and skip wiring the EF it now owns. The new tests only exercise the stable memory-runtime case, so this TOCTOU path is not covered.
+**Fix:**
+```go
+existingID := ""
+if req.CreateIfNotExists {
+	existing, lookupErr := client.embedded.GetCollection(localchroma.EmbeddedGetCollectionRequest{
+		Name:         req.Name,
+		TenantID:     req.Database.Tenant().Name(),
+		DatabaseName: req.Database.Name(),
+	})
+	if lookupErr == nil && existing != nil {
+		existingID = existing.ID
+	}
+}
 
-## Notes
+model, err := client.embedded.CreateCollection(...)
+if err != nil {
+	return nil, err
+}
 
-- Targeted verification passed locally:
-
-```bash
-go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...
+// Only treat this as the existing-path cleanup case when the returned model
+// matches the collection observed before the create call.
+sameExistingCollection := existingID != "" && model.ID == existingID
 ```
+
+Use that stronger signal for the cleanup branch, or preferably extend the embedded runtime API to return whether the collection was newly created versus reused. Add a regression runtime that makes the probe stale or fail while `CreateCollection(GetOrCreate=true)` returns a valid model, and assert the temporary default EF is closed only when the returned model really is the pre-existing collection.
 
 ---
 
-_Reviewed: 2026-04-11T09:48:23Z_
-_Reviewer: Codex manual review_
+_Reviewed: 2026-04-11T10:14:44Z_
+_Reviewer: Codex (gsd-code-reviewer)_
 _Depth: standard_

--- a/.planning/phases/23-ort-ef-leak-fix/23-REVIEWS.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-REVIEWS.md
@@ -1,0 +1,112 @@
+---
+phase: 23
+reviewers: [gemini, claude]
+reviewed_at: 2026-04-10T20:33:38+0300
+plans_reviewed: [23-01-PLAN.md]
+---
+
+# Cross-AI Plan Review - Phase 23
+
+## Gemini Review
+
+Invocation note: the Gemini CLI repeatedly stalled on the full and medium review packets in this environment. The review below was captured from a reduced prompt covering the core implementation, ownership, cleanup, and testing plan.
+
+Here is the summary of the Go bugfix plan:
+
+*   **Track SDK-managed ORT EF**: Add a boolean marker to identify when the default ONNX Runtime (ORT) Embedding Function is automatically initialized by the SDK.
+*   **Ensure Lifecycle Cleanup**: Explicitly close the SDK-created ORT EF when navigating the "existing collection" path to prevent resource leaks.
+*   **Strict Error Propagation**: Update the closing logic to return and handle errors if the embedding function fails to shut down correctly.
+*   **Maintain State Precedence**: Ensure the new tracking logic preserves existing priority rules for user-provided state and configurations.
+*   **Verify with Focused Tests**: Implement targeted test cases to validate proper initialization, resource cleanup, and error handling for the default EF lifecycle.
+
+---
+
+## Claude Review
+
+I don't have file-reading tools available in this environment, so I'll review the plan based on the detailed description provided and my knowledge of the codebase from prior context.
+
+---
+
+## Summary
+
+Phase 23 fixes a resource leak where `PrepareAndValidateCollectionRequest()` eagerly creates a default ORT (ONNX Runtime) dense embedding function, which is then silently discarded-without cleanup-when `CreateCollection` with `WithIfNotExistsCreate()` discovers the collection already exists. The fix adds an ownership marker (`sdkCreatedDefaultDenseEF`) to track whether the SDK created the default EF, then conditionally closes it on the existing-collection branch. The scope is intentionally narrow: no refactoring of the shared create flow, no deferred creation.
+
+---
+
+## Strengths
+
+1. **Precise ownership tracking.** The boolean marker `sdkCreatedDefaultDenseEF` is a clean, minimal way to distinguish SDK-created temporaries from caller-provided or state-backed EFs. This directly prevents the most dangerous class of bug-closing something the caller still owns.
+
+2. **Error-on-cleanup-failure is the right call.** Returning an error rather than logging-and-succeeding means the caller can't silently accumulate leaked ORT runtimes. This matches the library's panic-prevention philosophy: surface problems, don't hide them.
+
+3. **Narrow scope with clear boundaries.** The locked decisions explicitly prevent scope creep (no deferred creation refactor, no shared-flow changes). This keeps the blast radius small for a v0.4.2 patch.
+
+4. **Test plan covers the critical paths.** The three named tests cover: (a) successful cleanup, (b) cleanup-error propagation, and (c) regression guard for existing-state precedence. That's the right triangle of coverage.
+
+5. **Package-level seam for testability.** Introducing `newDefaultDenseEF` as a replaceable function variable lets tests inject a mock/spy without touching ORT, making the leak-fix tests fast and deterministic.
+
+---
+
+## Concerns
+
+1. **HIGH - Marker cleared on contentEF promotion may be incomplete.** The plan says "clear [the marker] if contentEF promotion closes/replaces that temporary default." But `PrepareAndValidateCollectionRequest` has multiple branches where the default EF could be superseded-not just contentEF promotion. If a caller passes a sparse EF but no dense EF, the default is created, and later logic may or may not replace it. Every branch that overwrites `req.embeddingFunction` after the default was assigned must also clear the marker, or the cleanup code on the existing-collection path may try to close an EF that's already been replaced (double-close) or skip closing one that's still live (leak). I'd recommend an explicit audit of all write-paths to `req.embeddingFunction` within `PrepareAndValidateCollectionRequest`.
+
+2. **HIGH - Race condition on the package-level `newDefaultDenseEF` seam.** If tests run in parallel (which `go test` does by default for separate packages, and can do within a package via `t.Parallel()`), swapping a package-level variable is a data race. This should either use `sync` protection, or the seam should be a field on the client/op struct rather than package-level. A struct-level field is safer and keeps the seam scoped to the operation.
+
+3. **MEDIUM - `Close()` interface check is brittle.** The plan says "if `req.embeddingFunction` is closable, call `Close()`." This relies on a type assertion to `io.Closer` (or similar). If the ORT EF's `Close` method is on a pointer receiver and the EF is stored as a non-pointer interface value, the assertion could silently fail, leaving the leak in place. The plan should specify the exact interface assertion and confirm it matches ORT's concrete type.
+
+4. **MEDIUM - Error wrapping semantics.** The plan specifies the error message `"error closing default embedding function for existing collection"` but doesn't mention whether this wraps the underlying close error with `%w`. For callers to use `errors.Is`/`errors.As`, the underlying error must be wrapped. This should be explicit: `fmt.Errorf("... : %w", closeErr)`.
+
+5. **LOW - Test naming is very long.** `TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDefaultAndPreservesState` is 90+ characters. While not a functional issue, it'll be truncated in most CI output. Consider shortening to something like `TestEmbeddedCreate_ExistingCollCleansTempEF`.
+
+6. **LOW - No test for the happy path (new collection, default EF kept).** The plan covers the existing-collection path but doesn't explicitly add a test proving that when a collection is newly created, the default EF is *not* closed. This is a regression guard for the marker logic itself.
+
+---
+
+## Suggestions
+
+1. **Move the seam from package-level to `CreateCollectionOp` struct.** Instead of `var newDefaultDenseEF = ort.NewDefaultEmbeddingFunction`, add a `defaultDenseEFFactory` field to the op struct (or the client). Tests set it per-instance. This eliminates the parallel-test race and keeps the seam scoped.
+
+2. **Add a `defaultDenseEFInstance` field alongside the marker.** Instead of just a boolean, store a reference to the actual default EF that was created. On the cleanup branch, compare `req.embeddingFunction == req.defaultDenseEFInstance` before closing. This is a pointer-equality check that's immune to the "marker not cleared on some branch" bug-if the EF was already replaced, the comparison fails and cleanup is skipped.
+
+3. **Add a happy-path regression test.** Something like `TestEmbeddedCreate_NewCollRetainsDefaultEF` that verifies the default EF is *not* closed when the collection is genuinely new. This catches accidental over-eager cleanup.
+
+4. **Explicitly specify the `Close()` interface.** State whether you're asserting `io.Closer` or a custom interface like `EmbeddingFunctionCloser`. Confirm with a compile-time check (`var _ io.Closer = (*ort.DefaultEmbeddingFunction)(nil)`) in the test file.
+
+5. **Consider a brief doc comment on `sdkCreatedDefaultDenseEF`.** I know the guidelines say minimize comments, but an unexported boolean marker on a request struct is the kind of "hidden invariant" that warrants a one-liner explaining when it's set and who clears it.
+
+---
+
+## Risk Assessment
+
+| Area | Risk | Rationale |
+|------|------|-----------|
+| Correctness | **Medium** | The marker approach is sound but has edge cases around multi-branch overwrites of `req.embeddingFunction`. Suggestion #2 (pointer comparison) would reduce this to low. |
+| Regressions | **Low** | The existing `IfNotExistsExistingDoesNotOverrideState` test is preserved. The fix is additive (new marker, new cleanup branch) and doesn't modify existing logic paths. |
+| Test reliability | **Medium** | Package-level seam introduces a potential data race in parallel tests. Moving it to the struct eliminates this. |
+| Scope creep | **Low** | Locked decisions are well-defined and the plan stays within them. |
+| Performance | **Negligible** | One boolean check and one potential `Close()` call on an already-rare path. |
+
+**Overall:** The plan is well-scoped and addresses the right root cause. The two HIGH concerns (marker clearing completeness and the package-level seam race) should be resolved before implementation. With the suggested pointer-comparison approach and struct-level seam, this becomes a clean, low-risk fix.
+
+---
+
+## Consensus Summary
+
+### Agreed Strengths
+
+- The plan is correctly centered on explicit SDK ownership tracking for the temporary default ORT EF.
+- The cleanup must happen on the embedded existing-collection path rather than through a broader create-flow refactor.
+- Preserving existing state-backed EF/contentEF precedence is the right safety boundary.
+- Focused regression coverage around cleanup behavior is necessary and appropriate.
+
+### Agreed Concerns
+
+- No concrete concern was explicitly raised by both reviewers. Gemini's reduced fallback review affirmed the core direction without surfacing specific objections.
+- Highest-priority concern from the detailed review: the ownership marker must stay aligned with the final `embeddingFunction` on every replacement path, or the fix can turn into either a leak or an accidental close.
+- Highest-priority concern from the detailed review: the package-level `newDefaultDenseEF` seam can create parallel-test race risk unless it is scoped or synchronized.
+
+### Divergent Views
+
+- Claude provided implementation-level objections around marker invalidation, seam design, `io.Closer` assertion details, and missing happy-path coverage.
+- Gemini's fallback review stayed at the architectural level and did not challenge the plan's core shape; it mainly validated tracking, cleanup, explicit error handling, state precedence, and focused tests as the right categories.

--- a/.planning/phases/23-ort-ef-leak-fix/23-VALIDATION.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-VALIDATION.md
@@ -1,0 +1,70 @@
+---
+phase: 23
+slug: ort-ef-leak-fix
+status: draft
+nyquist_compliant: false
+wave_0_complete: true
+created: 2026-04-10
+---
+
+# Phase 23 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | `go test` |
+| **Config file** | `Makefile` / existing `basicv2` build tag |
+| **Quick run command** | `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` |
+| **Full suite command** | `make test` |
+| **Estimated runtime** | ~10s focused / longer for full V2 suite |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...`
+- **After every plan wave:** Run `make test`
+- **Before `/gsd-verify-work`:** `make test` and `make lint` must be green
+- **Max feedback latency:** 45 seconds for focused feedback
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 23-01-01 | 01 | 1 | EFL-01 | T-23-01 / ownership confusion | Embedded `CreateCollection` closes the SDK-owned default ORT EF exactly once on the existing-collection path and returns an error if that cleanup fails | unit | `go test -tags=basicv2 -run 'TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` | ✅ | ⬜ pending |
+| 23-01-02 | 01 | 1 | EFL-01 | T-23-01 / resource leak | Existing embedded collection state still wins after `WithIfNotExistsCreate()`; no temporary default EF is adopted into the returned collection | unit | `go test -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState' ./pkg/api/v2/...` | ✅ | ⬜ pending |
+| 23-01-03 | 01 | 2 | EFL-01 | T-23-01 / regression safety | Embedded V2 lifecycle tests remain green after the leak fix | unit | `make test` | ✅ | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+Existing infrastructure covers all phase requirements.
+
+---
+
+## Manual-Only Verifications
+
+All phase behaviors can be validated with automated tests in this phase.
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references
+- [x] No watch-mode flags
+- [x] Feedback latency < 45s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/23-ort-ef-leak-fix/23-VERIFICATION.md
+++ b/.planning/phases/23-ort-ef-leak-fix/23-VERIFICATION.md
@@ -1,0 +1,88 @@
+---
+phase: 23-ort-ef-leak-fix
+verified: 2026-04-11T09:48:23Z
+status: passed
+score: 8/8 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 23: ORT EF Leak Fix Verification Report
+
+**Phase Goal:** Default ORT embedding function is properly cleaned up when `CreateCollection` encounters an existing collection  
+**Verified:** 2026-04-11T09:48:23Z  
+**Status:** passed  
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | `CreateCollectionOp` exposes a per-op default dense EF factory seam instead of a package-global override | ✓ VERIFIED | `pkg/api/v2/client.go:245-258` defines `defaultDenseEFFactory` and stores it on `CreateCollectionOp`; `pkg/api/v2/client.go:523-528` adds the package-local `withDefaultDenseEFFactoryCreate(...)` helper. |
+| 2 | Request validation resets default-EF provenance on every run so stale ownership cannot leak across reuse | ✓ VERIFIED | `pkg/api/v2/client.go:277-283` clears `op.sdkOwnedDefaultDenseEF = nil` before any default creation logic. |
+| 3 | When validation auto-creates the default dense EF, it tracks the exact SDK-owned instance that is currently active | ✓ VERIFIED | `pkg/api/v2/client.go:288-293` calls `op.defaultDenseEFFactory()`, assigns the EF to `op.embeddingFunction`, and stores the same instance in `op.sdkOwnedDefaultDenseEF`. |
+| 4 | Dual-interface content-EF promotion clears the tracked SDK-owned default before replacing the runtime dense EF | ✓ VERIFIED | `pkg/api/v2/client.go:330-337` closes the temporary default during promotion, nils `op.sdkOwnedDefaultDenseEF`, and then swaps in the promoted dense EF. |
+| 5 | Embedded existing-collection create closes only the tracked SDK-owned default EF when it is still the live dense EF | ✓ VERIFIED | `pkg/api/v2/client_local_embedded.go:409-418` gates cleanup on `req.sdkOwnedDefaultDenseEF != nil && req.embeddingFunction == req.sdkOwnedDefaultDenseEF` before discarding overrides. |
+| 6 | Cleanup failures surface synchronously with the exact wrapped error required by the plan | ✓ VERIFIED | `pkg/api/v2/client_local_embedded.go:411-417` returns `errors.Wrap(err, "error closing default embedding function for existing collection")` if `Close()` fails. |
+| 7 | Existing embedded collection state still wins on the idempotent create path while the temporary default is closed exactly once | ✓ VERIFIED | `pkg/api/v2/client_local_embedded_test.go:1661-1697` proves the temporary default close count reaches `1` while `gotCollection.embeddingFunctionSnapshot()` still unwraps to `initialEF` and metadata remains `"initial"`. |
+| 8 | New embedded collection creation does not eagerly close the temporary default; ownership transfers to collection close | ✓ VERIFIED | `pkg/api/v2/client_local_embedded_test.go:1727-1748` asserts close count `0` before `got.Close()` and `1` after the collection is closed. |
+
+**Score:** 8/8 truths verified
+
+### Roadmap Success Criteria
+
+| # | Success Criterion | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | When `CreateCollection` finds an existing collection, any default ORT EF created by `PrepareAndValidateCollectionRequest` is closed | ✓ VERIFIED | Proven structurally by `pkg/api/v2/client.go:288-293` plus `pkg/api/v2/client_local_embedded.go:409-418`, and behaviorally by `pkg/api/v2/client_local_embedded_test.go:1661-1697` and the uncached focused regression run below. |
+| 2 | No ORT runtime resources remain open after `CreateCollection` returns in the existing-collection path | ✓ VERIFIED | The phase uses close-counting lifecycle regressions rather than native leak instrumentation. `pkg/api/v2/client_local_embedded_test.go:1661-1697` verifies the SDK-owned temporary default is closed exactly once before return, which is the phase’s explicit cleanup contract for releasing the owned ORT resource. |
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `pkg/api/v2/client.go` | Per-op seam, explicit SDK-owned default EF provenance, and no package-global test seam | ✓ VERIFIED | `pkg/api/v2/client.go:245-258`, `261-293`, `330-337`, and `523-528` contain the new seam/provenance logic. `rg -n "var newDefaultDenseEF = ort.NewDefaultEmbeddingFunction" pkg/api/v2/client.go` returned `absent`. |
+| `pkg/api/v2/client_local_embedded.go` | Existing-path cleanup gate with exact closability and wrapped-error behavior | ✓ VERIFIED | `pkg/api/v2/client_local_embedded.go:409-418` contains the exact cleanup gate, closability error, and wrapped cleanup error string. |
+| `pkg/api/v2/client_local_embedded_test.go` | Focused `basicv2` regressions for existing-path cleanup, cleanup failure, and new-collection ownership | ✓ VERIFIED | `pkg/api/v2/client_local_embedded_test.go:1661-1748` contains all three required tests with close-count and state-preservation assertions. |
+| `.planning/phases/23-ort-ef-leak-fix/23-01-SUMMARY.md` | Execution summary tied to the phase commits and verification output | ✓ VERIFIED | Summary exists on disk and was committed in `62c4351`. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `pkg/api/v2/client.go:261-293` | `pkg/api/v2/client_local_embedded.go:409-418` | Tracked `sdkOwnedDefaultDenseEF` instance gates existing-path cleanup | WIRED | Validation records the exact SDK-owned default EF instance and the embedded existing-path cleanup only runs when the live dense EF is still that same instance. |
+| `pkg/api/v2/client.go:330-337` | `pkg/api/v2/client_local_embedded.go:409-418` | Promotion clears stale provenance before cleanup can run | WIRED | Content-EF promotion nils `sdkOwnedDefaultDenseEF` before swapping the dense EF, so the embedded cleanup gate cannot close a replaced runtime EF. |
+| `pkg/api/v2/client_local_embedded.go:409-418` | `pkg/api/v2/client_local_embedded_test.go:1661-1748` | Regression tests prove success, failure, and new-collection ownership behavior | WIRED | The three focused tests exercise the cleanup success path, cleanup-error propagation, and non-eager-close behavior for new collections. |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Existing-path cleanup, cleanup-error propagation, and Phase 20 precedence guard | `go test -count=1 -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState\|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.483s` | ✓ PASS |
+| Full V2 regression suite | `make test` | `DONE 1732 tests, 7 skipped` | ✓ PASS |
+| Lint gate | `make lint` | `0 issues.` | ✓ PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| `EFL-01` | `23-01-PLAN.md` | Default ORT EF created by `PrepareAndValidateCollectionRequest` is closed when `CreateCollection` finds an existing collection | ✓ SATISFIED | `REQUIREMENTS.md:17` defines the requirement and `REQUIREMENTS.md:67` maps it to Phase 23. The implementation and focused regressions above verify the SDK-owned temporary default EF is closed on the embedded existing path and that cleanup errors are returned synchronously. |
+
+Orphaned requirements for Phase 23: none. `23-01-PLAN.md` declares only `EFL-01`, and `REQUIREMENTS.md` maps only `EFL-01` to Phase 23.
+
+### Anti-Patterns Found
+
+None. The rejected package-global seam is absent, ownership tracking uses the actual EF instance rather than a boolean-only marker, and the phase stays within the narrow embedded lifecycle scope defined by the plan and context.
+
+### Human Verification Required
+
+None. The phase goal and all must-haves are verifiable programmatically through direct code inspection and automated test evidence.
+
+### Gaps Summary
+
+No gaps found. The phase goal is achieved, `EFL-01` is fully satisfied, the focused uncached regression slice passes, the repo-wide `make test` and `make lint` gates are green, and the implementation matches the plan’s must-haves without widening into Phase 24 or a broader create-flow refactor.
+
+---
+
+_Verified: 2026-04-11T09:48:23Z_  
+_Verifier: Codex manual verification_

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -519,6 +519,7 @@ func WithEmbeddingFunctionCreate(embeddingFunction embeddings.EmbeddingFunction)
 	}
 }
 
+//nolint:unused // Package-local seam used by basicv2 tests to inject a default EF per create op.
 func withDefaultDenseEFFactoryCreate(factory defaultDenseEFFactory) CreateCollectionOption {
 	return func(op *CreateCollectionOp) error {
 		if factory == nil {

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -271,6 +271,22 @@ func (op *CreateCollectionOp) ensureDefaultDenseEFFactory() {
 	op.defaultDenseEFFactory = newDefaultDenseEFFactory()
 }
 
+func (op *CreateCollectionOp) closeSDKOwnedDefaultDenseEF(wrapMessage string) error {
+	if op == nil || op.sdkOwnedDefaultDenseEF == nil || op.embeddingFunction != op.sdkOwnedDefaultDenseEF {
+		return nil
+	}
+	sdkOwnedDefaultEF := op.sdkOwnedDefaultDenseEF
+	closer, ok := sdkOwnedDefaultEF.(io.Closer)
+	if !ok {
+		return errors.New("sdk-owned default embedding function is not closable")
+	}
+	op.sdkOwnedDefaultDenseEF = nil
+	if err := closer.Close(); err != nil {
+		return errors.Wrap(err, wrapMessage)
+	}
+	return nil
+}
+
 func NewCreateCollectionOp(name string, opts ...CreateCollectionOption) (*CreateCollectionOp, error) {
 	op := &CreateCollectionOp{
 		Name:                  name,
@@ -293,10 +309,7 @@ func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
 	defaultedDenseEF := op.embeddingFunction == nil
 	if defaultedDenseEF {
 		op.ensureDefaultDenseEFFactory()
-		// Keep the returned close function out of here: collection constructors own the
-		// embedding function lifecycle and will close it via collection.Close().
-		// The EF object is retained in op.embeddingFunction, so its Close() method
-		// remains reachable without storing the separate closer return value.
+		// Track SDK-owned default EF so non-collection paths can clean it up explicitly.
 		ef, _, err := op.defaultDenseEFFactory()
 		if err != nil {
 			return errors.Wrap(err, "error creating default embedding function")
@@ -340,12 +353,9 @@ func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
 			// denseEF was provided, so the returned collection uses the same EF
 			// that was persisted to config (avoids mixed-model embeddings).
 			if defaultedDenseEF {
-				if closer, ok := op.embeddingFunction.(io.Closer); ok {
-					if err := closer.Close(); err != nil {
-						return errors.Wrap(err, "error closing default embedding function during contentEF promotion")
-					}
+				if err := op.closeSDKOwnedDefaultDenseEF("error closing default embedding function during contentEF promotion"); err != nil {
+					return err
 				}
-				op.sdkOwnedDefaultDenseEF = nil
 				op.embeddingFunction = denseEF
 			}
 		} else if op.Schema == nil {

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -244,6 +244,12 @@ type CreateCollectionOption func(*CreateCollectionOp) error
 
 type defaultDenseEFFactory func() (embeddings.EmbeddingFunction, func() error, error)
 
+func newDefaultDenseEFFactory() defaultDenseEFFactory {
+	return func() (embeddings.EmbeddingFunction, func() error, error) {
+		return ort.NewDefaultEmbeddingFunction()
+	}
+}
+
 type CreateCollectionOp struct {
 	Name                     string                              `json:"name"`
 	CreateIfNotExists        bool                                `json:"get_or_create,omitempty"`
@@ -258,12 +264,17 @@ type CreateCollectionOp struct {
 	sdkOwnedDefaultDenseEF   embeddings.EmbeddingFunction        `json:"-"`
 }
 
+func (op *CreateCollectionOp) ensureDefaultDenseEFFactory() {
+	if op.defaultDenseEFFactory != nil {
+		return
+	}
+	op.defaultDenseEFFactory = newDefaultDenseEFFactory()
+}
+
 func NewCreateCollectionOp(name string, opts ...CreateCollectionOption) (*CreateCollectionOp, error) {
 	op := &CreateCollectionOp{
-		Name: name,
-		defaultDenseEFFactory: func() (embeddings.EmbeddingFunction, func() error, error) {
-			return ort.NewDefaultEmbeddingFunction()
-		},
+		Name:                  name,
+		defaultDenseEFFactory: newDefaultDenseEFFactory(),
 	}
 	for _, opt := range opts {
 		err := opt(op)
@@ -281,6 +292,7 @@ func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
 	op.sdkOwnedDefaultDenseEF = nil
 	defaultedDenseEF := op.embeddingFunction == nil
 	if defaultedDenseEF {
+		op.ensureDefaultDenseEFFactory()
 		// Keep the returned close function out of here: collection constructors own the
 		// embedding function lifecycle and will close it via collection.Close().
 		// The EF object is retained in op.embeddingFunction, so its Close() method
@@ -362,6 +374,7 @@ func (op *CreateCollectionOp) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	op.Metadata = aux.Metadata
+	op.ensureDefaultDenseEFFactory()
 	return nil
 }
 

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -242,6 +242,8 @@ func NewGetCollectionOp(opts ...GetCollectionOption) (*GetCollectionOp, error) {
 
 type CreateCollectionOption func(*CreateCollectionOp) error
 
+type defaultDenseEFFactory func() (embeddings.EmbeddingFunction, func() error, error)
+
 type CreateCollectionOp struct {
 	Name                     string                              `json:"name"`
 	CreateIfNotExists        bool                                `json:"get_or_create,omitempty"`
@@ -252,11 +254,16 @@ type CreateCollectionOp struct {
 	Schema                   *Schema                             `json:"schema,omitempty"`
 	Database                 Database                            `json:"-"`
 	disableEFConfigStorage   bool                                `json:"-"`
+	defaultDenseEFFactory    defaultDenseEFFactory               `json:"-"`
+	sdkOwnedDefaultDenseEF   embeddings.EmbeddingFunction        `json:"-"`
 }
 
 func NewCreateCollectionOp(name string, opts ...CreateCollectionOption) (*CreateCollectionOp, error) {
 	op := &CreateCollectionOp{
 		Name: name,
+		defaultDenseEFFactory: func() (embeddings.EmbeddingFunction, func() error, error) {
+			return ort.NewDefaultEmbeddingFunction()
+		},
 	}
 	for _, opt := range opts {
 		err := opt(op)
@@ -271,17 +278,19 @@ func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
 	if op.Name == "" {
 		return errors.New("collection name cannot be empty")
 	}
+	op.sdkOwnedDefaultDenseEF = nil
 	defaultedDenseEF := op.embeddingFunction == nil
 	if defaultedDenseEF {
 		// Keep the returned close function out of here: collection constructors own the
 		// embedding function lifecycle and will close it via collection.Close().
 		// The EF object is retained in op.embeddingFunction, so its Close() method
 		// remains reachable without storing the separate closer return value.
-		ef, _, err := ort.NewDefaultEmbeddingFunction()
+		ef, _, err := op.defaultDenseEFFactory()
 		if err != nil {
 			return errors.Wrap(err, "error creating default embedding function")
 		}
 		op.embeddingFunction = ef
+		op.sdkOwnedDefaultDenseEF = ef
 	}
 
 	// Skip EF config storage if explicitly disabled (for older Chroma versions)
@@ -324,6 +333,7 @@ func (op *CreateCollectionOp) PrepareAndValidateCollectionRequest() error {
 						return errors.Wrap(err, "error closing default embedding function during contentEF promotion")
 					}
 				}
+				op.sdkOwnedDefaultDenseEF = nil
 				op.embeddingFunction = denseEF
 			}
 		} else if op.Schema == nil {
@@ -505,6 +515,16 @@ func WithEmbeddingFunctionCreate(embeddingFunction embeddings.EmbeddingFunction)
 			return errors.New("embeddingFunction cannot be nil")
 		}
 		op.embeddingFunction = embeddingFunction
+		return nil
+	}
+}
+
+func withDefaultDenseEFFactoryCreate(factory defaultDenseEFFactory) CreateCollectionOption {
+	return func(op *CreateCollectionOp) error {
+		if factory == nil {
+			return errors.New("default dense EF factory cannot be nil")
+		}
+		op.defaultDenseEFFactory = factory
 		return nil
 	}
 }

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -280,10 +280,15 @@ func (op *CreateCollectionOp) closeSDKOwnedDefaultDenseEF(wrapMessage string) er
 	if !ok {
 		return errors.New("sdk-owned default embedding function is not closable")
 	}
+	// Clear tracking before invoking Close so an outer defer that re-enters
+	// this method becomes a no-op. Running Close() twice on a C-backed EF
+	// (e.g. ORT) can double-free even when the first call returned an error,
+	// so we accept the single-attempt leak and surface the failure to the
+	// caller for logging.
+	op.sdkOwnedDefaultDenseEF = nil
 	if err := safeCloseEF(closer); err != nil {
 		return errors.Wrap(err, wrapMessage)
 	}
-	op.sdkOwnedDefaultDenseEF = nil
 	return nil
 }
 

--- a/pkg/api/v2/client.go
+++ b/pkg/api/v2/client.go
@@ -280,10 +280,10 @@ func (op *CreateCollectionOp) closeSDKOwnedDefaultDenseEF(wrapMessage string) er
 	if !ok {
 		return errors.New("sdk-owned default embedding function is not closable")
 	}
-	op.sdkOwnedDefaultDenseEF = nil
-	if err := closer.Close(); err != nil {
+	if err := safeCloseEF(closer); err != nil {
 		return errors.Wrap(err, wrapMessage)
 	}
+	op.sdkOwnedDefaultDenseEF = nil
 	return nil
 }
 

--- a/pkg/api/v2/client_http.go
+++ b/pkg/api/v2/client_http.go
@@ -320,8 +320,8 @@ func (client *APIClientV2) CreateCollection(ctx context.Context, name string, op
 	// PrepareAndValidateCollectionRequest allocates one and SendRequest or
 	// response decoding fails, this defer prevents the temporary EF from
 	// leaking. On the success path the EF is wrapped into the returned
-	// collection and closeSDKOwnedDefaultDenseEF is a no-op because the
-	// tracking field's guard sees embeddingFunction no longer matching.
+	// collection and req.sdkOwnedDefaultDenseEF is cleared explicitly before
+	// return, so closeSDKOwnedDefaultDenseEF becomes a no-op.
 	defer func() {
 		cleanupErr := req.closeSDKOwnedDefaultDenseEF("error cleaning up default embedding function during collection create")
 		if cleanupErr == nil {
@@ -381,6 +381,12 @@ func (client *APIClientV2) CreateCollection(ctx context.Context, name string, op
 		dimension:                cm.Dimension,
 	}
 	c.ownsEF.Store(true)
+	// Mark ownership transfer so the deferred cleanup becomes a no-op. The
+	// guard in closeSDKOwnedDefaultDenseEF compares req.embeddingFunction to
+	// req.sdkOwnedDefaultDenseEF by identity, and wrapping into CollectionImpl
+	// does not reassign req.embeddingFunction, so the guard would otherwise
+	// still match and close the EF the collection now owns.
+	req.sdkOwnedDefaultDenseEF = nil
 	client.addCollectionToCache(c)
 	return c, nil
 }

--- a/pkg/api/v2/client_http.go
+++ b/pkg/api/v2/client_http.go
@@ -310,14 +310,37 @@ func (client *APIClientV2) Reset(ctx context.Context) error {
 	return nil
 }
 
-func (client *APIClientV2) CreateCollection(ctx context.Context, name string, options ...CreateCollectionOption) (Collection, error) {
+func (client *APIClientV2) CreateCollection(ctx context.Context, name string, options ...CreateCollectionOption) (collection Collection, err error) {
 	newOptions := append([]CreateCollectionOption{WithDatabaseCreate(client.CurrentDatabase())}, options...)
 	req, err := NewCreateCollectionOp(name, newOptions...)
 	if err != nil {
 		return nil, errors.Wrap(err, "error preparing collection create request")
 	}
-	err = req.PrepareAndValidateCollectionRequest()
-	if err != nil {
+	// Close the SDK-owned temporary default EF on every exit. When
+	// PrepareAndValidateCollectionRequest allocates one and SendRequest or
+	// response decoding fails, this defer prevents the temporary EF from
+	// leaking. On the success path the EF is wrapped into the returned
+	// collection and closeSDKOwnedDefaultDenseEF is a no-op because the
+	// tracking field's guard sees embeddingFunction no longer matching.
+	defer func() {
+		cleanupErr := req.closeSDKOwnedDefaultDenseEF("error cleaning up default embedding function during collection create")
+		if cleanupErr == nil {
+			return
+		}
+		if collection != nil && err == nil {
+			client.logger.Error("failed to close sdk-owned temporary default embedding function",
+				logger.String("collection", collection.Name()),
+				logger.ErrorField("error", cleanupErr))
+			return
+		}
+		collection = nil
+		if err != nil {
+			err = stderrors.Join(err, cleanupErr)
+			return
+		}
+		err = cleanupErr
+	}()
+	if err = req.PrepareAndValidateCollectionRequest(); err != nil {
 		return nil, errors.Wrap(err, "error validating collection create request")
 	}
 	reqURL, err := url.JoinPath(client.BaseURL(), "tenants", req.Database.Tenant().Name(), "databases", req.Database.Name(), "collections")
@@ -338,7 +361,7 @@ func (client *APIClientV2) CreateCollection(ctx context.Context, name string, op
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var cm CollectionModel
-	if err := json.NewDecoder(resp.Body).Decode(&cm); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&cm); err != nil {
 		return nil, errors.Wrap(err, "error decoding response")
 	}
 	c := &CollectionImpl{

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1810,6 +1810,58 @@ func TestAPIClientV2_CreateCollection_ClosesTemporaryDefaultEFOnError(t *testing
 	})
 }
 
+// TestAPIClientV2_CreateCollection_PreservesTemporaryDefaultEFOnSuccess pins
+// the PR #504 follow-up fix: on the HTTP CreateCollection success path, the
+// SDK-owned temporary default EF must be transferred to the returned
+// collection rather than closed by the cleanup defer. Without the explicit
+// req.sdkOwnedDefaultDenseEF = nil handoff, the defer closed the EF
+// immediately, so the first Add/Query on the returned collection failed with
+// "embedding function is closed" -- which is exactly what broke the cloud
+// integration jobs (CRUD, Search, Schema, Config).
+func TestAPIClientV2_CreateCollection_PreservesTemporaryDefaultEFOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(&CollectionModel{
+			ID:       "create-success-id",
+			Name:     "create-success",
+			Tenant:   "default_tenant",
+			Database: "default_database",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	col, err := client.CreateCollection(
+		context.Background(),
+		"create-success",
+		withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, col)
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must not be closed on the success path -- ownership transferred to the returned collection")
+
+	// The collection must still be able to embed through the wrapped EF.
+	impl := col.(*CollectionImpl)
+	wrapped, ok := impl.embeddingFunction.(*closeOnceEF)
+	require.True(t, ok, "collection EF should be wrapped in closeOnceEF")
+	require.Same(t, temporaryDefaultEF, wrapped.ef,
+		"wrapped EF must point at the original temporary default EF")
+	_, err = wrapped.EmbedDocuments(context.Background(), []string{"hello"})
+	require.NoError(t, err, "wrapped EF must still be usable after CreateCollection returns")
+
+	// Closing the collection must now close the temp EF exactly once.
+	require.NoError(t, impl.Close())
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+		"collection Close() must close the owned temp EF exactly once")
+}
+
 func TestPrepareAndValidateCollectionRequest_ContentEFSchemaPath(t *testing.T) {
 	t.Run("dual-interface contentEF overrides schema EF", func(t *testing.T) {
 		schema, err := NewSchemaWithDefaults()

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1575,21 +1575,50 @@ func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_RecoversPanic(t *testing.
 	require.Contains(t, err.Error(), "panic during EF close")
 }
 
-func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsOnlyOnSuccess(t *testing.T) {
-	ef := &mockPanickingCloseEF{}
-	op := &CreateCollectionOp{
-		embeddingFunction:      ef,
-		sdkOwnedDefaultDenseEF: ef,
-	}
+// TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsOnAnyCloseAttempt pins
+// the contract that prevents the outer-defer double-close identified by the PR
+// #504 review (item 2): once Close() has been attempted on the SDK-owned default
+// EF -- success, error, or panic -- the tracking field must be nilled out. A
+// subsequent invocation from an outer defer must be a no-op so the underlying
+// resource is not closed a second time.
+func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsOnAnyCloseAttempt(t *testing.T) {
+	t.Run("close returning error clears tracking", func(t *testing.T) {
+		ef := &mockFailingCloseEF{closeErr: stderrors.New("boom")}
+		op := &CreateCollectionOp{
+			embeddingFunction:      ef,
+			sdkOwnedDefaultDenseEF: ef,
+		}
 
-	// Swallow panic via defer/recover in case Close currently propagates it.
-	func() {
-		defer func() { _ = recover() }()
-		_ = op.closeSDKOwnedDefaultDenseEF("error closing default embedding function")
-	}()
+		err := op.closeSDKOwnedDefaultDenseEF("first-call")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+		require.Nil(t, op.sdkOwnedDefaultDenseEF,
+			"sdkOwnedDefaultDenseEF must be cleared after any Close attempt to prevent outer defer double-close")
+		require.Equal(t, int32(1), ef.closeCount.Load())
 
-	require.Same(t, ef, op.sdkOwnedDefaultDenseEF,
-		"sdkOwnedDefaultDenseEF must remain tracked when Close failed so outer defers can retry or log the leak")
+		// Simulate the outer defer invoked by embeddedLocalClient.CreateCollection.
+		err2 := op.closeSDKOwnedDefaultDenseEF("second-call")
+		require.NoError(t, err2, "outer defer re-entry must be a no-op")
+		require.Equal(t, int32(1), ef.closeCount.Load(),
+			"Close must not run a second time via outer defer")
+	})
+
+	t.Run("close panic clears tracking", func(t *testing.T) {
+		ef := &mockPanickingCloseEF{}
+		op := &CreateCollectionOp{
+			embeddingFunction:      ef,
+			sdkOwnedDefaultDenseEF: ef,
+		}
+
+		err := op.closeSDKOwnedDefaultDenseEF("first-call")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "panic during EF close")
+		require.Nil(t, op.sdkOwnedDefaultDenseEF,
+			"panicking Close must also clear tracking so outer defer does not re-enter")
+
+		err2 := op.closeSDKOwnedDefaultDenseEF("second-call")
+		require.NoError(t, err2, "outer defer re-entry must be a no-op")
+	})
 }
 
 func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsAfterSuccessfulClose(t *testing.T) {
@@ -1722,6 +1751,62 @@ func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testi
 		denseView := wrapped.(embeddings.EmbeddingFunction)
 		require.Empty(t, denseView.Name(), "wrapper Name() must be empty for content-only inner EF")
 		require.Empty(t, denseView.GetConfig(), "wrapper GetConfig() must be empty for content-only inner EF")
+	})
+}
+
+// TestAPIClientV2_CreateCollection_ClosesTemporaryDefaultEFOnError pins the PR
+// #504 review item 1 fix: when the HTTP CreateCollection path allocates an
+// SDK-owned temporary default EF via PrepareAndValidateCollectionRequest and
+// then fails during SendRequest or response decoding, the temporary EF must be
+// closed rather than orphaned.
+func TestAPIClientV2_CreateCollection_ClosesTemporaryDefaultEFOnError(t *testing.T) {
+	t.Run("server error closes temporary default EF", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+		require.NoError(t, err)
+		defer func() { _ = client.Close() }()
+
+		temporaryDefaultEF := &mockCloseableEF{}
+		_, err = client.CreateCollection(
+			context.Background(),
+			"http-create-fails",
+			withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+				return temporaryDefaultEF, func() error { return nil }, nil
+			}),
+		)
+		require.Error(t, err, "CreateCollection must surface the server error")
+		require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+			"temporary default EF must be closed when HTTP CreateCollection fails")
+	})
+
+	t.Run("response decode error closes temporary default EF", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`not-json`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+		require.NoError(t, err)
+		defer func() { _ = client.Close() }()
+
+		temporaryDefaultEF := &mockCloseableEF{}
+		_, err = client.CreateCollection(
+			context.Background(),
+			"http-create-decode-fails",
+			withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+				return temporaryDefaultEF, func() error { return nil }, nil
+			}),
+		)
+		require.Error(t, err, "CreateCollection must surface the decode error")
+		require.Contains(t, err.Error(), "error decoding response")
+		require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+			"temporary default EF must be closed when response decode fails")
 	})
 }
 

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1547,6 +1547,18 @@ func TestCreateCollectionOpEnsureDefaultDenseEFFactory_ZeroValue(t *testing.T) {
 	require.NotNil(t, op.defaultDenseEFFactory)
 }
 
+func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_NonClosableKeepsTrackedReference(t *testing.T) {
+	ef := &mockNonCloseableEF{}
+	op := &CreateCollectionOp{
+		embeddingFunction:      ef,
+		sdkOwnedDefaultDenseEF: ef,
+	}
+
+	err := op.closeSDKOwnedDefaultDenseEF("unused")
+	require.EqualError(t, err, "sdk-owned default embedding function is not closable")
+	require.Same(t, ef, op.sdkOwnedDefaultDenseEF)
+}
+
 func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testing.T) {
 	t.Run("dual-interface contentEF persists config", func(t *testing.T) {
 		dualEF := &mockDualEF{}
@@ -1602,6 +1614,19 @@ func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testi
 		require.NoError(t, err)
 		require.Equal(t, explicitEF.Name(), op.embeddingFunction.(embeddings.EmbeddingFunction).Name(),
 			"runtime denseEF must remain the user-provided EF")
+	})
+
+	t.Run("non-closable sdk-owned default EF returns error during promotion", func(t *testing.T) {
+		dualEF := &mockDualEF{}
+		op, err := NewCreateCollectionOp("test-promote-non-closable",
+			WithContentEmbeddingFunctionCreate(dualEF),
+			withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+				return &mockNonCloseableEF{}, func() error { return nil }, nil
+			}),
+		)
+		require.NoError(t, err)
+		err = op.PrepareAndValidateCollectionRequest()
+		require.EqualError(t, err, "sdk-owned default embedding function is not closable")
 	})
 
 	t.Run("wrapped content-only EF does not persist empty config", func(t *testing.T) {

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1559,6 +1559,11 @@ func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_NonClosableKeepsTrackedRe
 	require.Same(t, ef, op.sdkOwnedDefaultDenseEF)
 }
 
+func TestWithDefaultDenseEFFactoryCreate_RejectsNil(t *testing.T) {
+	_, err := NewCreateCollectionOp("test-nil-default-factory", withDefaultDenseEFFactoryCreate(nil))
+	require.EqualError(t, err, "default dense EF factory cannot be nil")
+}
+
 func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testing.T) {
 	t.Run("dual-interface contentEF persists config", func(t *testing.T) {
 		dualEF := &mockDualEF{}
@@ -1627,6 +1632,36 @@ func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testi
 		require.NoError(t, err)
 		err = op.PrepareAndValidateCollectionRequest()
 		require.EqualError(t, err, "sdk-owned default embedding function is not closable")
+	})
+
+	t.Run("default dense factory error surfaces", func(t *testing.T) {
+		op, err := NewCreateCollectionOp("test-factory-error",
+			withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+				return nil, nil, stderrors.New("factory boom")
+			}),
+		)
+		require.NoError(t, err)
+
+		err = op.PrepareAndValidateCollectionRequest()
+		require.EqualError(t, err, "error creating default embedding function: factory boom")
+	})
+
+	t.Run("dual contentEF promotion closes sdk-owned default EF once", func(t *testing.T) {
+		dualEF := &mockDualEF{}
+		temporaryDefaultEF := &mockCloseableEF{}
+		op, err := NewCreateCollectionOp("test-promote-close-count",
+			WithContentEmbeddingFunctionCreate(dualEF),
+			withDefaultDenseEFFactoryCreate(func() (embeddings.EmbeddingFunction, func() error, error) {
+				return temporaryDefaultEF, func() error { return nil }, nil
+			}),
+		)
+		require.NoError(t, err)
+
+		err = op.PrepareAndValidateCollectionRequest()
+		require.NoError(t, err)
+		require.Same(t, dualEF, op.embeddingFunction)
+		require.Nil(t, op.sdkOwnedDefaultDenseEF)
+		require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
 	})
 
 	t.Run("wrapped content-only EF does not persist empty config", func(t *testing.T) {

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1559,6 +1559,53 @@ func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_NonClosableKeepsTrackedRe
 	require.Same(t, ef, op.sdkOwnedDefaultDenseEF)
 }
 
+func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_RecoversPanic(t *testing.T) {
+	ef := &mockPanickingCloseEF{}
+	op := &CreateCollectionOp{
+		embeddingFunction:      ef,
+		sdkOwnedDefaultDenseEF: ef,
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		err = op.closeSDKOwnedDefaultDenseEF("error closing default embedding function")
+	})
+	require.Error(t, err, "panicking Close must surface as an error, not a panic")
+	require.Contains(t, err.Error(), "error closing default embedding function")
+	require.Contains(t, err.Error(), "panic during EF close")
+}
+
+func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsOnlyOnSuccess(t *testing.T) {
+	ef := &mockPanickingCloseEF{}
+	op := &CreateCollectionOp{
+		embeddingFunction:      ef,
+		sdkOwnedDefaultDenseEF: ef,
+	}
+
+	// Swallow panic via defer/recover in case Close currently propagates it.
+	func() {
+		defer func() { _ = recover() }()
+		_ = op.closeSDKOwnedDefaultDenseEF("error closing default embedding function")
+	}()
+
+	require.Same(t, ef, op.sdkOwnedDefaultDenseEF,
+		"sdkOwnedDefaultDenseEF must remain tracked when Close failed so outer defers can retry or log the leak")
+}
+
+func TestCreateCollectionOpCloseSDKOwnedDefaultDenseEF_ClearsAfterSuccessfulClose(t *testing.T) {
+	ef := &mockCloseableEF{}
+	op := &CreateCollectionOp{
+		embeddingFunction:      ef,
+		sdkOwnedDefaultDenseEF: ef,
+	}
+
+	err := op.closeSDKOwnedDefaultDenseEF("unused")
+	require.NoError(t, err)
+	require.Nil(t, op.sdkOwnedDefaultDenseEF,
+		"sdkOwnedDefaultDenseEF must be cleared after a successful close")
+	require.Equal(t, int32(1), ef.closeCount.Load())
+}
+
 func TestWithDefaultDenseEFFactoryCreate_RejectsNil(t *testing.T) {
 	_, err := NewCreateCollectionOp("test-nil-default-factory", withDefaultDenseEFFactoryCreate(nil))
 	require.EqualError(t, err, "default dense EF factory cannot be nil")

--- a/pkg/api/v2/client_http_test.go
+++ b/pkg/api/v2/client_http_test.go
@@ -1531,6 +1531,22 @@ func TestWithContentEmbeddingFunctionCreateNil(t *testing.T) {
 	require.Contains(t, err.Error(), "content embedding function cannot be nil")
 }
 
+func TestCreateCollectionOpUnmarshalJSON_InitializesDefaultDenseEFFactory(t *testing.T) {
+	var op CreateCollectionOp
+
+	err := json.Unmarshal([]byte(`{"name":"test-json-default"}`), &op)
+	require.NoError(t, err)
+	require.NotNil(t, op.defaultDenseEFFactory)
+}
+
+func TestCreateCollectionOpEnsureDefaultDenseEFFactory_ZeroValue(t *testing.T) {
+	var op CreateCollectionOp
+
+	require.Nil(t, op.defaultDenseEFFactory)
+	op.ensureDefaultDenseEFFactory()
+	require.NotNil(t, op.defaultDenseEFFactory)
+}
+
 func TestPrepareAndValidateCollectionRequest_ContentEFConfigPersistence(t *testing.T) {
 	t.Run("dual-interface contentEF persists config", func(t *testing.T) {
 		dualEF := &mockDualEF{}

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
-	"io"
 	"math"
 	"reflect"
 	"strings"
@@ -69,11 +68,16 @@ func newEmbeddedLocalClient(cfg *localClientConfig, embedded localEmbeddedRuntim
 		return nil, errors.Wrap(err, "embedded runtime failed readiness checks")
 	}
 
+	clientLogger := cfg.logger
+	if clientLogger == nil {
+		clientLogger = logger.NewNoopLogger()
+	}
+
 	return &embeddedLocalClient{
 		state:           stateClient,
 		embedded:        embedded,
 		collectionState: map[string]*embeddedCollectionState{},
-		logger:          cfg.logger,
+		logger:          clientLogger,
 	}, nil
 }
 
@@ -339,7 +343,7 @@ func (client *embeddedLocalClient) Reset(ctx context.Context) error {
 	return client.embedded.Reset()
 }
 
-func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name string, options ...CreateCollectionOption) (Collection, error) {
+func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name string, options ...CreateCollectionOption) (collection Collection, err error) {
 	newOptions := append([]CreateCollectionOption{WithDatabaseCreate(client.CurrentDatabase())}, options...)
 	req, err := NewCreateCollectionOp(name, newOptions...)
 	if err != nil {
@@ -348,6 +352,19 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 	if err := req.PrepareAndValidateCollectionRequest(); err != nil {
 		return nil, errors.Wrap(err, "error validating collection create request")
 	}
+	cleanupMessage := "error cleaning up default embedding function during collection create"
+	defer func() {
+		cleanupErr := req.closeSDKOwnedDefaultDenseEF(cleanupMessage)
+		if cleanupErr == nil {
+			return
+		}
+		collection = nil
+		if err != nil {
+			err = stderrors.Join(err, cleanupErr)
+			return
+		}
+		err = cleanupErr
+	}()
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -373,6 +390,10 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		})
 		if lookupErr == nil && existingCollection != nil {
 			existingCollectionID = existingCollection.ID
+		} else if lookupErr != nil && !isEmbeddedCollectionNotFoundError(lookupErr) {
+			client.logger.Warn("create-if-not-exists preflight GetCollection failed",
+				logger.String("collection", req.Name),
+				logger.ErrorField("error", lookupErr))
 		}
 	}
 
@@ -393,9 +414,9 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		req.sdkOwnedDefaultDenseEF != nil &&
 		existingCollectionID == "" &&
 		!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap) {
-		if err := closeSDKOwnedDefaultDenseEF(req, "error closing default embedding function for existing collection"); err != nil {
-			return nil, err
-		}
+		cleanupMessage = "error closing default embedding function for existing collection"
+		// A missed preflight probe on a fresh client can still reuse an existing
+		// collection; reload it so the returned collection uses the stored EF state.
 		collection, getErr := client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
 		if getErr != nil {
 			return nil, errors.Wrap(getErr, "error retrieving existing collection after create-if-not-exists reuse")
@@ -423,16 +444,31 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 				state.schema = req.Schema
 			}
 		})
+		req.sdkOwnedDefaultDenseEF = nil
 	} else {
-		if err := closeSDKOwnedDefaultDenseEF(req, "error closing default embedding function for existing collection"); err != nil {
-			return nil, err
-		}
+		cleanupMessage = "error closing default embedding function for existing collection"
 		overrideEF = nil
 		overrideContentEF = nil
 	}
 
-	collection, err := client.buildEmbeddedCollection(*model, req.Database, overrideEF, overrideContentEF, true, true)
+	collection, err = client.buildEmbeddedCollection(*model, req.Database, overrideEF, overrideContentEF, true, true)
 	if err != nil {
+		if !reusedExistingCollection {
+			deleteErr := client.embedded.DeleteCollection(localchroma.EmbeddedDeleteCollectionRequest{
+				Name:         req.Name,
+				TenantID:     req.Database.Tenant().Name(),
+				DatabaseName: req.Database.Name(),
+			})
+			cleanupErr := client.deleteCollectionState(model.ID)
+			err = errors.Wrap(err, "error building collection")
+			if deleteErr != nil {
+				err = stderrors.Join(err, errors.Wrap(deleteErr, "error deleting collection after build failure"))
+			}
+			if cleanupErr != nil {
+				return nil, stderrors.Join(err, cleanupErr)
+			}
+			return nil, err
+		}
 		return nil, errors.Wrap(err, "error building collection")
 	}
 	return collection, nil
@@ -776,21 +812,6 @@ func (client *embeddedLocalClient) returnedExistingCollection(name, returnedColl
 	return cached != nil && cached.ID() == returnedCollectionID
 }
 
-func closeSDKOwnedDefaultDenseEF(req *CreateCollectionOp, wrapMessage string) error {
-	if req == nil || req.sdkOwnedDefaultDenseEF == nil || req.embeddingFunction != req.sdkOwnedDefaultDenseEF {
-		return nil
-	}
-	closer, ok := req.sdkOwnedDefaultDenseEF.(io.Closer)
-	if !ok {
-		return errors.New("sdk-owned default embedding function is not closable")
-	}
-	if err := closer.Close(); err != nil {
-		return errors.Wrap(err, wrapMessage)
-	}
-	req.sdkOwnedDefaultDenseEF = nil
-	return nil
-}
-
 func collectionModelMatchesCreateRequest(model *localchroma.EmbeddedCollection, metadataMap, configurationMap, schemaMap map[string]any) bool {
 	if model == nil {
 		return false
@@ -807,7 +828,22 @@ func comparableCollectionMap(left, right map[string]any) bool {
 	if len(right) == 0 {
 		right = nil
 	}
-	return reflect.DeepEqual(left, right)
+	leftPayload, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+	rightPayload, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(leftPayload, rightPayload)
+}
+
+func isEmbeddedCollectionNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
 }
 
 func (client *embeddedLocalClient) renameCollectionInCache(oldName string, collection Collection) {

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -433,24 +433,19 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		return nil, errors.Wrap(err, "error creating collection")
 	}
 
-	// Reload via GetCollection when the returned model looks like reuse of a
-	// pre-existing collection that our local client hasn't seen yet. Two gates:
-	//  - Differential: the returned model differs from what we requested.
-	//  - Inconclusive empty-match: every comparison field is empty on both
-	//    sides (so JSON equality tells us nothing) AND preflight did not
-	//    conclusively report not-found. This covers the PR #504 review case
-	//    where a transient preflight error lets an empty pre-existing
-	//    collection slip past both reuse signals on a fresh client.
-	// The preflight-conclusive-not-found path is deliberately excluded so
-	// genuinely-new empty collections still install their throwaway default
-	// EF as state (see
-	// TestEmbeddedCreateCollection_DefaultORTNewEmptyCollectionWithIfNotExistsStillInstallsTemporaryDefault).
+	// Reload via GetCollection when the returned model differs from what we
+	// requested -- a positive signal that the server holds authoritative state
+	// (e.g. writer's custom EF config) that we should pick up instead of the
+	// reader's temporary default. The previously-widened "all-empty" branch
+	// was removed per PR #504 review item 3: when both sides are empty there
+	// is no server-side EF config to reload, so closing the temp EF left the
+	// caller with a nil-EF collection. The normal install path below now
+	// handles that case, installing the temp EF as state so subsequent
+	// Add/Query work.
 	shouldReloadForReuse := req.CreateIfNotExists &&
 		req.sdkOwnedDefaultDenseEF != nil &&
 		existingCollectionID == "" &&
-		(!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap) ||
-			(!preflightConclusivelyNotFound &&
-				collectionModelRequestAllEmpty(model, metadataMap, configurationMap, schemaMap)))
+		!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap)
 	if shouldReloadForReuse {
 		cleanupMessage = "error closing default embedding function for existing collection"
 		var getErr error
@@ -882,19 +877,6 @@ func collectionModelMatchesCreateRequest(model *localchroma.EmbeddedCollection, 
 		comparableCollectionMap(model.Schema, schemaMap)
 }
 
-// collectionModelRequestAllEmpty reports whether every field compared by
-// collectionModelMatchesCreateRequest is empty on both the persisted model
-// and the create request. When true, the JSON-equality match is vacuous and
-// cannot distinguish "pre-existing collection" from "newly created".
-func collectionModelRequestAllEmpty(model *localchroma.EmbeddedCollection, metadataMap, configurationMap, schemaMap map[string]any) bool {
-	if model == nil {
-		return false
-	}
-	return len(model.Metadata) == 0 && len(metadataMap) == 0 &&
-		len(model.ConfigurationJSON) == 0 && len(configurationMap) == 0 &&
-		len(model.Schema) == 0 && len(schemaMap) == 0
-}
-
 func comparableCollectionMap(left, right map[string]any) bool {
 	if len(left) == 0 {
 		left = nil
@@ -920,9 +902,24 @@ func comparableCollectionMap(left, right map[string]any) bool {
 // Substring sniffing is a maintenance hazard — any upstream rewording of the
 // error message silently flips classification. Pinned today by
 // TestIsEmbeddedCollectionNotFoundError_RealEmbeddedRuntime.
+// ErrEmbeddedCollectionNotFound is returned (or wrapped) when the embedded
+// runtime reports that a collection does not exist. External code classifying
+// such errors should prefer errors.Is against this sentinel; the substring
+// fallback in isEmbeddedCollectionNotFoundError exists only for localchroma
+// versions that have not yet been adapted to return the typed sentinel.
+//
+// The sentinel is defined here (rather than in localchroma) because the
+// upstream shim returns string-only errors today. When upstream exposes a
+// typed error, this sentinel can be removed in favour of a direct errors.Is
+// against the upstream type, and the substring fallback can be dropped.
+var ErrEmbeddedCollectionNotFound = stderrors.New("embedded collection not found")
+
 func isEmbeddedCollectionNotFoundError(err error) bool {
 	if err == nil {
 		return false
+	}
+	if stderrors.Is(err, ErrEmbeddedCollectionNotFound) {
+		return true
 	}
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "not found") || strings.Contains(message, "does not exist")

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -433,13 +433,26 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		return nil, errors.Wrap(err, "error creating collection")
 	}
 
-	if req.CreateIfNotExists &&
+	// Reload via GetCollection when the returned model looks like reuse of a
+	// pre-existing collection that our local client hasn't seen yet. Two gates:
+	//  - Differential: the returned model differs from what we requested.
+	//  - Inconclusive empty-match: every comparison field is empty on both
+	//    sides (so JSON equality tells us nothing) AND preflight did not
+	//    conclusively report not-found. This covers the PR #504 review case
+	//    where a transient preflight error lets an empty pre-existing
+	//    collection slip past both reuse signals on a fresh client.
+	// The preflight-conclusive-not-found path is deliberately excluded so
+	// genuinely-new empty collections still install their throwaway default
+	// EF as state (see
+	// TestEmbeddedCreateCollection_DefaultORTNewEmptyCollectionWithIfNotExistsStillInstallsTemporaryDefault).
+	shouldReloadForReuse := req.CreateIfNotExists &&
 		req.sdkOwnedDefaultDenseEF != nil &&
 		existingCollectionID == "" &&
-		!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap) {
+		(!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap) ||
+			(!preflightConclusivelyNotFound &&
+				collectionModelRequestAllEmpty(model, metadataMap, configurationMap, schemaMap)))
+	if shouldReloadForReuse {
 		cleanupMessage = "error closing default embedding function for existing collection"
-		// A missed preflight probe on a fresh client can still reuse an existing
-		// collection; reload it so the returned collection uses the stored EF state.
 		var getErr error
 		collection, getErr = client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
 		if getErr != nil {
@@ -867,6 +880,19 @@ func collectionModelMatchesCreateRequest(model *localchroma.EmbeddedCollection, 
 	return comparableCollectionMap(model.Metadata, metadataMap) &&
 		comparableCollectionMap(model.ConfigurationJSON, configurationMap) &&
 		comparableCollectionMap(model.Schema, schemaMap)
+}
+
+// collectionModelRequestAllEmpty reports whether every field compared by
+// collectionModelMatchesCreateRequest is empty on both the persisted model
+// and the create request. When true, the JSON-equality match is vacuous and
+// cannot distinguish "pre-existing collection" from "newly created".
+func collectionModelRequestAllEmpty(model *localchroma.EmbeddedCollection, metadataMap, configurationMap, schemaMap map[string]any) bool {
+	if model == nil {
+		return false
+	}
+	return len(model.Metadata) == 0 && len(metadataMap) == 0 &&
+		len(model.ConfigurationJSON) == 0 && len(configurationMap) == 0 &&
+		len(model.Schema) == 0 && len(schemaMap) == 0
 }
 
 func comparableCollectionMap(left, right map[string]any) bool {

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"io"
 	"math"
 	"reflect"
 	"strings"
@@ -406,6 +407,16 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 			}
 		})
 	} else {
+		if req.sdkOwnedDefaultDenseEF != nil && req.embeddingFunction == req.sdkOwnedDefaultDenseEF {
+			closer, ok := req.sdkOwnedDefaultDenseEF.(io.Closer)
+			if !ok {
+				return nil, errors.New("sdk-owned default embedding function is not closable")
+			}
+			if err := closer.Close(); err != nil {
+				return nil, errors.Wrap(err, "error closing default embedding function for existing collection")
+			}
+			req.sdkOwnedDefaultDenseEF = nil
+		}
 		overrideEF = nil
 		overrideContentEF = nil
 	}

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -389,6 +389,20 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		return nil, errors.Wrap(err, "error creating collection")
 	}
 
+	if req.CreateIfNotExists &&
+		req.sdkOwnedDefaultDenseEF != nil &&
+		existingCollectionID == "" &&
+		!collectionModelMatchesCreateRequest(model, metadataMap, configurationMap, schemaMap) {
+		if err := closeSDKOwnedDefaultDenseEF(req, "error closing default embedding function for existing collection"); err != nil {
+			return nil, err
+		}
+		collection, getErr := client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
+		if getErr != nil {
+			return nil, errors.Wrap(getErr, "error retrieving existing collection after create-if-not-exists reuse")
+		}
+		return collection, nil
+	}
+
 	overrideEF := req.embeddingFunction
 	overrideContentEF := req.contentEmbeddingFunction
 	reusedExistingCollection := client.returnedExistingCollection(req.Name, model.ID, existingCollectionID)
@@ -410,15 +424,8 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 			}
 		})
 	} else {
-		if req.sdkOwnedDefaultDenseEF != nil && req.embeddingFunction == req.sdkOwnedDefaultDenseEF {
-			closer, ok := req.sdkOwnedDefaultDenseEF.(io.Closer)
-			if !ok {
-				return nil, errors.New("sdk-owned default embedding function is not closable")
-			}
-			if err := closer.Close(); err != nil {
-				return nil, errors.Wrap(err, "error closing default embedding function for existing collection")
-			}
-			req.sdkOwnedDefaultDenseEF = nil
+		if err := closeSDKOwnedDefaultDenseEF(req, "error closing default embedding function for existing collection"); err != nil {
+			return nil, err
 		}
 		overrideEF = nil
 		overrideContentEF = nil
@@ -767,6 +774,40 @@ func (client *embeddedLocalClient) returnedExistingCollection(name, returnedColl
 
 	cached := client.cachedCollectionByName(name)
 	return cached != nil && cached.ID() == returnedCollectionID
+}
+
+func closeSDKOwnedDefaultDenseEF(req *CreateCollectionOp, wrapMessage string) error {
+	if req == nil || req.sdkOwnedDefaultDenseEF == nil || req.embeddingFunction != req.sdkOwnedDefaultDenseEF {
+		return nil
+	}
+	closer, ok := req.sdkOwnedDefaultDenseEF.(io.Closer)
+	if !ok {
+		return errors.New("sdk-owned default embedding function is not closable")
+	}
+	if err := closer.Close(); err != nil {
+		return errors.Wrap(err, wrapMessage)
+	}
+	req.sdkOwnedDefaultDenseEF = nil
+	return nil
+}
+
+func collectionModelMatchesCreateRequest(model *localchroma.EmbeddedCollection, metadataMap, configurationMap, schemaMap map[string]any) bool {
+	if model == nil {
+		return false
+	}
+	return comparableCollectionMap(model.Metadata, metadataMap) &&
+		comparableCollectionMap(model.ConfigurationJSON, configurationMap) &&
+		comparableCollectionMap(model.Schema, schemaMap)
+}
+
+func comparableCollectionMap(left, right map[string]any) bool {
+	if len(left) == 0 {
+		left = nil
+	}
+	if len(right) == 0 {
+		right = nil
+	}
+	return reflect.DeepEqual(left, right)
 }
 
 func (client *embeddedLocalClient) renameCollectionInCache(oldName string, collection Collection) {

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -364,14 +364,16 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		return nil, errors.Wrap(err, "error converting collection schema")
 	}
 
-	isNewCreation := true
+	existingCollectionID := ""
 	if req.CreateIfNotExists {
 		existingCollection, lookupErr := client.embedded.GetCollection(localchroma.EmbeddedGetCollectionRequest{
 			Name:         req.Name,
 			TenantID:     req.Database.Tenant().Name(),
 			DatabaseName: req.Database.Name(),
 		})
-		isNewCreation = lookupErr != nil || existingCollection == nil
+		if lookupErr == nil && existingCollection != nil {
+			existingCollectionID = existingCollection.ID
+		}
 	}
 
 	model, err := client.embedded.CreateCollection(localchroma.EmbeddedCreateCollectionRequest{
@@ -389,7 +391,8 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 
 	overrideEF := req.embeddingFunction
 	overrideContentEF := req.contentEmbeddingFunction
-	if isNewCreation {
+	reusedExistingCollection := client.returnedExistingCollection(req.Name, model.ID, existingCollectionID)
+	if !reusedExistingCollection {
 		overrideEF = wrapEFCloseOnce(req.embeddingFunction)
 		// NOTE: wrapping must occur after PrepareAndValidateCollectionRequest (see client_http.go).
 		overrideContentEF = wrapContentEFCloseOnce(req.contentEmbeddingFunction)
@@ -745,6 +748,25 @@ func (client *embeddedLocalClient) cachedCollectionByName(name string) Collectio
 		return nil
 	}
 	return client.state.localCollectionByName(name)
+}
+
+func (client *embeddedLocalClient) returnedExistingCollection(name, returnedCollectionID, observedCollectionID string) bool {
+	if returnedCollectionID == "" {
+		return false
+	}
+	if observedCollectionID != "" && observedCollectionID == returnedCollectionID {
+		return true
+	}
+
+	client.collectionStateMu.RLock()
+	state := client.collectionState[returnedCollectionID]
+	client.collectionStateMu.RUnlock()
+	if state != nil {
+		return true
+	}
+
+	cached := client.cachedCollectionByName(name)
+	return cached != nil && cached.ID() == returnedCollectionID
 }
 
 func (client *embeddedLocalClient) renameCollectionInCache(oldName string, collection Collection) {

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -355,6 +355,17 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		if cleanupErr == nil {
 			return
 		}
+		// When a valid collection has already been built, the SDK-owned
+		// temporary default EF is a throwaway distinct from the collection's
+		// own embedding functions (which come from persisted state). Failing
+		// to close the throwaway leaks the temp EF's resources but does not
+		// invalidate the collection, so we surface the failure via the
+		// logger and return the collection instead of discarding it.
+		if collection != nil && err == nil {
+			client.logCloseError("failed to close sdk-owned temporary default embedding function",
+				collection.Name(), cleanupErr)
+			return
+		}
 		collection = nil
 		if err != nil {
 			err = stderrors.Join(err, cleanupErr)
@@ -382,15 +393,23 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 	}
 
 	existingCollectionID := ""
+	// preflightConclusivelyNotFound is the only positive signal that this call
+	// must have created the collection itself (vs. reusing a pre-existing one
+	// via GetOrCreate). It gates the build-failure delete below so we never
+	// destroy a pre-existing user collection after an ambiguous reuse.
+	preflightConclusivelyNotFound := false
 	if req.CreateIfNotExists {
 		existingCollection, lookupErr := client.embedded.GetCollection(localchroma.EmbeddedGetCollectionRequest{
 			Name:         req.Name,
 			TenantID:     req.Database.Tenant().Name(),
 			DatabaseName: req.Database.Name(),
 		})
-		if lookupErr == nil && existingCollection != nil {
+		switch {
+		case lookupErr == nil && existingCollection != nil:
 			existingCollectionID = existingCollection.ID
-		} else if lookupErr != nil && !isEmbeddedCollectionNotFoundError(lookupErr) {
+		case lookupErr != nil && isEmbeddedCollectionNotFoundError(lookupErr):
+			preflightConclusivelyNotFound = true
+		case lookupErr != nil:
 			if client.logger != nil {
 				client.logger.Warn("create-if-not-exists preflight GetCollection failed",
 					logger.String("collection", req.Name),
@@ -467,7 +486,6 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		})
 		req.sdkOwnedDefaultDenseEF = nil
 	} else {
-		cleanupMessage = "error closing default embedding function for existing collection"
 		overrideEF = nil
 		overrideContentEF = nil
 	}
@@ -475,15 +493,24 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 	collection, err = client.buildEmbeddedCollection(*model, req.Database, overrideEF, overrideContentEF, true, true)
 	if err != nil {
 		if !reusedExistingCollection {
-			deleteErr := client.embedded.DeleteCollection(localchroma.EmbeddedDeleteCollectionRequest{
-				Name:         req.Name,
-				TenantID:     req.Database.Tenant().Name(),
-				DatabaseName: req.Database.Name(),
-			})
 			cleanupErr := client.deleteCollectionState(model.ID)
 			err = errors.Wrap(err, "error building collection")
-			if deleteErr != nil && !isEmbeddedCollectionNotFoundError(deleteErr) {
-				err = stderrors.Join(err, errors.Wrap(deleteErr, "error deleting collection after build failure"))
+			// Only purge the runtime collection when we have positive evidence
+			// this call created it: either a non-GetOrCreate request (the
+			// runtime would have failed outright if it already existed) or a
+			// preflight probe that conclusively reported not-found. Otherwise
+			// an ambiguous reuse (transient preflight failure + GetOrCreate
+			// returning a pre-existing collection) would silently destroy
+			// user data.
+			if !req.CreateIfNotExists || preflightConclusivelyNotFound {
+				deleteErr := client.embedded.DeleteCollection(localchroma.EmbeddedDeleteCollectionRequest{
+					Name:         req.Name,
+					TenantID:     req.Database.Tenant().Name(),
+					DatabaseName: req.Database.Name(),
+				})
+				if deleteErr != nil && !isEmbeddedCollectionNotFoundError(deleteErr) {
+					err = stderrors.Join(err, errors.Wrap(deleteErr, "error deleting collection after build failure"))
+				}
 			}
 			if cleanupErr != nil {
 				return nil, stderrors.Join(err, cleanupErr)
@@ -851,15 +878,22 @@ func comparableCollectionMap(left, right map[string]any) bool {
 	}
 	leftPayload, err := json.Marshal(left)
 	if err != nil {
+		logComparableCollectionMapMarshalErrorToStderr(err)
 		return false
 	}
 	rightPayload, err := json.Marshal(right)
 	if err != nil {
+		logComparableCollectionMapMarshalErrorToStderr(err)
 		return false
 	}
 	return bytes.Equal(leftPayload, rightPayload)
 }
 
+// TODO: switch to errors.Is with a typed sentinel (e.g.
+// localchroma.ErrCollectionNotFound) once the embedded runtime exports one.
+// Substring sniffing is a maintenance hazard — any upstream rewording of the
+// error message silently flips classification. Pinned today by
+// TestIsEmbeddedCollectionNotFoundError_RealEmbeddedRuntime.
 func isEmbeddedCollectionNotFoundError(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/api/v2/client_local_embedded.go
+++ b/pkg/api/v2/client_local_embedded.go
@@ -349,9 +349,6 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 	if err != nil {
 		return nil, errors.Wrap(err, "error preparing collection create request")
 	}
-	if err := req.PrepareAndValidateCollectionRequest(); err != nil {
-		return nil, errors.Wrap(err, "error validating collection create request")
-	}
 	cleanupMessage := "error cleaning up default embedding function during collection create"
 	defer func() {
 		cleanupErr := req.closeSDKOwnedDefaultDenseEF(cleanupMessage)
@@ -365,6 +362,9 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		}
 		err = cleanupErr
 	}()
+	if err := req.PrepareAndValidateCollectionRequest(); err != nil {
+		return nil, errors.Wrap(err, "error validating collection create request")
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -391,9 +391,13 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		if lookupErr == nil && existingCollection != nil {
 			existingCollectionID = existingCollection.ID
 		} else if lookupErr != nil && !isEmbeddedCollectionNotFoundError(lookupErr) {
-			client.logger.Warn("create-if-not-exists preflight GetCollection failed",
-				logger.String("collection", req.Name),
-				logger.ErrorField("error", lookupErr))
+			if client.logger != nil {
+				client.logger.Warn("create-if-not-exists preflight GetCollection failed",
+					logger.String("collection", req.Name),
+					logger.ErrorField("error", lookupErr))
+			} else {
+				logCreateIfNotExistsPreflightErrorToStderr(req.Name, lookupErr)
+			}
 		}
 	}
 
@@ -417,7 +421,8 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 		cleanupMessage = "error closing default embedding function for existing collection"
 		// A missed preflight probe on a fresh client can still reuse an existing
 		// collection; reload it so the returned collection uses the stored EF state.
-		collection, getErr := client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
+		var getErr error
+		collection, getErr = client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
 		if getErr != nil {
 			return nil, errors.Wrap(getErr, "error retrieving existing collection after create-if-not-exists reuse")
 		}
@@ -427,6 +432,22 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 	overrideEF := req.embeddingFunction
 	overrideContentEF := req.contentEmbeddingFunction
 	reusedExistingCollection := client.returnedExistingCollection(req.Name, model.ID, existingCollectionID)
+	if reusedExistingCollection {
+		cleanupMessage = "error closing default embedding function for existing collection"
+		client.collectionStateMu.RLock()
+		hasState := client.collectionState[model.ID] != nil
+		client.collectionStateMu.RUnlock()
+		cached := client.cachedCollectionByName(req.Name)
+		hasCachedCollection := cached != nil && cached.ID() == model.ID
+		if !hasState && !hasCachedCollection {
+			var getErr error
+			collection, getErr = client.GetCollection(ctx, req.Name, WithDatabaseGet(req.Database))
+			if getErr != nil {
+				return nil, errors.Wrap(getErr, "error retrieving existing collection after create-if-not-exists reuse")
+			}
+			return collection, nil
+		}
+	}
 	if !reusedExistingCollection {
 		overrideEF = wrapEFCloseOnce(req.embeddingFunction)
 		// NOTE: wrapping must occur after PrepareAndValidateCollectionRequest (see client_http.go).
@@ -461,7 +482,7 @@ func (client *embeddedLocalClient) CreateCollection(ctx context.Context, name st
 			})
 			cleanupErr := client.deleteCollectionState(model.ID)
 			err = errors.Wrap(err, "error building collection")
-			if deleteErr != nil {
+			if deleteErr != nil && !isEmbeddedCollectionNotFoundError(deleteErr) {
 				err = stderrors.Join(err, errors.Wrap(deleteErr, "error deleting collection after build failure"))
 			}
 			if cleanupErr != nil {
@@ -843,7 +864,8 @@ func isEmbeddedCollectionNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "not found")
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") || strings.Contains(message, "does not exist")
 }
 
 func (client *embeddedLocalClient) renameCollectionInCache(oldName string, collection Collection) {

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -99,12 +99,26 @@ type countingMemoryEmbeddedRuntime struct {
 	getCollectionCalls    int
 }
 
+type jsonRoundTripMissingGetCollectionOnceRuntime struct {
+	*missingGetCollectionOnceRuntime
+}
+
 type blockingGetMemoryEmbeddedRuntime struct {
 	*memoryEmbeddedRuntime
 
 	firstSnapshotTaken chan struct{}
 	unblockFirstGet    chan struct{}
 	getCalls           atomic.Int32
+}
+
+type failingCreateCollectionRuntime struct {
+	*stubEmbeddedRuntime
+	createErr error
+}
+
+type invalidCreateResponseDeleteTrackingRuntime struct {
+	*memoryEmbeddedRuntime
+	deleteCalls []localchroma.EmbeddedDeleteCollectionRequest
 }
 
 type missingGetCollectionOnceRuntime struct {
@@ -170,6 +184,19 @@ func newBlockingGetMemoryEmbeddedRuntime() *blockingGetMemoryEmbeddedRuntime {
 	}
 }
 
+func newJSONRoundTripMissingGetCollectionOnceRuntime() *jsonRoundTripMissingGetCollectionOnceRuntime {
+	return &jsonRoundTripMissingGetCollectionOnceRuntime{
+		missingGetCollectionOnceRuntime: newMissingGetCollectionOnceRuntime(),
+	}
+}
+
+func newInvalidCreateResponseDeleteTrackingRuntime() *invalidCreateResponseDeleteTrackingRuntime {
+	return &invalidCreateResponseDeleteTrackingRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
+	}
+}
+
 func newMissingGetCollectionOnceRuntime() *missingGetCollectionOnceRuntime {
 	runtime := &missingGetCollectionOnceRuntime{
 		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
@@ -223,6 +250,43 @@ func (s *blockingGetMemoryEmbeddedRuntime) GetCollection(request localchroma.Emb
 		<-s.unblockFirstGet
 	}
 	return col, nil
+}
+
+func (s *jsonRoundTripMissingGetCollectionOnceRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	col, err := s.missingGetCollectionOnceRuntime.CreateCollection(request)
+	if err != nil {
+		return nil, err
+	}
+	return roundTripEmbeddedCollectionModel(col)
+}
+
+func (s *jsonRoundTripMissingGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	col, err := s.missingGetCollectionOnceRuntime.GetCollection(request)
+	if err != nil {
+		return nil, err
+	}
+	return roundTripEmbeddedCollectionModel(col)
+}
+
+func (s *failingCreateCollectionRuntime) CreateCollection(localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	return nil, s.createErr
+}
+
+func (s *invalidCreateResponseDeleteTrackingRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	col, err := s.memoryEmbeddedRuntime.CreateCollection(request)
+	if err != nil {
+		return nil, err
+	}
+	invalid := *col
+	invalid.Metadata = map[string]any{
+		"invalid": map[string]any{"nested": "object"},
+	}
+	return &invalid, nil
+}
+
+func (s *invalidCreateResponseDeleteTrackingRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
+	s.deleteCalls = append(s.deleteCalls, request)
+	return s.memoryEmbeddedRuntime.DeleteCollection(request)
 }
 
 func (s *missingGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
@@ -346,6 +410,21 @@ func cloneEmbedding(src []float32) []float32 {
 	dst := make([]float32, len(src))
 	copy(dst, src)
 	return dst
+}
+
+func roundTripEmbeddedCollectionModel(model *localchroma.EmbeddedCollection) (*localchroma.EmbeddedCollection, error) {
+	if model == nil {
+		return nil, nil
+	}
+	payload, err := json.Marshal(model)
+	if err != nil {
+		return nil, err
+	}
+	var roundTripped localchroma.EmbeddedCollection
+	if err := json.Unmarshal(payload, &roundTripped); err != nil {
+		return nil, err
+	}
+	return &roundTripped, nil
 }
 
 func (s *memoryEmbeddedRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
@@ -1886,6 +1965,39 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionOnFreshClientUsesS
 	require.NotSame(t, temporaryDefaultEF, unwrapCloseOnceEF(againEmbedded.embeddingFunctionSnapshot()))
 }
 
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionOnFreshClientUsesStoredEFWhenProbeMisses_AfterJSONRoundTrip(t *testing.T) {
+	runtime := newJSONRoundTripMissingGetCollectionOnceRuntime()
+	writer := newEmbeddedClientForRuntime(t, runtime)
+	reader := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
+	created, err := writer.CreateCollection(
+		ctx,
+		"default-ort-existing-fresh-client-probe-miss-json-roundtrip",
+		WithEmbeddingFunctionCreate(initialEF),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := reader.CreateCollection(
+		ctx,
+		"default-ort-existing-fresh-client-probe-miss-json-roundtrip",
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, created.ID(), got.ID())
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Equal(t, initialEF.Name(), unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()).Name())
+	require.NotSame(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+}
+
 func TestEmbeddedCreateCollection_DefaultORTReplacementCollectionKeepsTemporaryDefaultWhenProbeIsStale(t *testing.T) {
 	runtime := newStaleGetCollectionDeleteRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
@@ -1913,6 +2025,118 @@ func TestEmbeddedCreateCollection_DefaultORTReplacementCollectionKeepsTemporaryD
 
 	require.NoError(t, got.Close())
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
+func TestEmbeddedCreateCollection_DefaultORTCreateFailureClosesTemporaryDefault(t *testing.T) {
+	runtime := &failingCreateCollectionRuntime{
+		stubEmbeddedRuntime: &stubEmbeddedRuntime{},
+		createErr:           errors.New("create boom"),
+	}
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	_, err := client.CreateCollection(
+		ctx,
+		"default-ort-create-failure",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error creating collection")
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
+func TestEmbeddedCreateCollection_DefaultORTCanceledContextClosesTemporaryDefault(t *testing.T) {
+	runtime := newCountingMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	_, err := client.CreateCollection(
+		ctx,
+		"default-ort-canceled-context",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionWithNonClosableDefaultReturnsError(t *testing.T) {
+	runtime := newCountingMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	_, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-non-closable",
+		WithEmbeddingFunctionCreate(embeddingspkg.NewConsistentHashEmbeddingFunction()),
+	)
+	require.NoError(t, err)
+
+	_, err = client.CreateCollection(
+		ctx,
+		"default-ort-existing-non-closable",
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return &mockNonCloseableEF{}, func() error { return nil }, nil
+		}),
+	)
+	require.EqualError(t, err, "sdk-owned default embedding function is not closable")
+}
+
+func TestEmbeddedCreateCollection_BuildFailureDeletesRuntimeCollection(t *testing.T) {
+	runtime := newInvalidCreateResponseDeleteTrackingRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	_, err := client.CreateCollection(ctx, "invalid-create-response")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error parsing collection metadata")
+
+	require.Len(t, runtime.deleteCalls, 1)
+	require.Equal(t, "invalid-create-response", runtime.deleteCalls[0].Name)
+
+	_, getErr := runtime.GetCollection(localchroma.EmbeddedGetCollectionRequest{
+		Name:         "invalid-create-response",
+		TenantID:     DefaultTenant,
+		DatabaseName: DefaultDatabase,
+	})
+	require.Error(t, getErr)
+}
+
+func TestComparableCollectionMap_NormalizesJSONNumberAndFloat64(t *testing.T) {
+	left := map[string]any{
+		"hnsw": map[string]any{
+			"construction_ef": float64(200),
+			"m":               float64(16),
+		},
+	}
+	right := map[string]any{
+		"hnsw": map[string]any{
+			"construction_ef": json.Number("200"),
+			"m":               json.Number("16"),
+		},
+	}
+
+	require.True(t, comparableCollectionMap(left, right))
+	require.True(t, comparableCollectionMap(right, left))
+}
+
+func TestComparableCollectionMap_EmptyAndNilMatch(t *testing.T) {
+	require.True(t, comparableCollectionMap(nil, map[string]any{}))
+	require.True(t, comparableCollectionMap(map[string]any{}, nil))
+}
+
+func TestIsEmbeddedCollectionNotFoundError(t *testing.T) {
+	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("collection not found")))
+	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("Collection NOT FOUND in runtime")))
+	require.False(t, isEmbeddedCollectionNotFoundError(errors.New("embedded runtime unavailable")))
+	require.False(t, isEmbeddedCollectionNotFoundError(nil))
 }
 
 func TestEmbeddedCollectionCRUD_AddUpsertQueryDelete(t *testing.T) {

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -107,6 +107,16 @@ type blockingGetMemoryEmbeddedRuntime struct {
 	getCalls           atomic.Int32
 }
 
+type missingGetCollectionOnceRuntime struct {
+	*memoryEmbeddedRuntime
+	missNextGet atomic.Bool
+}
+
+type staleGetCollectionDeleteRuntime struct {
+	*memoryEmbeddedRuntime
+	staleNextGet atomic.Bool
+}
+
 type failingUpdateEmbeddedRuntime struct {
 	*memoryEmbeddedRuntime
 
@@ -160,6 +170,22 @@ func newBlockingGetMemoryEmbeddedRuntime() *blockingGetMemoryEmbeddedRuntime {
 	}
 }
 
+func newMissingGetCollectionOnceRuntime() *missingGetCollectionOnceRuntime {
+	runtime := &missingGetCollectionOnceRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+	}
+	runtime.missNextGet.Store(true)
+	return runtime
+}
+
+func newStaleGetCollectionDeleteRuntime() *staleGetCollectionDeleteRuntime {
+	runtime := &staleGetCollectionDeleteRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+	}
+	runtime.staleNextGet.Store(true)
+	return runtime
+}
+
 func newFailingUpdateEmbeddedRuntime(updateErr error) *failingUpdateEmbeddedRuntime {
 	return &failingUpdateEmbeddedRuntime{
 		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
@@ -197,6 +223,36 @@ func (s *blockingGetMemoryEmbeddedRuntime) GetCollection(request localchroma.Emb
 		<-s.unblockFirstGet
 	}
 	return col, nil
+}
+
+func (s *missingGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	if s.missNextGet.CompareAndSwap(true, false) {
+		return nil, errors.New("collection not found")
+	}
+	return s.memoryEmbeddedRuntime.GetCollection(request)
+}
+
+func (s *staleGetCollectionDeleteRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	if !s.staleNextGet.CompareAndSwap(true, false) {
+		return s.memoryEmbeddedRuntime.GetCollection(request)
+	}
+
+	s.memoryEmbeddedRuntime.mu.Lock()
+	defer s.memoryEmbeddedRuntime.mu.Unlock()
+
+	key := collectionRuntimeKey(request.TenantID, request.DatabaseName, request.Name)
+	col, ok := s.memoryEmbeddedRuntime.collections[key]
+	if !ok {
+		return nil, errors.New("collection not found")
+	}
+
+	delete(s.memoryEmbeddedRuntime.collections, key)
+	delete(s.memoryEmbeddedRuntime.collectionByID, col.ID)
+	delete(s.memoryEmbeddedRuntime.records, col.ID)
+	delete(s.memoryEmbeddedRuntime.recordOrder, col.ID)
+
+	copyCol := col
+	return &copyCol, nil
 }
 
 func (s *failingUpdateEmbeddedRuntime) UpdateCollection(request localchroma.EmbeddedUpdateCollectionRequest) error {
@@ -1697,6 +1753,45 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDef
 	require.Equal(t, "initial", source)
 }
 
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionProbeMissStillClosesTemporaryDefault(t *testing.T) {
+	runtime := newMissingGetCollectionOnceRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
+	initialMetadata := NewMetadataFromMap(map[string]interface{}{"source": "initial"})
+	created, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-missed-probe",
+		WithEmbeddingFunctionCreate(initialEF),
+		WithCollectionMetadataCreate(initialMetadata),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	overrideMetadata := NewMetadataFromMap(map[string]interface{}{"source": "override"})
+	got, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-missed-probe",
+		WithIfNotExistsCreate(),
+		WithCollectionMetadataCreate(overrideMetadata),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, created.ID(), got.ID())
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, initialEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+
+	source, ok := gotCollection.Metadata().GetString("source")
+	require.True(t, ok)
+	require.Equal(t, "initial", source)
+}
+
 func TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError(t *testing.T) {
 	runtime := newCountingMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
@@ -1743,6 +1838,35 @@ func TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDe
 	gotCollection, ok := got.(*embeddedCollection)
 	require.True(t, ok)
 	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+
+	require.NoError(t, got.Close())
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
+func TestEmbeddedCreateCollection_DefaultORTReplacementCollectionKeepsTemporaryDefaultWhenProbeIsStale(t *testing.T) {
+	runtime := newStaleGetCollectionDeleteRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	original, err := client.CreateCollection(ctx, "default-ort-recreated-after-stale-probe")
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := client.CreateCollection(
+		ctx,
+		"default-ort-recreated-after-stale-probe",
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, original.ID(), got.ID())
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load())
 
 	require.NoError(t, got.Close())
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -2180,6 +2180,88 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionOnFreshClientUsesS
 	require.NotSame(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
 }
 
+// TestEmbeddedCreateCollection_DefaultORTExistingEmptyCollectionOnFreshClientDoesNotPromoteTemporaryDefaultWhenPreflightErrors
+// pins the item 3 race from PR #504 review: when a pre-existing collection has
+// all-empty metadata/config/schema (e.g. created via a path that skipped EF
+// config persistence) AND the reader is a fresh client with no cached state AND
+// the preflight GetCollection returned a transient (non-not-found) error, the
+// JSON-equality heuristic in collectionModelMatchesCreateRequest can't detect
+// reuse. The current behaviour installs the reader's throwaway default EF as
+// persistent state; the fix routes this case through the reload branch so the
+// throwaway is closed instead.
+func TestEmbeddedCreateCollection_DefaultORTExistingEmptyCollectionOnFreshClientDoesNotPromoteTemporaryDefaultWhenPreflightErrors(t *testing.T) {
+	runtime := newErrorGetCollectionOnceRuntime(errors.New("transient backend error"))
+	writer := newEmbeddedClientForRuntime(t, runtime)
+	reader := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	const name = "default-ort-existing-empty-preflight-error"
+
+	// Create a persisted collection with empty metadata/config/schema by using
+	// WithDisableEFConfigStorage on the writer and omitting metadata/schema.
+	_, err := writer.CreateCollection(
+		ctx,
+		name,
+		WithDisableEFConfigStorage(),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := reader.CreateCollection(
+		ctx,
+		name,
+		WithIfNotExistsCreate(),
+		WithDisableEFConfigStorage(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must be closed when a fresh client reuses a pre-existing empty collection after a transient preflight error")
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	gotEF := unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot())
+	var temporaryAsEF embeddingspkg.EmbeddingFunction = temporaryDefaultEF
+	require.False(t, gotEF == temporaryAsEF,
+		"returned collection must not wrap the reader's throwaway temporary default EF")
+}
+
+// TestEmbeddedCreateCollection_DefaultORTNewEmptyCollectionWithIfNotExistsStillInstallsTemporaryDefault
+// is a regression guard for the item 3 fix: when the preflight probe
+// conclusively reports not-found for a genuinely-new collection (no transient
+// error), the reader's throwaway default EF must still be promoted to state
+// so that subsequent Add/Query calls on the fresh collection have a usable EF.
+// This is the "legitimately new, all empty, CreateIfNotExists" path that the
+// narrow reload widening must NOT touch.
+func TestEmbeddedCreateCollection_DefaultORTNewEmptyCollectionWithIfNotExistsStillInstallsTemporaryDefault(t *testing.T) {
+	runtime := newMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := client.CreateCollection(
+		ctx,
+		"default-ort-new-empty-if-not-exists",
+		WithIfNotExistsCreate(),
+		WithDisableEFConfigStorage(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load(),
+		"brand-new collection must keep its temporary default EF alive as state")
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+}
+
 func TestEmbeddedCreateCollection_DefaultORTReplacementCollectionKeepsTemporaryDefaultWhenProbeIsStale(t *testing.T) {
 	runtime := newStaleGetCollectionDeleteRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -1658,6 +1658,96 @@ func TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideS
 	require.Equal(t, 1, getCalls)
 }
 
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionClosesTemporaryDefaultAndPreservesState(t *testing.T) {
+	runtime := newCountingMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
+	initialMetadata := NewMetadataFromMap(map[string]interface{}{"source": "initial"})
+	created, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-close",
+		WithEmbeddingFunctionCreate(initialEF),
+		WithCollectionMetadataCreate(initialMetadata),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	overrideMetadata := NewMetadataFromMap(map[string]interface{}{"source": "override"})
+	got, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-close",
+		WithIfNotExistsCreate(),
+		WithCollectionMetadataCreate(overrideMetadata),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, created.ID(), got.ID())
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, initialEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+
+	source, ok := gotCollection.Metadata().GetString("source")
+	require.True(t, ok)
+	require.Equal(t, "initial", source)
+}
+
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError(t *testing.T) {
+	runtime := newCountingMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
+	_, err := client.CreateCollection(
+		ctx,
+		"default-ort-existing-close-error",
+		WithEmbeddingFunctionCreate(initialEF),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockFailingCloseEF{closeErr: errors.New("close boom")}
+	_, err = client.CreateCollection(
+		ctx,
+		"default-ort-existing-close-error",
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error closing default embedding function for existing collection")
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
+func TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDefault(t *testing.T) {
+	runtime := newCountingMemoryEmbeddedRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := client.CreateCollection(
+		ctx,
+		"default-ort-new-collection",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load())
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()))
+
+	require.NoError(t, got.Close())
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
 func TestEmbeddedCollectionCRUD_AddUpsertQueryDelete(t *testing.T) {
 	runtime := newMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -1843,6 +1843,49 @@ func TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDe
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
 }
 
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionOnFreshClientUsesStoredEFWhenProbeMisses(t *testing.T) {
+	runtime := newMissingGetCollectionOnceRuntime()
+	writer := newEmbeddedClientForRuntime(t, runtime)
+	reader := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
+	created, err := writer.CreateCollection(
+		ctx,
+		"default-ort-existing-fresh-client-probe-miss",
+		WithEmbeddingFunctionCreate(initialEF),
+	)
+	require.NoError(t, err)
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := reader.CreateCollection(
+		ctx,
+		"default-ort-existing-fresh-client-probe-miss",
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, created.ID(), got.ID())
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must be closed when CreateCollection reused an existing collection")
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	gotDenseEF := unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot())
+	require.NotNil(t, gotDenseEF)
+	require.Equal(t, initialEF.Name(), gotDenseEF.Name())
+	require.NotSame(t, temporaryDefaultEF, gotDenseEF)
+
+	again, err := reader.GetCollection(ctx, "default-ort-existing-fresh-client-probe-miss")
+	require.NoError(t, err)
+	againEmbedded, ok := again.(*embeddedCollection)
+	require.True(t, ok)
+	require.Equal(t, initialEF.Name(), unwrapCloseOnceEF(againEmbedded.embeddingFunctionSnapshot()).Name())
+	require.NotSame(t, temporaryDefaultEF, unwrapCloseOnceEF(againEmbedded.embeddingFunctionSnapshot()))
+}
+
 func TestEmbeddedCreateCollection_DefaultORTReplacementCollectionKeepsTemporaryDefaultWhenProbeIsStale(t *testing.T) {
 	runtime := newStaleGetCollectionDeleteRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"strconv"
@@ -930,6 +931,27 @@ func newRealPersistentClientForTest(t *testing.T, persistPath string) *Persisten
 	persistent, ok := client.(*PersistentClient)
 	require.True(t, ok)
 	return persistent
+}
+
+type countingCloseableEF struct {
+	embeddingspkg.EmbeddingFunction
+
+	closeFn    func() error
+	closeOnce  sync.Once
+	closeErr   error
+	closeCount atomic.Int32
+}
+
+var _ io.Closer = (*countingCloseableEF)(nil)
+
+func (e *countingCloseableEF) Close() error {
+	e.closeOnce.Do(func() {
+		e.closeCount.Add(1)
+		if e.closeFn != nil {
+			e.closeErr = e.closeFn()
+		}
+	})
+	return e.closeErr
 }
 
 func seedEmbeddedCollectionForTest(t *testing.T, runtime *memoryEmbeddedRuntime, name string, configuration *CollectionConfigurationImpl) string {
@@ -3558,20 +3580,33 @@ func TestEmbeddedCreateCollection_RealORTIfNotExistsRoundTrip(t *testing.T) {
 	require.NotNil(t, createdDenseEF)
 	require.Equal(t, "default", createdDenseEF.Name())
 
-	_, closeORT, err := ortpkg.NewDefaultEmbeddingFunction()
-	if err != nil {
-		t.Skipf("ORT embedding function unavailable in this environment: %v", err)
-	}
-	require.NoError(t, closeORT())
-
 	reader := newRealPersistentClientForTest(t, persistPath)
 	defer func() {
 		_ = reader.Close()
 	}()
 
-	got, err := reader.CreateCollection(ctx, collectionName, WithIfNotExistsCreate())
+	var temporaryDefaultEF *countingCloseableEF
+	got, err := reader.CreateCollection(
+		ctx,
+		collectionName,
+		WithIfNotExistsCreate(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			ef, closeFn, factoryErr := ortpkg.NewDefaultEmbeddingFunction()
+			if factoryErr != nil {
+				return nil, nil, factoryErr
+			}
+			temporaryDefaultEF = &countingCloseableEF{
+				EmbeddingFunction: ef,
+				closeFn:           closeFn,
+			}
+			return temporaryDefaultEF, temporaryDefaultEF.Close, nil
+		}),
+	)
 	require.NoError(t, err)
 	require.Equal(t, created.ID(), got.ID())
+	require.NotNil(t, temporaryDefaultEF)
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must be closed when CreateCollection reused an existing collection")
 
 	gotEmbedded, ok := got.(*embeddedCollection)
 	require.True(t, ok)

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -4,6 +4,7 @@
 package v2
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,6 +22,8 @@ import (
 
 	localchroma "github.com/amikos-tech/chroma-go-local"
 	embeddingspkg "github.com/amikos-tech/chroma-go/pkg/embeddings"
+	ortpkg "github.com/amikos-tech/chroma-go/pkg/embeddings/ort"
+	loggerpkg "github.com/amikos-tech/chroma-go/pkg/logger"
 )
 
 type scriptedEmbeddedRuntime struct {
@@ -103,6 +107,12 @@ type jsonRoundTripMissingGetCollectionOnceRuntime struct {
 	*missingGetCollectionOnceRuntime
 }
 
+type errorGetCollectionOnceRuntime struct {
+	*memoryEmbeddedRuntime
+	lookupErr error
+	failOnce  atomic.Bool
+}
+
 type blockingGetMemoryEmbeddedRuntime struct {
 	*memoryEmbeddedRuntime
 
@@ -119,6 +129,17 @@ type failingCreateCollectionRuntime struct {
 type invalidCreateResponseDeleteTrackingRuntime struct {
 	*memoryEmbeddedRuntime
 	deleteCalls []localchroma.EmbeddedDeleteCollectionRequest
+}
+
+type invalidCreateResponseMissingDeleteRuntime struct {
+	*memoryEmbeddedRuntime
+	deleteCalls []localchroma.EmbeddedDeleteCollectionRequest
+}
+
+type invalidCreateResponseDeleteErrorRuntime struct {
+	*memoryEmbeddedRuntime
+	deleteCalls []localchroma.EmbeddedDeleteCollectionRequest
+	deleteErr   error
 }
 
 type missingGetCollectionOnceRuntime struct {
@@ -190,10 +211,34 @@ func newJSONRoundTripMissingGetCollectionOnceRuntime() *jsonRoundTripMissingGetC
 	}
 }
 
+func newErrorGetCollectionOnceRuntime(lookupErr error) *errorGetCollectionOnceRuntime {
+	runtime := &errorGetCollectionOnceRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+		lookupErr:             lookupErr,
+	}
+	runtime.failOnce.Store(true)
+	return runtime
+}
+
 func newInvalidCreateResponseDeleteTrackingRuntime() *invalidCreateResponseDeleteTrackingRuntime {
 	return &invalidCreateResponseDeleteTrackingRuntime{
 		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
 		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
+	}
+}
+
+func newInvalidCreateResponseMissingDeleteRuntime() *invalidCreateResponseMissingDeleteRuntime {
+	return &invalidCreateResponseMissingDeleteRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
+	}
+}
+
+func newInvalidCreateResponseDeleteErrorRuntime(deleteErr error) *invalidCreateResponseDeleteErrorRuntime {
+	return &invalidCreateResponseDeleteErrorRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
+		deleteErr:             deleteErr,
 	}
 }
 
@@ -268,6 +313,13 @@ func (s *jsonRoundTripMissingGetCollectionOnceRuntime) GetCollection(request loc
 	return roundTripEmbeddedCollectionModel(col)
 }
 
+func (s *errorGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	if s.failOnce.CompareAndSwap(true, false) {
+		return nil, s.lookupErr
+	}
+	return s.memoryEmbeddedRuntime.GetCollection(request)
+}
+
 func (s *failingCreateCollectionRuntime) CreateCollection(localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
 	return nil, s.createErr
 }
@@ -287,6 +339,40 @@ func (s *invalidCreateResponseDeleteTrackingRuntime) CreateCollection(request lo
 func (s *invalidCreateResponseDeleteTrackingRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
 	s.deleteCalls = append(s.deleteCalls, request)
 	return s.memoryEmbeddedRuntime.DeleteCollection(request)
+}
+
+func (s *invalidCreateResponseMissingDeleteRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	return &localchroma.EmbeddedCollection{
+		ID:       "dangling-invalid-id",
+		Name:     request.Name,
+		Tenant:   normalizeEmbeddedTenant(request.TenantID),
+		Database: normalizeEmbeddedDatabase(request.DatabaseName),
+		Metadata: map[string]any{
+			"invalid": map[string]any{"nested": "object"},
+		},
+	}, nil
+}
+
+func (s *invalidCreateResponseMissingDeleteRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
+	s.deleteCalls = append(s.deleteCalls, request)
+	return s.memoryEmbeddedRuntime.DeleteCollection(request)
+}
+
+func (s *invalidCreateResponseDeleteErrorRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	col, err := s.memoryEmbeddedRuntime.CreateCollection(request)
+	if err != nil {
+		return nil, err
+	}
+	invalid := *col
+	invalid.Metadata = map[string]any{
+		"invalid": map[string]any{"nested": "object"},
+	}
+	return &invalid, nil
+}
+
+func (s *invalidCreateResponseDeleteErrorRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
+	s.deleteCalls = append(s.deleteCalls, request)
+	return s.deleteErr
 }
 
 func (s *missingGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
@@ -421,7 +507,9 @@ func roundTripEmbeddedCollectionModel(model *localchroma.EmbeddedCollection) (*l
 		return nil, err
 	}
 	var roundTripped localchroma.EmbeddedCollection
-	if err := json.Unmarshal(payload, &roundTripped); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&roundTripped); err != nil {
 		return nil, err
 	}
 	return &roundTripped, nil
@@ -820,7 +908,28 @@ func newEmbeddedClientForRuntime(t *testing.T, runtime localEmbeddedRuntime) *em
 		state:           apiState,
 		embedded:        runtime,
 		collectionState: map[string]*embeddedCollectionState{},
+		logger:          loggerpkg.NewNoopLogger(),
 	}
+}
+
+func newRealPersistentClientForTest(t *testing.T, persistPath string) *PersistentClient {
+	t.Helper()
+
+	opts := []PersistentClientOption{
+		WithPersistentPath(persistPath),
+		WithPersistentLibraryAutoDownload(true),
+	}
+	if libPath := strings.TrimSpace(os.Getenv("CHROMA_LIB_PATH")); libPath != "" {
+		opts = append(opts, WithPersistentLibraryPath(libPath))
+	}
+
+	client, err := NewPersistentClient(opts...)
+	if err != nil {
+		t.Skipf("embedded local runtime unavailable in this environment: %v", err)
+	}
+	persistent, ok := client.(*PersistentClient)
+	require.True(t, ok)
+	return persistent
 }
 
 func seedEmbeddedCollectionForTest(t *testing.T, runtime *memoryEmbeddedRuntime, name string, configuration *CollectionConfigurationImpl) string {
@@ -2048,6 +2157,28 @@ func TestEmbeddedCreateCollection_DefaultORTCreateFailureClosesTemporaryDefault(
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
 }
 
+func TestEmbeddedCreateCollection_DefaultORTCreateFailureJoinsCleanupError(t *testing.T) {
+	runtime := &failingCreateCollectionRuntime{
+		stubEmbeddedRuntime: &stubEmbeddedRuntime{},
+		createErr:           errors.New("create boom"),
+	}
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	temporaryDefaultEF := &mockFailingCloseEF{closeErr: errors.New("close boom")}
+	_, err := client.CreateCollection(
+		ctx,
+		"default-ort-create-failure-cleanup-join",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error creating collection")
+	require.Contains(t, err.Error(), "error cleaning up default embedding function during collection create")
+	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+}
+
 func TestEmbeddedCreateCollection_DefaultORTCanceledContextClosesTemporaryDefault(t *testing.T) {
 	runtime := newCountingMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
@@ -2109,6 +2240,33 @@ func TestEmbeddedCreateCollection_BuildFailureDeletesRuntimeCollection(t *testin
 	require.Error(t, getErr)
 }
 
+func TestEmbeddedCreateCollection_BuildFailureSuppressesDeleteCollectionNotFound(t *testing.T) {
+	runtime := newInvalidCreateResponseMissingDeleteRuntime()
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	_, err := client.CreateCollection(ctx, "invalid-create-response-delete-missing")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error building collection")
+	require.NotContains(t, err.Error(), "error deleting collection after build failure")
+	require.Len(t, runtime.deleteCalls, 1)
+}
+
+func TestEmbeddedCreateCollection_BuildFailureJoinsDeleteAndCleanupErrors(t *testing.T) {
+	runtime := newInvalidCreateResponseDeleteErrorRuntime(errors.New("delete boom"))
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	_, err := client.CreateCollection(ctx, "invalid-create-response-delete-error", WithEmbeddingFunctionCreate(&mockFailingCloseEF{
+		closeErr: errors.New("cleanup boom"),
+	}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error building collection")
+	require.Contains(t, err.Error(), "error deleting collection after build failure: delete boom")
+	require.Contains(t, err.Error(), "cleanup boom")
+	require.Len(t, runtime.deleteCalls, 1)
+}
+
 func TestComparableCollectionMap_NormalizesJSONNumberAndFloat64(t *testing.T) {
 	left := map[string]any{
 		"hnsw": map[string]any{
@@ -2132,11 +2290,66 @@ func TestComparableCollectionMap_EmptyAndNilMatch(t *testing.T) {
 	require.True(t, comparableCollectionMap(map[string]any{}, nil))
 }
 
+func TestRoundTripEmbeddedCollectionModel_PreservesJSONNumbers(t *testing.T) {
+	model := &localchroma.EmbeddedCollection{
+		ID:   "roundtrip-json-number",
+		Name: "roundtrip-json-number",
+		ConfigurationJSON: map[string]any{
+			"hnsw": map[string]any{
+				"construction_ef": float64(200),
+			},
+		},
+	}
+
+	roundTripped, err := roundTripEmbeddedCollectionModel(model)
+	require.NoError(t, err)
+
+	hnsw, ok := roundTripped.ConfigurationJSON["hnsw"].(map[string]any)
+	require.True(t, ok)
+	require.IsType(t, json.Number("200"), hnsw["construction_ef"])
+}
+
 func TestIsEmbeddedCollectionNotFoundError(t *testing.T) {
 	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("collection not found")))
 	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("Collection NOT FOUND in runtime")))
+	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("Collection [missing] does not exist")))
 	require.False(t, isEmbeddedCollectionNotFoundError(errors.New("embedded runtime unavailable")))
 	require.False(t, isEmbeddedCollectionNotFoundError(nil))
+}
+
+func TestIsEmbeddedCollectionNotFoundError_RealEmbeddedRuntime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real embedded runtime test in short mode")
+	}
+
+	client := newRealPersistentClientForTest(t, t.TempDir())
+	defer func() {
+		_ = client.Close()
+	}()
+
+	embeddedClient, ok := client.Client.(*embeddedLocalClient)
+	require.True(t, ok)
+	embedded := embeddedClient.embedded
+	databaseName := fmt.Sprintf("not-found-db-%d", time.Now().UnixNano())
+	require.NoError(t, embedded.CreateDatabase(localchroma.EmbeddedCreateDatabaseRequest{
+		Name: databaseName,
+	}))
+
+	_, getErr := embedded.GetCollection(localchroma.EmbeddedGetCollectionRequest{
+		Name:         "missing-collection",
+		TenantID:     DefaultTenant,
+		DatabaseName: databaseName,
+	})
+	require.Error(t, getErr)
+	require.True(t, isEmbeddedCollectionNotFoundError(getErr))
+
+	deleteErr := embedded.DeleteCollection(localchroma.EmbeddedDeleteCollectionRequest{
+		Name:         "missing-collection",
+		TenantID:     DefaultTenant,
+		DatabaseName: databaseName,
+	})
+	require.Error(t, deleteErr)
+	require.True(t, isEmbeddedCollectionNotFoundError(deleteErr))
 }
 
 func TestEmbeddedCollectionCRUD_AddUpsertQueryDelete(t *testing.T) {
@@ -2635,6 +2848,7 @@ func TestEmbeddedGetCollection_LogsAutoWireErrorsToStderr(t *testing.T) {
 	seedEmbeddedCollectionForTest(t, runtime, "test-autowire-log", configuration)
 
 	client := newEmbeddedClientForRuntime(t, runtime)
+	client.logger = nil
 	output := captureStderr(t, func() {
 		got, getErr := client.GetCollection(ctx, "test-autowire-log")
 		require.NoError(t, getErr)
@@ -2875,6 +3089,7 @@ func TestEmbeddedLocalClient_Close_IsSafeToCallTwice(t *testing.T) {
 func TestEmbeddedLocalClient_Close_NoLoggerFallsBackToStderrWithShutdownContext(t *testing.T) {
 	runtime := newMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
+	client.logger = nil
 
 	mockEF := &mockFailingCloseEF{closeErr: errors.New("shutdown stderr test error")}
 	client.collectionStateMu.Lock()
@@ -3285,10 +3500,90 @@ func TestEmbeddedClient_LoggerReceivesErrors(t *testing.T) {
 	})
 }
 
+func TestNewEmbeddedClientForRuntime_DefaultsToLoggerInvariant(t *testing.T) {
+	client := newEmbeddedClientForRuntime(t, newMemoryEmbeddedRuntime())
+	require.NotNil(t, client.logger)
+}
+
+func TestEmbeddedCreateCollection_IfNotExistsPreflightFallsBackToStderrWhenLoggerNil(t *testing.T) {
+	runtime := newErrorGetCollectionOnceRuntime(errors.New("runtime temporarily unavailable"))
+	client := newEmbeddedClientForRuntime(t, runtime)
+	client.logger = nil
+
+	output := captureStderr(t, func() {
+		got, err := client.CreateCollection(context.Background(), "preflight-warn-nil-logger", WithIfNotExistsCreate())
+		require.NoError(t, err)
+		require.NotNil(t, got)
+	})
+
+	require.Contains(t, output, "create-if-not-exists preflight GetCollection failed")
+	require.Contains(t, output, "runtime temporarily unavailable")
+}
+
+func TestEmbeddedCreateCollection_IfNotExistsPreflightWarnsViaLogger(t *testing.T) {
+	runtime := newErrorGetCollectionOnceRuntime(errors.New("runtime temporarily unavailable"))
+	client := newEmbeddedClientForRuntime(t, runtime)
+	log := &capturingLogger{}
+	client.logger = log
+
+	got, err := client.CreateCollection(context.Background(), "preflight-warn-logger", WithIfNotExistsCreate())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.GreaterOrEqual(t, log.warnCount, 1)
+	require.Contains(t, log.lastMsg, "create-if-not-exists preflight GetCollection failed")
+}
+
+func TestEmbeddedCreateCollection_RealORTIfNotExistsRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real ORT/local runtime test in short mode")
+	}
+
+	persistPath := t.TempDir()
+	ctx := context.Background()
+	collectionName := fmt.Sprintf("real-ort-if-not-exists-%d", time.Now().UnixNano())
+
+	writer := newRealPersistentClientForTest(t, persistPath)
+	created, err := writer.CreateCollection(ctx, collectionName, WithIfNotExistsCreate())
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "error creating default embedding function") {
+			t.Skipf("ORT embedding function unavailable in this environment: %v", err)
+		}
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Close())
+
+	createdEmbedded, ok := created.(*embeddedCollection)
+	require.True(t, ok)
+	createdDenseEF := unwrapCloseOnceEF(createdEmbedded.embeddingFunctionSnapshot())
+	require.NotNil(t, createdDenseEF)
+	require.Equal(t, "default", createdDenseEF.Name())
+
+	_, closeORT, err := ortpkg.NewDefaultEmbeddingFunction()
+	if err != nil {
+		t.Skipf("ORT embedding function unavailable in this environment: %v", err)
+	}
+	require.NoError(t, closeORT())
+
+	reader := newRealPersistentClientForTest(t, persistPath)
+	defer func() {
+		_ = reader.Close()
+	}()
+
+	got, err := reader.CreateCollection(ctx, collectionName, WithIfNotExistsCreate())
+	require.NoError(t, err)
+	require.Equal(t, created.ID(), got.ID())
+
+	gotEmbedded, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	gotDenseEF := unwrapCloseOnceEF(gotEmbedded.embeddingFunctionSnapshot())
+	require.NotNil(t, gotDenseEF)
+	require.Equal(t, "default", gotDenseEF.Name())
+}
+
 func TestEmbeddedClient_NoLoggerFallsBackToStderr(t *testing.T) {
 	runtime := newMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
-	// logger is nil by default -- do NOT set it.
+	client.logger = nil
 
 	mockEF := &mockFailingCloseEF{closeErr: errors.New("stderr test error")}
 	wrappedEF := wrapEFCloseOnce(mockEF)

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -968,25 +968,28 @@ func newRealPersistentClientForTest(t *testing.T, persistPath string) *Persisten
 	return persistent
 }
 
+// countingCloseableEF is a test helper that records every Close() invocation
+// on the wrapped EmbeddingFunction. It deliberately does NOT deduplicate Close
+// via sync.Once so tests can detect double-close regressions -- in particular
+// the PR #504 review item 2 scenario where a failed contentEF-promotion close
+// could cause an outer defer to invoke Close() a second time on a C-backed EF.
+// If you need idempotent Close in a test, wrap the EF with wrapEFCloseOnce
+// instead so the production close-once wrapper is exercised.
 type countingCloseableEF struct {
 	embeddingspkg.EmbeddingFunction
 
 	closeFn    func() error
-	closeOnce  sync.Once
-	closeErr   error
 	closeCount atomic.Int32
 }
 
 var _ io.Closer = (*countingCloseableEF)(nil)
 
 func (e *countingCloseableEF) Close() error {
-	e.closeOnce.Do(func() {
-		e.closeCount.Add(1)
-		if e.closeFn != nil {
-			e.closeErr = e.closeFn()
-		}
-	})
-	return e.closeErr
+	e.closeCount.Add(1)
+	if e.closeFn != nil {
+		return e.closeFn()
+	}
+	return nil
 }
 
 func seedEmbeddedCollectionForTest(t *testing.T, runtime *memoryEmbeddedRuntime, name string, configuration *CollectionConfigurationImpl) string {
@@ -2219,15 +2222,54 @@ func TestEmbeddedCreateCollection_DefaultORTExistingEmptyCollectionOnFreshClient
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
-	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load(),
-		"temporary default EF must be closed when a fresh client reuses a pre-existing empty collection after a transient preflight error")
+	// PR #504 review item 3 fix: when a fresh client lands in the all-empty
+	// ambiguous branch with a transient preflight error, we cannot tell from
+	// the runtime whether the collection was just created or was a pre-existing
+	// empty one. In both cases there is no server-side EF config to reload, so
+	// the reader's temporary default EF is the best (and only) fallback. Install
+	// it as state rather than closing it -- a usable collection beats a
+	// semantically-"pure" nil-EF collection that fails on the first Add/Query.
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must remain alive so the reader's collection has a usable EF")
 
 	gotCollection, ok := got.(*embeddedCollection)
 	require.True(t, ok)
-	gotEF := unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot())
-	var temporaryAsEF embeddingspkg.EmbeddingFunction = temporaryDefaultEF
-	require.False(t, gotEF == temporaryAsEF,
-		"returned collection must not wrap the reader's throwaway temporary default EF")
+	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()),
+		"returned collection must wrap the reader's temporary default EF as fallback")
+}
+
+// TestEmbeddedCreateCollection_DefaultORTFreshClientTransientPreflightOnNewEmptyInstallsTemporaryDefault
+// pins the PR #504 review item 3 fix for the genuinely-new path: a fresh
+// client creates a brand-new empty collection via CreateIfNotExists +
+// DisableEFConfigStorage, and the preflight GetCollection returns a transient
+// (non-not-found) error. Previously the all-empty reload branch wrongly fired
+// and closed the temp EF, handing the caller a nil-EF collection. The fix
+// ensures the temp EF is installed as state so Add/Query work.
+func TestEmbeddedCreateCollection_DefaultORTFreshClientTransientPreflightOnNewEmptyInstallsTemporaryDefault(t *testing.T) {
+	runtime := newErrorGetCollectionOnceRuntime(errors.New("transient backend error"))
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	temporaryDefaultEF := &mockCloseableEF{}
+	got, err := client.CreateCollection(
+		ctx,
+		"fresh-new-empty-preflight-error",
+		WithIfNotExistsCreate(),
+		WithDisableEFConfigStorage(),
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return temporaryDefaultEF, func() error { return nil }, nil
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Equal(t, int32(0), temporaryDefaultEF.closeCount.Load(),
+		"temporary default EF must remain alive on genuinely-new empty collection even after transient preflight error")
+
+	gotCollection, ok := got.(*embeddedCollection)
+	require.True(t, ok)
+	require.Same(t, temporaryDefaultEF, unwrapCloseOnceEF(gotCollection.embeddingFunctionSnapshot()),
+		"returned collection must wrap the temporary default EF as fallback")
 }
 
 // TestEmbeddedCreateCollection_DefaultORTNewEmptyCollectionWithIfNotExistsStillInstallsTemporaryDefault
@@ -2530,6 +2572,33 @@ func TestIsEmbeddedCollectionNotFoundError(t *testing.T) {
 	require.True(t, isEmbeddedCollectionNotFoundError(errors.New("Collection [missing] does not exist")))
 	require.False(t, isEmbeddedCollectionNotFoundError(errors.New("embedded runtime unavailable")))
 	require.False(t, isEmbeddedCollectionNotFoundError(nil))
+}
+
+// TestIsEmbeddedCollectionNotFoundError_SentinelPath pins the PR #504 review
+// item 5 defensive improvement: classification is keyed on errors.Is against
+// ErrEmbeddedCollectionNotFound so future upstream message rewording cannot
+// silently flip the classifier. Substring matching remains as a fallback for
+// localchroma versions that have not yet been wrapped with the sentinel.
+func TestIsEmbeddedCollectionNotFoundError_SentinelPath(t *testing.T) {
+	t.Run("direct sentinel is classified", func(t *testing.T) {
+		require.True(t, isEmbeddedCollectionNotFoundError(ErrEmbeddedCollectionNotFound))
+	})
+
+	t.Run("wrapped sentinel is classified via errors.Is", func(t *testing.T) {
+		wrapped := fmt.Errorf("failed to fetch: %w", ErrEmbeddedCollectionNotFound)
+		require.True(t, isEmbeddedCollectionNotFoundError(wrapped))
+	})
+
+	t.Run("sentinel with message that would not match substring is still classified", func(t *testing.T) {
+		// Simulate upstream rewording the message to something like "missing
+		// target" -- substring match would not catch it, but the sentinel does.
+		reworded := fmt.Errorf("%w: missing target entity", ErrEmbeddedCollectionNotFound)
+		require.True(t, isEmbeddedCollectionNotFoundError(reworded))
+	})
+
+	t.Run("unrelated error is not classified", func(t *testing.T) {
+		require.False(t, isEmbeddedCollectionNotFoundError(errors.New("permission denied")))
+	})
 }
 
 func TestIsEmbeddedCollectionNotFoundError_RealEmbeddedRuntime(t *testing.T) {

--- a/pkg/api/v2/client_local_embedded_test.go
+++ b/pkg/api/v2/client_local_embedded_test.go
@@ -143,6 +143,12 @@ type invalidCreateResponseDeleteErrorRuntime struct {
 	deleteErr   error
 }
 
+type preExistingInvalidCreateRuntime struct {
+	*memoryEmbeddedRuntime
+	preflightErr error
+	deleteCalls  []localchroma.EmbeddedDeleteCollectionRequest
+}
+
 type missingGetCollectionOnceRuntime struct {
 	*memoryEmbeddedRuntime
 	missNextGet atomic.Bool
@@ -240,6 +246,14 @@ func newInvalidCreateResponseDeleteErrorRuntime(deleteErr error) *invalidCreateR
 		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
 		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
 		deleteErr:             deleteErr,
+	}
+}
+
+func newPreExistingInvalidCreateRuntime(preflightErr error) *preExistingInvalidCreateRuntime {
+	return &preExistingInvalidCreateRuntime{
+		memoryEmbeddedRuntime: newMemoryEmbeddedRuntime(),
+		preflightErr:          preflightErr,
+		deleteCalls:           make([]localchroma.EmbeddedDeleteCollectionRequest, 0, 1),
 	}
 }
 
@@ -374,6 +388,27 @@ func (s *invalidCreateResponseDeleteErrorRuntime) CreateCollection(request local
 func (s *invalidCreateResponseDeleteErrorRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
 	s.deleteCalls = append(s.deleteCalls, request)
 	return s.deleteErr
+}
+
+func (s *preExistingInvalidCreateRuntime) GetCollection(_ localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	return nil, s.preflightErr
+}
+
+func (s *preExistingInvalidCreateRuntime) CreateCollection(request localchroma.EmbeddedCreateCollectionRequest) (*localchroma.EmbeddedCollection, error) {
+	col, err := s.memoryEmbeddedRuntime.CreateCollection(request)
+	if err != nil {
+		return nil, err
+	}
+	invalid := *col
+	invalid.Metadata = map[string]any{
+		"invalid": map[string]any{"nested": "object"},
+	}
+	return &invalid, nil
+}
+
+func (s *preExistingInvalidCreateRuntime) DeleteCollection(request localchroma.EmbeddedDeleteCollectionRequest) error {
+	s.deleteCalls = append(s.deleteCalls, request)
+	return s.memoryEmbeddedRuntime.DeleteCollection(request)
 }
 
 func (s *missingGetCollectionOnceRuntime) GetCollection(request localchroma.EmbeddedGetCollectionRequest) (*localchroma.EmbeddedCollection, error) {
@@ -2002,13 +2037,21 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionProbeMissStillClos
 	require.Equal(t, "initial", source)
 }
 
-func TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupError(t *testing.T) {
+// TestEmbeddedCreateCollection_DefaultORTExistingCollectionLogsCleanupErrorAndReturnsCollection
+// verifies that when cleaning up the temporary SDK-owned default embedding
+// function fails after an existing-collection reuse, the user still receives
+// the built collection (since it wraps state EFs unaffected by the cleanup
+// failure) and the failure is surfaced via the logger. Replaces the Phase 23
+// "synchronous error" contract, which incorrectly discarded a valid handle.
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionLogsCleanupErrorAndReturnsCollection(t *testing.T) {
 	runtime := newCountingMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
+	log := &capturingLogger{}
+	client.logger = log
 	ctx := context.Background()
 
 	initialEF := embeddingspkg.NewConsistentHashEmbeddingFunction()
-	_, err := client.CreateCollection(
+	created, err := client.CreateCollection(
 		ctx,
 		"default-ort-existing-close-error",
 		WithEmbeddingFunctionCreate(initialEF),
@@ -2016,7 +2059,7 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupErro
 	require.NoError(t, err)
 
 	temporaryDefaultEF := &mockFailingCloseEF{closeErr: errors.New("close boom")}
-	_, err = client.CreateCollection(
+	got, err := client.CreateCollection(
 		ctx,
 		"default-ort-existing-close-error",
 		WithIfNotExistsCreate(),
@@ -2024,9 +2067,17 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionReturnsCleanupErro
 			return temporaryDefaultEF, func() error { return nil }, nil
 		}),
 	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error closing default embedding function for existing collection")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, created.ID(), got.ID())
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	require.GreaterOrEqual(t, log.errorCount, 1,
+		"cleanup failure must be surfaced to the logger when the collection is still returned")
+	require.Contains(t, log.lastMsg, "close",
+		"logged message should describe the cleanup failure")
 }
 
 func TestEmbeddedCreateCollection_DefaultORTNewCollectionDoesNotCloseTemporaryDefault(t *testing.T) {
@@ -2219,19 +2270,21 @@ func TestEmbeddedCreateCollection_DefaultORTCanceledContextClosesTemporaryDefaul
 	require.Equal(t, int32(1), temporaryDefaultEF.closeCount.Load())
 }
 
-func TestEmbeddedCreateCollection_DefaultORTExistingCollectionWithNonClosableDefaultReturnsError(t *testing.T) {
+func TestEmbeddedCreateCollection_DefaultORTExistingCollectionWithNonClosableDefaultLogsAndReturnsCollection(t *testing.T) {
 	runtime := newCountingMemoryEmbeddedRuntime()
 	client := newEmbeddedClientForRuntime(t, runtime)
+	log := &capturingLogger{}
+	client.logger = log
 	ctx := context.Background()
 
-	_, err := client.CreateCollection(
+	created, err := client.CreateCollection(
 		ctx,
 		"default-ort-existing-non-closable",
 		WithEmbeddingFunctionCreate(embeddingspkg.NewConsistentHashEmbeddingFunction()),
 	)
 	require.NoError(t, err)
 
-	_, err = client.CreateCollection(
+	got, err := client.CreateCollection(
 		ctx,
 		"default-ort-existing-non-closable",
 		WithIfNotExistsCreate(),
@@ -2239,7 +2292,13 @@ func TestEmbeddedCreateCollection_DefaultORTExistingCollectionWithNonClosableDef
 			return &mockNonCloseableEF{}, func() error { return nil }, nil
 		}),
 	)
-	require.EqualError(t, err, "sdk-owned default embedding function is not closable")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, created.ID(), got.ID())
+
+	log.mu.Lock()
+	defer log.mu.Unlock()
+	require.GreaterOrEqual(t, log.errorCount, 1)
 }
 
 func TestEmbeddedCreateCollection_BuildFailureDeletesRuntimeCollection(t *testing.T) {
@@ -2247,7 +2306,13 @@ func TestEmbeddedCreateCollection_BuildFailureDeletesRuntimeCollection(t *testin
 	client := newEmbeddedClientForRuntime(t, runtime)
 	ctx := context.Background()
 
-	_, err := client.CreateCollection(ctx, "invalid-create-response")
+	_, err := client.CreateCollection(
+		ctx,
+		"invalid-create-response",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return &mockCloseableEF{}, func() error { return nil }, nil
+		}),
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error parsing collection metadata")
 
@@ -2267,7 +2332,13 @@ func TestEmbeddedCreateCollection_BuildFailureSuppressesDeleteCollectionNotFound
 	client := newEmbeddedClientForRuntime(t, runtime)
 	ctx := context.Background()
 
-	_, err := client.CreateCollection(ctx, "invalid-create-response-delete-missing")
+	_, err := client.CreateCollection(
+		ctx,
+		"invalid-create-response-delete-missing",
+		withDefaultDenseEFFactoryCreate(func() (embeddingspkg.EmbeddingFunction, func() error, error) {
+			return &mockCloseableEF{}, func() error { return nil }, nil
+		}),
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error building collection")
 	require.NotContains(t, err.Error(), "error deleting collection after build failure")
@@ -2287,6 +2358,46 @@ func TestEmbeddedCreateCollection_BuildFailureJoinsDeleteAndCleanupErrors(t *tes
 	require.Contains(t, err.Error(), "error deleting collection after build failure: delete boom")
 	require.Contains(t, err.Error(), "cleanup boom")
 	require.Len(t, runtime.deleteCalls, 1)
+}
+
+// TestEmbeddedCreateCollection_BuildFailureDoesNotDeletePreExistingCollection
+// reproduces the dangerous scenario where a failing post-create build could
+// destroy a pre-existing user collection: preflight GetCollection fails
+// transiently (non-not-found), runtime CreateCollection(GetOrCreate:true)
+// returns the pre-existing collection, and buildEmbeddedCollection then fails.
+// The delete that used to fire in that path has been gated on positive
+// evidence that this call created the collection.
+func TestEmbeddedCreateCollection_BuildFailureDoesNotDeletePreExistingCollection(t *testing.T) {
+	runtime := newPreExistingInvalidCreateRuntime(errors.New("transient preflight failure"))
+	_, preseedErr := runtime.memoryEmbeddedRuntime.CreateCollection(localchroma.EmbeddedCreateCollectionRequest{
+		Name:         "preexisting",
+		TenantID:     DefaultTenant,
+		DatabaseName: DefaultDatabase,
+	})
+	require.NoError(t, preseedErr)
+
+	client := newEmbeddedClientForRuntime(t, runtime)
+	ctx := context.Background()
+
+	_, err := client.CreateCollection(
+		ctx,
+		"preexisting",
+		WithIfNotExistsCreate(),
+		WithEmbeddingFunctionCreate(embeddingspkg.NewConsistentHashEmbeddingFunction()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error parsing collection metadata")
+
+	require.Empty(t, runtime.deleteCalls,
+		"pre-existing user collection must not be deleted on build failure when preflight did not conclusively confirm absence")
+
+	stillThere, getErr := runtime.memoryEmbeddedRuntime.GetCollection(localchroma.EmbeddedGetCollectionRequest{
+		Name:         "preexisting",
+		TenantID:     DefaultTenant,
+		DatabaseName: DefaultDatabase,
+	})
+	require.NoError(t, getErr)
+	require.NotNil(t, stillThere)
 }
 
 func TestComparableCollectionMap_NormalizesJSONNumberAndFloat64(t *testing.T) {

--- a/pkg/api/v2/client_local_test.go
+++ b/pkg/api/v2/client_local_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	localchroma "github.com/amikos-tech/chroma-go-local"
+	loggerpkg "github.com/amikos-tech/chroma-go/pkg/logger"
 )
 
 type stubLocalServer struct {
@@ -100,6 +101,25 @@ func (s *stubEmbeddedRuntime) CountCollections(localchroma.EmbeddedCountCollecti
 
 func (s *stubEmbeddedRuntime) UpdateCollection(localchroma.EmbeddedUpdateCollectionRequest) error {
 	return nil
+}
+
+func TestNewEmbeddedLocalClient_DefaultsToNoopLogger(t *testing.T) {
+	origWaitEmbedded := localWaitEmbeddedReadyFunc
+	t.Cleanup(func() {
+		localWaitEmbeddedReadyFunc = origWaitEmbedded
+	})
+	localWaitEmbeddedReadyFunc = func(embedded localEmbeddedRuntime) error { return nil }
+
+	client, err := newEmbeddedLocalClient(defaultLocalClientConfig(), &stubEmbeddedRuntime{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.Close()
+	})
+
+	embeddedClient, ok := client.(*embeddedLocalClient)
+	require.True(t, ok)
+	require.NotNil(t, embeddedClient.logger)
+	require.IsType(t, loggerpkg.NewNoopLogger(), embeddedClient.logger)
 }
 
 func (s *stubEmbeddedRuntime) ForkCollection(localchroma.EmbeddedForkCollectionRequest) (*localchroma.EmbeddedCollection, error) {

--- a/pkg/api/v2/close_logging.go
+++ b/pkg/api/v2/close_logging.go
@@ -94,3 +94,15 @@ func logAutoWireBuildErrorToStderr(collectionName, target string, err error) {
 		err,
 	)
 }
+
+func logCreateIfNotExistsPreflightErrorToStderr(collectionName string, err error) {
+	if err == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"chroma-go: create-if-not-exists preflight GetCollection failed: collection=%s error=%v\n",
+		collectionName,
+		err,
+	)
+}

--- a/pkg/api/v2/close_logging.go
+++ b/pkg/api/v2/close_logging.go
@@ -106,3 +106,14 @@ func logCreateIfNotExistsPreflightErrorToStderr(collectionName string, err error
 		err,
 	)
 }
+
+func logComparableCollectionMapMarshalErrorToStderr(err error) {
+	if err == nil {
+		return
+	}
+	_, _ = fmt.Fprintf(
+		os.Stderr,
+		"chroma-go: unexpected json.Marshal failure comparing collection payloads: error=%v\n",
+		err,
+	)
+}


### PR DESCRIPTION
## Summary

**Phase 23: ORT EF Leak Fix**
**Goal:** Default ORT embedding function is properly cleaned up when `CreateCollection` encounters an existing collection.
**Status:** Verified ✓

This phase hardens the embedded `CreateCollection(..., WithIfNotExistsCreate())` path so SDK-owned temporary default ORT dense embedding functions are closed on existing-collection reuse without overriding stored collection state. The implementation narrows ownership tracking to the exact per-op default EF instance, preserves Phase 20 precedence for persisted collection state, and now includes a real ORT round-trip assertion that the temporary reader-side EF is actually closed on the reuse path.

## Changes

### Plan 23-01: ORT EF Leak Fix
Closes SDK-owned temporary default ORT dense embedding functions on embedded existing-collection create while preserving existing state and surfacing cleanup failures synchronously.

**Key files:**
- `pkg/api/v2/client.go`
- `pkg/api/v2/client_local_embedded.go`
- `pkg/api/v2/client_local_embedded_test.go`

**Highlights:**
- Added a per-op `defaultDenseEFFactory` seam and tracked the exact SDK-owned default dense EF instance instead of relying on package-global mutable state.
- Closed the tracked temporary default EF only when the embedded create-if-not-exists path reuses an existing collection.
- Added focused `basicv2` regressions for cleanup success, cleanup failure, ownership transfer on new collections, and a real ORT round-trip assertion that the temporary default EF is closed on reuse.

## Requirements Addressed

- `EFL-01`: Default ORT EF created by `PrepareAndValidateCollectionRequest` is closed when `CreateCollection` finds an existing collection.

## Verification

- [x] Automated verification: passed
- `go test -count=1 -tags=basicv2 -run 'TestEmbeddedLocalClientCreateCollection_IfNotExistsExistingDoesNotOverrideState|TestEmbeddedCreateCollection_DefaultORT.*' ./pkg/api/v2/...`
- `make test`
- `make lint`
- Follow-up after final test hardening:
- `go test -tags basicv2 ./pkg/api/v2 -run '^TestEmbeddedCreateCollection_RealORTIfNotExistsRoundTrip$' -count=1 -v`
- `go test -tags basicv2 ./pkg/api/v2 -count=1`

## Key Decisions

- Used a per-op `defaultDenseEFFactory` seam instead of a package-global override so basicv2 tests can inject a temporary default EF without parallel-test races.
- Tracked the current SDK-owned default dense EF instance directly and only cleaned it up when the embedded existing-path still held that exact instance.
- Kept the fix narrow in the embedded existing path and returned cleanup failures synchronously with `error closing default embedding function for existing collection`.
