### PR TITLE
Phase 26: Twelve Labs Async Embedding

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -497,8 +497,11 @@ jobs:
           CHROMA_API_KEY: ${{ secrets.CHROMA_API_KEY }}
           CHROMA_TENANT: ${{ secrets.CHROMA_TENANT }}
           CHROMA_DATABASE: ${{ secrets.CHROMA_DATABASE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test local runtime cross-persistence
         run: make test-crosslang-local
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -332,6 +332,8 @@ jobs:
             test_path: ./pkg/embeddings/baseten/...
           - provider: bedrock
             test_path: ./pkg/embeddings/bedrock/...
+          - provider: twelvelabs
+            test_path: ./pkg/embeddings/twelvelabs/...
           # Local providers (no API keys)
           - provider: default_ef
             test_path: ./pkg/embeddings/default_ef/...
@@ -390,6 +392,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ matrix.provider == 'bedrock' && secrets.AWS_SECRET_ACCESS_KEY || '' }}
           AWS_REGION: ${{ matrix.provider == 'bedrock' && secrets.AWS_REGION || '' }}
           AWS_BEARER_TOKEN_BEDROCK: ${{ matrix.provider == 'bedrock' && secrets.AWS_BEARER_TOKEN_BEDROCK || '' }}
+          # Unset until the secret exists; the twelvelabs integration test skips
+          # without it, so the mock-server unit tests still run.
+          TWELVE_LABS_API_KEY: ${{ matrix.provider == 'twelvelabs' && secrets.TWELVE_LABS_API_KEY || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -25,10 +25,10 @@
 
 ### Provider Enhancement
 
-- [ ] **TLA-01**: Twelve Labs provider detects async task responses from the sync endpoint and enters a polling loop
-- [ ] **TLA-02**: Async polling respects caller context for cancellation and timeout
-- [ ] **TLA-03**: Async polling handles terminal states (ready, failed) with appropriate error messages
-- [ ] **TLA-04**: Tests cover async task creation, polling, completion, failure, and context cancellation
+- [x] **TLA-01**: Twelve Labs provider detects async task responses from the sync endpoint and enters a polling loop
+- [x] **TLA-02**: Async polling respects caller context for cancellation and timeout
+- [x] **TLA-03**: Async polling handles terminal states (ready, failed) with appropriate error messages
+- [x] **TLA-04**: Tests cover async task creation, polling, completion, failure, and context cancellation
 
 ### Internal Cleanup
 
@@ -69,10 +69,10 @@
 | EFL-03 | Phase 24 | Pending |
 | ERR-01 | Phase 25 | Complete |
 | ERR-02 | Phase 25 | Complete |
-| TLA-01 | Phase 26 | Pending |
-| TLA-02 | Phase 26 | Pending |
-| TLA-03 | Phase 26 | Pending |
-| TLA-04 | Phase 26 | Pending |
+| TLA-01 | Phase 26 | Complete |
+| TLA-02 | Phase 26 | Complete |
+| TLA-03 | Phase 26 | Complete |
+| TLA-04 | Phase 26 | Complete |
 | DL-01 | Phase 27 | Pending |
 | DL-02 | Phase 27 | Pending |
 | MORPH-01 | Phase 28 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -126,10 +126,13 @@ Plans:
   2. Polling respects the caller's context.Context for cancellation and timeout
   3. Terminal states (ready, failed) are handled with appropriate result delivery or error messages
   4. Tests cover async task creation, polling to completion, polling to failure, and context cancellation
-**Plans**: TBD
+**Plans**: 4 plans
 
 Plans:
-- [ ] 26-01: TBD
+- [ ] 26-01-PLAN.md — Async HTTP foundation: request/response types, polling fields, doTaskPost/doTaskGet helpers
+- [ ] 26-02-PLAN.md — Polling loop, modality routing, and async orchestrator (pollTask + content.go branch)
+- [ ] 26-03-PLAN.md — WithAsyncPolling option and GetConfig/FromConfig async round-trip
+- [ ] 26-04-PLAN.md — Seven async tests (create, poll-ready, poll-failed, unexpected-status, ctx-cancel, maxWait, config round-trip)
 
 ### Phase 27: Download Stack Consolidation
 **Goal**: default_ef download code uses the shared downloadutil package instead of its own HTTP download implementation
@@ -200,7 +203,7 @@ Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on 
 | 23. ORT EF Leak Fix | v0.4.2 | 1/1 | Complete    | 2026-04-11 |
 | 24. GetOrCreateCollection EF Safety | v0.4.2 | 1/1 | Complete    | 2026-04-12 |
 | 25. Error Body Truncation | v0.4.2 | 4/4 | Complete   | 2026-04-13 |
-| 26. Twelve Labs Async Embedding | v0.4.2 | 0/0 | Not started | - |
+| 26. Twelve Labs Async Embedding | v0.4.2 | 0/4 | Not started | - |
 | 27. Download Stack Consolidation | v0.4.2 | 0/0 | Not started | - |
 | 28. Morph Test Fix | v0.4.2 | 0/0 | Not started | - |
 | 29. Rank Expression Composition Robustness | v0.4.2 | 0/3 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -27,7 +27,7 @@ See: [v0.4.1 Archived Roadmap](milestones/v0.4.1-ROADMAP.md)
 - [x] **Phase 23: ORT EF Leak Fix** - Default ORT EF is properly closed when CreateCollection finds an existing collection (completed 2026-04-11)
 - [x] **Phase 24: GetOrCreateCollection EF Safety** - GetOrCreateCollection does not pass closed EFs to CreateCollection fallback (completed 2026-04-12)
 - [x] **Phase 25: Error Body Truncation** - Embedding provider error messages truncate raw HTTP bodies to safe display lengths (completed 2026-04-13)
-- [ ] **Phase 26: Twelve Labs Async Embedding** - Twelve Labs provider handles async task responses for long-running media
+- [x] **Phase 26: Twelve Labs Async Embedding** - Twelve Labs provider handles async task responses for long-running media (completed 2026-04-14)
 - [ ] **Phase 27: Download Stack Consolidation** - default_ef download code uses shared downloadutil instead of its own HTTP implementation
 - [ ] **Phase 28: Morph Test Fix** - Morph EF integration test handles upstream 404 gracefully
 - [ ] **Phase 29: Rank Expression Composition Robustness** - Reject silent footguns in rank composition (nil operands, degenerate RRF compositions)
@@ -129,10 +129,10 @@ Plans:
 **Plans**: 4 plans
 
 Plans:
-- [ ] 26-01-PLAN.md — Async HTTP foundation: request/response types, polling fields, doTaskPost/doTaskGet helpers
-- [ ] 26-02-PLAN.md — Polling loop, modality routing, and async orchestrator (pollTask + content.go branch)
-- [ ] 26-03-PLAN.md — WithAsyncPolling option and GetConfig/FromConfig async round-trip
-- [ ] 26-04-PLAN.md — Seven async tests (create, poll-ready, poll-failed, unexpected-status, ctx-cancel, maxWait, config round-trip)
+- [x] 26-01-PLAN.md — Async HTTP foundation: request/response types, polling fields, doTaskPost/doTaskGet helpers
+- [x] 26-02-PLAN.md — Polling loop, modality routing, and async orchestrator (pollTask + content.go branch)
+- [x] 26-03-PLAN.md — WithAsyncPolling option and GetConfig/FromConfig async round-trip
+- [x] 26-04-PLAN.md — Seven async tests (create, poll-ready, poll-failed, unexpected-status, ctx-cancel, maxWait, config round-trip)
 
 ### Phase 27: Download Stack Consolidation
 **Goal**: default_ef download code uses the shared downloadutil package instead of its own HTTP download implementation
@@ -203,7 +203,7 @@ Phase 24 depends on Phase 23. Phase 26 depends on Phase 25. Phase 29 depends on 
 | 23. ORT EF Leak Fix | v0.4.2 | 1/1 | Complete    | 2026-04-11 |
 | 24. GetOrCreateCollection EF Safety | v0.4.2 | 1/1 | Complete    | 2026-04-12 |
 | 25. Error Body Truncation | v0.4.2 | 4/4 | Complete   | 2026-04-13 |
-| 26. Twelve Labs Async Embedding | v0.4.2 | 0/4 | Not started | - |
+| 26. Twelve Labs Async Embedding | v0.4.2 | 4/4 | Complete    | 2026-04-14 |
 | 27. Download Stack Consolidation | v0.4.2 | 0/0 | Not started | - |
 | 28. Morph Test Fix | v0.4.2 | 0/0 | Not started | - |
 | 29. Rank Expression Composition Robustness | v0.4.2 | 0/3 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -189,6 +189,30 @@ Plans:
 Plans:
 - [ ] 30-01: TBD — Audit sibling SearchRequestOption helpers and pin a consistent explicit-nil contract (#503)
 
+## Backlog
+
+### Phase 999.1: [CLN] Unify HTTP status code acceptance across Twelve Labs doPost/doTaskPost/doTaskGet (BACKLOG)
+
+**Goal:** [Captured for future planning]
+**Requirements:** TBD
+**Plans:** 0 plans
+
+Context: sync `doPost` (pkg/embeddings/twelvelabs/twelvelabs.go:264) rejects anything `!= 200 OK`; async `doTaskPost`/`doTaskGet` accept any 2xx. If Twelve Labs ever returns `201 Created` on /embed-v2 the sync path breaks. Flagged by PR #509 automated review; out of scope for Phase 26 since it is pre-existing v1 code. Single-file change + one test.
+
+Plans:
+- [ ] TBD (promote with /gsd-review-backlog when ready)
+
+### Phase 999.2: [ENH] Add default HTTP client timeout to Twelve Labs client (BACKLOG)
+
+**Goal:** [Captured for future planning]
+**Requirements:** TBD
+**Plans:** 0 plans
+
+Context: `applyDefaults` creates `&http.Client{}` with no `Timeout`. Async path is protected by per-call `context.WithDeadline`, but sync `doPost` has no SDK-enforced timeout — a hung Twelve Labs server blocks the caller indefinitely. Consider a sensible default (e.g., 30s) on the fallback client. Flagged by PR #509 automated review; out of scope for Phase 26 since it is pre-existing. Minor behavior change for existing sync users.
+
+Plans:
+- [ ] TBD (promote with /gsd-review-backlog when ready)
+
 ## Progress
 
 **Execution Order:**

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: ready
-stopped_at: Phase 25 shipped — PR #506
-last_updated: "2026-04-13T18:25:33.287Z"
+status: "Phase 25 shipped — PR #506"
+stopped_at: Phase 26 context gathered
+last_updated: "2026-04-14T06:03:58.201Z"
 last_activity: "2026-04-13 -- Phase 25 shipped — PR #506"
 progress:
   total_phases: 11
@@ -70,5 +70,5 @@ Decisions are logged in PROJECT.md Key Decisions table.
 
 ## Session
 
-**Last Date:** 2026-04-13T08:13:19.127Z
-**Stopped At:** Phase 25 shipped — PR #506
+**Last Date:** 2026-04-14T06:03:58.196Z
+**Stopped At:** Phase 26 context gathered

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
 status: executing
-stopped_at: Phase 26 context gathered
-last_updated: "2026-04-14T10:25:32.195Z"
+stopped_at: Phase 26 shipped — PR #509
+last_updated: "2026-04-14T12:47:58.488Z"
 last_activity: 2026-04-14
 progress:
   total_phases: 11
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Executing Phase 26
+Status: Phase 26 shipped — PR #509
 Last activity: 2026-04-14
 
 Progress: [██████████] 100%
@@ -71,4 +71,4 @@ Decisions are logged in PROJECT.md Key Decisions table.
 ## Session
 
 **Last Date:** 2026-04-14T06:03:58.196Z
-**Stopped At:** Phase 26 context gathered
+**Stopped At:** Phase 26 shipped — PR #509

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Phase 25 shipped — PR #506"
+status: executing
 stopped_at: Phase 26 context gathered
-last_updated: "2026-04-14T06:03:58.201Z"
-last_activity: "2026-04-13 -- Phase 25 shipped — PR #506"
+last_updated: "2026-04-14T07:06:32.187Z"
+last_activity: 2026-04-14 -- Phase 26 planning complete
 progress:
   total_phases: 11
   completed_phases: 6
-  total_plans: 10
+  total_plans: 14
   completed_plans: 10
-  percent: 100
+  percent: 71
 ---
 
 # Project State
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Phase 25 shipped — PR #506
-Last activity: 2026-04-13 -- Phase 25 shipped — PR #506
+Status: Ready to execute
+Last activity: 2026-04-14 -- Phase 26 planning complete
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
 status: executing
 stopped_at: Phase 26 context gathered
-last_updated: "2026-04-14T07:06:32.187Z"
-last_activity: 2026-04-14 -- Phase 26 planning complete
+last_updated: "2026-04-14T10:25:32.195Z"
+last_activity: 2026-04-14
 progress:
   total_phases: 11
-  completed_phases: 6
+  completed_phases: 7
   total_plans: 14
-  completed_plans: 10
-  percent: 71
+  completed_plans: 14
+  percent: 100
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-10)
 
 **Core value:** Go applications can use Chroma and embedding providers through a stable, portable API that minimizes provider-specific friction.
-**Current focus:** Phase 30 — v2-searchrequestoption-nil-consistency
+**Current focus:** Phase 26 — twelve-labs-async-embedding
 
 ## Current Position
 
 Phase: 30
 Plan: Not started
-Status: Ready to execute
-Last activity: 2026-04-14 -- Phase 26 planning complete
+Status: Executing Phase 26
+Last activity: 2026-04-14
 
 Progress: [██████████] 100%
 
@@ -36,7 +36,7 @@ Progress: [██████████] 100%
 
 **Velocity:**
 
-- Total plans completed: 10
+- Total plans completed: 14
 - Average duration: 23 min
 - Total execution time: 23 min
 

--- a/.planning/phases/26-twelve-labs-async-embedding/26-01-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-01-PLAN.md
@@ -1,0 +1,373 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/embeddings/twelvelabs/twelvelabs.go
+autonomous: true
+requirements: [TLA-01, TLA-02, TLA-03]
+tags: [twelvelabs, embeddings, async, http-client]
+
+must_haves:
+  truths:
+    - "An async request type distinct from EmbedV2Request exists and models the tasks-endpoint body shape (embedding_option as []string)."
+    - "Task response types decode the Twelve Labs _id field (Mongo-style alias) and the status/data discriminator correctly."
+    - "TwelveLabsClient carries unexported polling fields with defaults applied in applyDefaults (initial=2s, multiplier=1.5, cap=60s)."
+    - "doTaskPost creates a task against POST {BaseAPI}/tasks and returns a parsed TaskCreateResponse."
+    - "doTaskGet retrieves a task via GET {BaseAPI}/tasks/{id} and returns a parsed TaskResponse (single endpoint per RESEARCH F-01)."
+    - "Both task helpers sanitize error bodies via chttp.SanitizeErrorBody (Phase 25 convention)."
+  artifacts:
+    - path: "pkg/embeddings/twelvelabs/twelvelabs.go"
+      provides: "Async request/response types, polling client fields + defaults, doTaskPost/doTaskGet helpers"
+      contains: 'json:"_id"'
+  key_links:
+    - from: "doTaskPost"
+      to: "chttp.SanitizeErrorBody"
+      via: "error body sanitization"
+      pattern: "chttp\\.SanitizeErrorBody"
+    - from: "doTaskGet"
+      to: "chttp.ReadLimitedBody + chttp.SanitizeErrorBody"
+      via: "existing Phase 25 pattern"
+      pattern: "ReadLimitedBody"
+    - from: "applyDefaults"
+      to: "asyncPollInitial/asyncPollMultiplier/asyncPollCap"
+      via: "default-value assignment"
+      pattern: "asyncPollInitial"
+---
+
+<objective>
+Lay the async plumbing foundation inside `pkg/embeddings/twelvelabs/twelvelabs.go`: introduce a dedicated async request type (per RESEARCH F-02 — the tasks endpoint takes `embedding_option: []string`, not a bare string), add `TaskCreateResponse` and `TaskResponse` types with the Mongo-style `_id` JSON alias, extend `TwelveLabsClient` with unexported polling fields (`asyncPollingEnabled`, `asyncMaxWait`, `asyncPollInitial`, `asyncPollMultiplier`, `asyncPollCap`) and wire defaults into `applyDefaults`, then implement two HTTP helpers — `doTaskPost` and `doTaskGet` — that mirror the existing `doPost` for the `POST /tasks` and `GET /tasks/{id}` endpoints respectively.
+
+Purpose: Downstream plans (02 polling loop, 03 option + config) depend on these contracts. Landing the types and helpers first in Wave 1 lets Plans 02 and 03 run in parallel in Wave 2 without stepping on each other's struct changes.
+
+Output: `twelvelabs.go` compiles with new types, new fields, new defaults, and two new helpers — with no behavior change for existing callers (no public surface altered yet).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+@.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
+@pkg/embeddings/twelvelabs/twelvelabs.go
+@pkg/commons/http/utils.go
+@CLAUDE.md
+
+<interfaces>
+<!-- Existing contracts the executor will extend. Do not reinvent. -->
+
+From pkg/embeddings/twelvelabs/twelvelabs.go (existing — do not break):
+```go
+type TwelveLabsClient struct {
+    BaseAPI              string
+    APIKey               embeddings.Secret `json:"-" validate:"required"`
+    APIKeyEnvVar         string
+    DefaultModel         embeddings.EmbeddingModel
+    Client               *http.Client
+    Insecure             bool
+    AudioEmbeddingOption string
+}
+
+type MediaSource struct {
+    URL          string `json:"url,omitempty"`
+    Base64String string `json:"base64_string,omitempty"`
+}
+
+type EmbedV2DataItem struct {
+    Embedding []float64 `json:"embedding"`
+}
+
+type EmbedV2ErrorResponse struct {
+    Message string `json:"message"`
+    Code    string `json:"code"`
+}
+
+func applyDefaults(c *TwelveLabsClient)
+func (e *TwelveLabsEmbeddingFunction) doPost(ctx context.Context, req EmbedV2Request) (*EmbedV2Response, error)
+```
+
+From pkg/commons/http (reuse verbatim — Phase 25 convention):
+```go
+chttp.ReadLimitedBody(body io.Reader) ([]byte, error)
+chttp.SanitizeErrorBody(b []byte) string
+chttp.ChromaGoClientUserAgent // string constant
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Add async request/response types and polling fields to TwelveLabsClient</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs.go (full file — understand existing type layout and applyDefaults)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-03, D-11, D-14, D-21 for field semantics)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pattern 1, Pattern 2, Pitfall 1 for _id alias, Pitfall 5 for embedding_option list shape)
+  </read_first>
+  <behavior>
+    - Type presence: `AsyncEmbedV2Request`, `AsyncAudioInput`, `AsyncVideoInput`, `TaskCreateResponse`, `TaskResponse` compile and marshal/unmarshal correctly.
+    - `_id` alias: `json.Unmarshal([]byte(`{"_id":"task_abc","status":"processing"}`), &TaskCreateResponse{})` populates `.ID` to `"task_abc"`.
+    - `embedding_option` list shape: `json.Marshal(&AsyncAudioInput{EmbeddingOption: []string{"audio"}})` contains `"embedding_option":["audio"]` (array), NOT `"audio"` (string).
+    - Defaults applied: `applyDefaults` on a zero-value client sets `asyncPollInitial=2s`, `asyncPollMultiplier=1.5`, `asyncPollCap=60s` (other async fields remain zero until WithAsyncPolling is applied in Plan 03).
+    - Existing callers unaffected: all existing tests still pass (no signature changes to `TwelveLabsClient`, `applyDefaults`, or the sync types).
+  </behavior>
+  <action>
+    Edit `pkg/embeddings/twelvelabs/twelvelabs.go`:
+
+    1. Extend `TwelveLabsClient` with these unexported fields (append inside the struct, after `AudioEmbeddingOption`):
+       ```go
+       asyncPollingEnabled bool
+       asyncMaxWait        time.Duration
+       asyncPollInitial    time.Duration
+       asyncPollMultiplier float64
+       asyncPollCap        time.Duration
+       ```
+       Add `"time"` to the import block.
+
+    2. Extend `applyDefaults` (do NOT touch existing default lines; append only) to set polling backoff defaults per D-11. Do NOT default `asyncPollingEnabled` or `asyncMaxWait` — those are driven by `WithAsyncPolling` in Plan 03. Per D-22, omission of the option means the flag stays `false` and maxWait stays `0`.
+       ```go
+       if c.asyncPollInitial == 0 {
+           c.asyncPollInitial = 2 * time.Second
+       }
+       if c.asyncPollMultiplier == 0 {
+           c.asyncPollMultiplier = 1.5
+       }
+       if c.asyncPollCap == 0 {
+           c.asyncPollCap = 60 * time.Second
+       }
+       ```
+
+    3. Add async request types after the existing sync request types (near line 120). CRITICAL: `embedding_option` MUST be `[]string`, not `string` (RESEARCH F-02; sync endpoint uses string, async uses list — do not reuse `AudioInput`).
+       ```go
+       // AsyncEmbedV2Request is the JSON body for POST /v1.3/embed-v2/tasks.
+       // The async endpoint uses a distinct shape from the sync endpoint
+       // (embedding_option is a list, not a single string). See RESEARCH F-02.
+       type AsyncEmbedV2Request struct {
+           InputType string           `json:"input_type"`
+           ModelName string           `json:"model_name"`
+           Audio     *AsyncAudioInput `json:"audio,omitempty"`
+           Video     *AsyncVideoInput `json:"video,omitempty"`
+       }
+
+       type AsyncAudioInput struct {
+           MediaSource     MediaSource `json:"media_source"`
+           EmbeddingOption []string    `json:"embedding_option,omitempty"`
+       }
+
+       type AsyncVideoInput struct {
+           MediaSource MediaSource `json:"media_source"`
+       }
+       ```
+
+    4. Add task-endpoint response types. CRITICAL: use `json:"_id"` (Mongo-style alias) not `json:"id"` — missing this silently decodes task IDs to `""` (RESEARCH Pitfall 1).
+       ```go
+       // TaskCreateResponse is returned from POST /v1.3/embed-v2/tasks.
+       // NOTE: task ID uses `_id` alias (Mongo-style) — RESEARCH Pitfall 1.
+       type TaskCreateResponse struct {
+           ID     string            `json:"_id"`
+           Status string            `json:"status"`
+           Data   []EmbedV2DataItem `json:"data,omitempty"`
+       }
+
+       // TaskResponse is returned from GET /v1.3/embed-v2/tasks/{id}.
+       // Serves BOTH polling and retrieval (RESEARCH F-01 — only two
+       // endpoints exist; there is no separate /status sub-path).
+       type TaskResponse struct {
+           ID     string            `json:"_id"`
+           Status string            `json:"status"` // "processing" | "ready" | "failed"
+           Data   []EmbedV2DataItem `json:"data,omitempty"`
+       }
+       ```
+
+    5. Run `go build ./pkg/embeddings/twelvelabs/...` and `make lint` to confirm no regressions.
+
+    Do NOT modify: `NewTwelveLabsClient`, `validate`, existing sync types, `doPost`, `GetConfig`, `NewTwelveLabsEmbeddingFunctionFromConfig`, or anything in `option.go`/`content.go`. Those live in Plans 02/03.
+  </action>
+  <verify>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... 2>&1 | tee /tmp/p26-01-t1-build.log; grep -q 'ID.*`json:"_id"`' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'EmbeddingOption.*\[\]string.*`json:"embedding_option' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncPollInitial' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncPollMultiplier' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncPollCap' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncPollingEnabled' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncMaxWait' pkg/embeddings/twelvelabs/twelvelabs.go && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `grep -q 'ID.*\`json:"_id"\`' pkg/embeddings/twelvelabs/twelvelabs.go` matches (both `TaskCreateResponse.ID` and `TaskResponse.ID`).
+    - `grep -q 'EmbeddingOption.*\[\]string.*\`json:"embedding_option' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'type AsyncEmbedV2Request struct' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'asyncPollingEnabled bool' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'asyncMaxWait        time.Duration' pkg/embeddings/twelvelabs/twelvelabs.go` matches (or with single space — the key is the field name + `time.Duration` type).
+    - `grep -c 'asyncPollInitial\|asyncPollMultiplier\|asyncPollCap' pkg/embeddings/twelvelabs/twelvelabs.go` >= 6 (3 field decls + 3 default assignments).
+    - `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` exits 0 (no existing-test regression).
+  </acceptance_criteria>
+  <done>Types + fields + defaults compile, no regressions, ready for Wave 2 plans to build on.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Implement doTaskPost and doTaskGet HTTP helpers</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs.go (existing `doPost` at ~line 157 is the template to mirror)
+    - pkg/commons/http/utils.go (verify `SanitizeErrorBody` and `ReadLimitedBody` signatures)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pattern 3 skeleton, "doTaskPost pattern" code example ~line 387, F-01 collapses poll+retrieve to one GET)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-17, D-18 for error semantics)
+  </read_first>
+  <behavior>
+    - `doTaskPost` sends `POST {BaseAPI}/tasks` with JSON body, headers mirror existing `doPost` (`x-api-key`, `Content-Type: application/json`, `Accept: application/json`, `User-Agent: chttp.ChromaGoClientUserAgent`), decodes a `TaskCreateResponse`, and on non-2xx sanitizes the body via `chttp.SanitizeErrorBody`.
+    - `doTaskGet` sends `GET {BaseAPI}/tasks/{taskID}` (taskID URL-escaped), same headers, decodes a `TaskResponse`, and sanitizes non-2xx bodies the same way.
+    - Both helpers use `chttp.ReadLimitedBody` (never `io.ReadAll`) — Phase 25 convention.
+    - Both helpers `defer resp.Body.Close()`.
+    - Empty taskID passed to `doTaskGet` returns a descriptive error instead of building a URL with a trailing `/` (defensive guard against the `_id`-alias footgun from Pitfall 1).
+    - Neither helper mutates shared state; caller's ctx is threaded into `http.NewRequestWithContext`.
+  </behavior>
+  <action>
+    Append two new methods on `*TwelveLabsEmbeddingFunction` to `twelvelabs.go`, after the existing `doPost` method. Mirror `doPost` structurally — identical headers, identical error-sanitization pattern, identical `ReadLimitedBody` usage.
+
+    Add `"net/url"` import if not already present (it is — verify).
+
+    ```go
+    // doTaskPost creates an async embedding task via POST {BaseAPI}/tasks.
+    // Used when WithAsyncPolling is enabled and the content modality is
+    // audio or video. See CONTEXT.md D-01, D-07.
+    func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncEmbedV2Request) (*TaskCreateResponse, error) {
+        reqJSON, err := json.Marshal(req)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to marshal async task request")
+        }
+        endpoint := strings.TrimRight(e.apiClient.BaseAPI, "/") + "/tasks"
+        httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(reqJSON))
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to create HTTP request")
+        }
+        httpReq.Header.Set("x-api-key", e.apiClient.APIKey.Value())
+        httpReq.Header.Set("Content-Type", "application/json")
+        httpReq.Header.Set("Accept", "application/json")
+        httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+
+        resp, err := e.apiClient.Client.Do(httpReq)
+        if err != nil {
+            return nil, errors.Wrapf(err, "failed to send task request to %s", endpoint)
+        }
+        defer resp.Body.Close()
+
+        respData, err := chttp.ReadLimitedBody(resp.Body)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to read response body")
+        }
+        if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+            var apiErr EmbedV2ErrorResponse
+            if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
+                return nil, errors.Errorf("Twelve Labs task create error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+            }
+            return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
+        }
+
+        var out TaskCreateResponse
+        if err := json.Unmarshal(respData, &out); err != nil {
+            return nil, errors.Wrap(err, "failed to unmarshal task create response")
+        }
+        return &out, nil
+    }
+
+    // doTaskGet retrieves an async embedding task via GET {BaseAPI}/tasks/{id}.
+    // Per RESEARCH F-01 this single endpoint serves BOTH status polling and
+    // final result retrieval — the response carries status + data.
+    func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID string) (*TaskResponse, error) {
+        if taskID == "" {
+            return nil, errors.New("task ID cannot be empty (check _id JSON tag on create response)")
+        }
+        endpoint := strings.TrimRight(e.apiClient.BaseAPI, "/") + "/tasks/" + url.PathEscape(taskID)
+        httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to create HTTP request")
+        }
+        httpReq.Header.Set("x-api-key", e.apiClient.APIKey.Value())
+        httpReq.Header.Set("Accept", "application/json")
+        httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+
+        resp, err := e.apiClient.Client.Do(httpReq)
+        if err != nil {
+            return nil, errors.Wrapf(err, "failed to send task retrieve request to %s", endpoint)
+        }
+        defer resp.Body.Close()
+
+        respData, err := chttp.ReadLimitedBody(resp.Body)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to read response body")
+        }
+        if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+            var apiErr EmbedV2ErrorResponse
+            if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
+                return nil, errors.Errorf("Twelve Labs task retrieve error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+            }
+            return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
+        }
+
+        var out TaskResponse
+        if err := json.Unmarshal(respData, &out); err != nil {
+            return nil, errors.Wrap(err, "failed to unmarshal task retrieve response")
+        }
+        return &out, nil
+    }
+    ```
+
+    Run `make lint` — fix any `goimports`/`gofmt` issues.
+  </action>
+  <verify>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'func (e \*TwelveLabsEmbeddingFunction) doTaskPost' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'func (e \*TwelveLabsEmbeddingFunction) doTaskGet' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'url.PathEscape(taskID)' pkg/embeddings/twelvelabs/twelvelabs.go && grep -c 'chttp.SanitizeErrorBody' pkg/embeddings/twelvelabs/twelvelabs.go | awk '$1 >= 4 {exit 0} {exit 1}' && grep -c 'chttp.ReadLimitedBody' pkg/embeddings/twelvelabs/twelvelabs.go | awk '$1 >= 3 {exit 0} {exit 1}' && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -q 'func (e \*TwelveLabsEmbeddingFunction) doTaskPost' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'func (e \*TwelveLabsEmbeddingFunction) doTaskGet' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'url.PathEscape(taskID)' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'task ID cannot be empty' pkg/embeddings/twelvelabs/twelvelabs.go` matches (empty-id guard).
+    - `grep -c 'chttp.SanitizeErrorBody' pkg/embeddings/twelvelabs/twelvelabs.go` is >= 4 (existing 2 + new 2 for each helper).
+    - `grep -c 'chttp.ReadLimitedBody' pkg/embeddings/twelvelabs/twelvelabs.go` is >= 3 (existing 1 + new 2).
+    - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `go vet ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `make lint` exits 0.
+    - `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` exits 0 (no existing test regression).
+  </acceptance_criteria>
+  <done>doTaskPost and doTaskGet compile, sanitize error bodies, use ReadLimitedBody, URL-escape task IDs, and guard empty IDs. No existing tests broken.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| caller → TwelveLabsClient | Untrusted media URLs / base64 already validated upstream; this plan handles error surfaces derived from server responses. |
+| Twelve Labs API → client | Server response bodies are untrusted text that flows into error messages and log output. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-26-01 | I (Information Disclosure) | doTaskPost / doTaskGet error paths | mitigate | All body-derived error text flows through `chttp.SanitizeErrorBody` (Phase 25 convention) — truncates to safe display length and escapes control bytes that could corrupt logs. Grep-enforced: `chttp.SanitizeErrorBody` appears on every raw-body error path. |
+| T-26-02 | T (Tampering) | response body bloat | mitigate | `chttp.ReadLimitedBody` caps read size at 200 MB — prevents an adversarial server from exhausting memory via oversized response bodies. |
+| T-26-03 | D (Denial of Service) | unbounded response size | mitigate | Same `ReadLimitedBody` cap. Additional bounds (polling maxWait, backoff cap) are Plan 02's responsibility. |
+| T-26-04 | S (Spoofing) | task ID construction | mitigate | `url.PathEscape(taskID)` on the GET path prevents path-segment injection if a malicious server returns a task ID containing `../` or URL-control characters. Empty-ID guard prevents a silent 404-loop against `/tasks/`. |
+| T-26-05 | I (Information Disclosure) | API key in logs | accept | API key stays in `x-api-key` header; error messages never include `e.apiClient.APIKey.Value()`. Existing `doPost` convention preserved. |
+</threat_model>
+
+<verification>
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` passes.
+- `go vet ./pkg/embeddings/twelvelabs/...` passes.
+- `make lint` passes.
+- Existing `TestTwelveLabs*` suite (`go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...`) exits 0 — no behavior regression for sync callers.
+- Grep assertions in acceptance_criteria all match.
+</verification>
+
+<success_criteria>
+Twelve Labs provider has a compile-clean async foundation: distinct async request/response types with correct `_id` and `embedding_option: []string` shapes, unexported polling fields on `TwelveLabsClient` with backoff defaults applied, and two HTTP helpers (`doTaskPost`, `doTaskGet`) that mirror existing conventions (headers, ReadLimitedBody, SanitizeErrorBody, errors.Wrap pattern). Zero public surface change. Plans 02 and 03 can now run in parallel.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/26-twelve-labs-async-embedding/26-01-SUMMARY.md`.
+</output>

--- a/.planning/phases/26-twelve-labs-async-embedding/26-01-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-01-PLAN.md
@@ -17,6 +17,7 @@ must_haves:
     - "TwelveLabsClient carries unexported polling fields with defaults applied in applyDefaults (initial=2s, multiplier=1.5, cap=60s)."
     - "doTaskPost creates a task against POST {BaseAPI}/tasks and returns a parsed TaskCreateResponse."
     - "doTaskGet retrieves a task via GET {BaseAPI}/tasks/{id} and returns a parsed TaskResponse (single endpoint per RESEARCH F-01)."
+    - "TaskResponse preserves the raw server response bytes in FailureDetail so Plan 02 can sanitize the real server-provided failure reason (not a re-marshaled subset)."
     - "Both task helpers sanitize error bodies via chttp.SanitizeErrorBody (Phase 25 convention)."
   artifacts:
     - path: "pkg/embeddings/twelvelabs/twelvelabs.go"
@@ -180,10 +181,17 @@ chttp.ChromaGoClientUserAgent // string constant
        // TaskResponse is returned from GET /v1.3/embed-v2/tasks/{id}.
        // Serves BOTH polling and retrieval (RESEARCH F-01 — only two
        // endpoints exist; there is no separate /status sub-path).
+       //
+       // FailureDetail holds the raw HTTP response body so that on status=failed
+       // Plan 02 can sanitize the actual server-provided failure reason rather
+       // than re-marshaling this struct's subset of fields (D-17 compliance).
+       // The `json:"-"` tag excludes it from unmarshaling; doTaskGet populates
+       // it directly from the body bytes.
        type TaskResponse struct {
-           ID     string            `json:"_id"`
-           Status string            `json:"status"` // "processing" | "ready" | "failed"
-           Data   []EmbedV2DataItem `json:"data,omitempty"`
+           ID            string            `json:"_id"`
+           Status        string            `json:"status"` // "processing" | "ready" | "failed"
+           Data          []EmbedV2DataItem `json:"data,omitempty"`
+           FailureDetail json.RawMessage   `json:"-"`
        }
        ```
 
@@ -202,6 +210,7 @@ chttp.ChromaGoClientUserAgent // string constant
     - `grep -q 'asyncPollingEnabled bool' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
     - `grep -q 'asyncMaxWait        time.Duration' pkg/embeddings/twelvelabs/twelvelabs.go` matches (or with single space — the key is the field name + `time.Duration` type).
     - `grep -c 'asyncPollInitial\|asyncPollMultiplier\|asyncPollCap' pkg/embeddings/twelvelabs/twelvelabs.go` >= 6 (3 field decls + 3 default assignments).
+    - `grep -q 'FailureDetail json.RawMessage' pkg/embeddings/twelvelabs/twelvelabs.go` matches — raw-body preservation field on `TaskResponse`.
     - `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` exits 0 (no existing-test regression).
   </acceptance_criteria>
   <done>Types + fields + defaults compile, no regressions, ready for Wave 2 plans to build on.</done>
@@ -218,7 +227,7 @@ chttp.ChromaGoClientUserAgent // string constant
   </read_first>
   <behavior>
     - `doTaskPost` sends `POST {BaseAPI}/tasks` with JSON body, headers mirror existing `doPost` (`x-api-key`, `Content-Type: application/json`, `Accept: application/json`, `User-Agent: chttp.ChromaGoClientUserAgent`), decodes a `TaskCreateResponse`, and on non-2xx sanitizes the body via `chttp.SanitizeErrorBody`.
-    - `doTaskGet` sends `GET {BaseAPI}/tasks/{taskID}` (taskID URL-escaped), same headers, decodes a `TaskResponse`, and sanitizes non-2xx bodies the same way.
+    - `doTaskGet` sends `GET {BaseAPI}/tasks/{taskID}` (taskID URL-escaped), same headers, decodes a `TaskResponse`, sanitizes non-2xx bodies the same way, AND populates `TaskResponse.FailureDetail` with the raw 2xx body bytes (as `json.RawMessage`) so callers can sanitize the authentic server reason on status=failed per D-17.
     - Both helpers use `chttp.ReadLimitedBody` (never `io.ReadAll`) — Phase 25 convention.
     - Both helpers `defer resp.Body.Close()`.
     - Empty taskID passed to `doTaskGet` returns a descriptive error instead of building a URL with a trailing `/` (defensive guard against the `_id`-alias footgun from Pitfall 1).
@@ -311,6 +320,10 @@ chttp.ChromaGoClientUserAgent // string constant
         if err := json.Unmarshal(respData, &out); err != nil {
             return nil, errors.Wrap(err, "failed to unmarshal task retrieve response")
         }
+        // Preserve raw body so pollTask can sanitize the authentic server reason
+        // on status=failed (D-17). Copy respData — the underlying buffer may be
+        // reused; json.RawMessage needs stable bytes.
+        out.FailureDetail = append(json.RawMessage(nil), respData...)
         return &out, nil
     }
     ```
@@ -327,6 +340,7 @@ chttp.ChromaGoClientUserAgent // string constant
     - `grep -q 'task ID cannot be empty' pkg/embeddings/twelvelabs/twelvelabs.go` matches (empty-id guard).
     - `grep -c 'chttp.SanitizeErrorBody' pkg/embeddings/twelvelabs/twelvelabs.go` is >= 4 (existing 2 + new 2 for each helper).
     - `grep -c 'chttp.ReadLimitedBody' pkg/embeddings/twelvelabs/twelvelabs.go` is >= 3 (existing 1 + new 2).
+    - `grep -q 'out.FailureDetail = append(json.RawMessage(nil), respData' pkg/embeddings/twelvelabs/twelvelabs.go` matches — raw body preserved on `TaskResponse` for Plan 02 failure-reason sanitization.
     - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
     - `go vet ./pkg/embeddings/twelvelabs/...` exits 0.
     - `make lint` exits 0.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-01-SUMMARY.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-01-SUMMARY.md
@@ -1,0 +1,134 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 01
+subsystem: embeddings
+tags: [twelvelabs, embeddings, async, http-client, tasks-endpoint]
+
+# Dependency graph
+requires:
+  - phase: 25-error-body-truncation
+    provides: chttp.SanitizeErrorBody and chttp.ReadLimitedBody conventions reused verbatim on new task helpers
+provides:
+  - AsyncEmbedV2Request / AsyncAudioInput / AsyncVideoInput types with `embedding_option: []string` list shape (RESEARCH F-02)
+  - TaskCreateResponse and TaskResponse types with `_id` Mongo-style JSON alias (RESEARCH Pitfall 1)
+  - TaskResponse.FailureDetail (json.RawMessage, `json:"-"`) for Plan 02 D-17 failure-reason sanitization
+  - Unexported async polling fields on TwelveLabsClient: asyncPollingEnabled, asyncMaxWait, asyncPollInitial, asyncPollMultiplier, asyncPollCap
+  - applyDefaults populates backoff defaults: initial=2s, multiplier=1.5, cap=60s (D-11)
+  - doTaskPost HTTP helper (POST {BaseAPI}/tasks) mirroring doPost headers + error sanitization
+  - doTaskGet HTTP helper (GET {BaseAPI}/tasks/{id}) with url.PathEscape, empty-ID guard, and raw-body preservation
+affects: [26-02-polling-loop, 26-03-option-and-config, 26-04-content-routing-and-tests]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Async request type distinct from sync EmbedV2Request to model endpoint shape differences (embedding_option list vs string)"
+    - "Raw-body preservation on success responses via json.RawMessage FailureDetail field so downstream callers sanitize the authentic server reason instead of re-marshaling"
+    - "//nolint:unused annotations on feature-foundation symbols consumed by later plans in the same wave"
+
+key-files:
+  created: []
+  modified:
+    - pkg/embeddings/twelvelabs/twelvelabs.go
+
+key-decisions:
+  - "Introduced AsyncEmbedV2Request as a distinct type from EmbedV2Request because the async tasks endpoint takes embedding_option as []string, not a bare string (RESEARCH F-02). Reusing AudioInput would encode the wrong shape."
+  - "Used json:\"_id\" aliases on both TaskCreateResponse.ID and TaskResponse.ID so the Mongo-style server response decodes correctly; silent empty-ID bugs are a documented pitfall."
+  - "Added TaskResponse.FailureDetail as json.RawMessage with json:\"-\" tag; doTaskGet populates it directly from the raw body bytes. This lets Plan 02 sanitize the server's verbatim failure reason instead of re-marshaling a struct subset (D-17)."
+  - "doTaskGet guards empty taskID with a descriptive error instead of silently building /tasks/ URLs (defends against the _id alias footgun from Pitfall 1)."
+  - "Applied polling backoff defaults in applyDefaults (initial=2s, multiplier=1.5, cap=60s) but intentionally left asyncPollingEnabled and asyncMaxWait at zero-value — per D-22, opt-in is driven only by WithAsyncPolling from Plan 03."
+  - "Used //nolint:unused annotations on async fields and helpers rather than temporary stubs, because Plans 02/03 wire them in the same wave and removing them after the fact would churn this file."
+
+patterns-established:
+  - "Async endpoint variant types live alongside sync types in the same file, with comments that name the RESEARCH finding they encode"
+  - "HTTP task helpers mirror doPost structure byte-for-byte on headers, ReadLimitedBody, and SanitizeErrorBody"
+
+requirements-completed: [TLA-01, TLA-02, TLA-03]
+
+# Metrics
+duration: ~20min
+completed: 2026-04-14
+---
+
+# Phase 26 Plan 01: Async Embedding Foundation Summary
+
+**Async tasks-endpoint plumbing for Twelve Labs: dedicated request/response types with `_id` alias + `embedding_option: []string` shape, client polling fields with backoff defaults, and two HTTP helpers (doTaskPost, doTaskGet) that mirror existing Phase 25 sanitization conventions.**
+
+## Performance
+
+- **Duration:** ~20 min
+- **Started:** 2026-04-14T09:06:00Z
+- **Completed:** 2026-04-14T09:26:00Z
+- **Tasks:** 2
+- **Files modified:** 1
+
+## Accomplishments
+
+- New async request/response types (`AsyncEmbedV2Request`, `AsyncAudioInput`, `AsyncVideoInput`, `TaskCreateResponse`, `TaskResponse`) encode the exact tasks-endpoint contract — correct `_id` Mongo alias and `embedding_option` as a list.
+- `TwelveLabsClient` gained five unexported async polling fields plus backoff defaults in `applyDefaults` without touching any existing defaults or public surface.
+- `doTaskPost` and `doTaskGet` HTTP helpers land with the same headers, `ReadLimitedBody`, and `SanitizeErrorBody` posture as the existing `doPost`, plus URL-escaped task IDs and an empty-ID defensive guard.
+- `TaskResponse.FailureDetail` preserves raw response bytes so Plan 02's polling loop can surface the authentic server-provided failure reason rather than a re-marshaled subset.
+
+## Task Commits
+
+1. **Task 1: Async types + polling fields + defaults** — `818c569` (feat)
+2. **Task 2: doTaskPost and doTaskGet HTTP helpers** — `0566ec2` (feat)
+
+## Files Created/Modified
+
+- `pkg/embeddings/twelvelabs/twelvelabs.go` — added async request/response types, polling fields on TwelveLabsClient, backoff defaults in applyDefaults, and two HTTP helpers (doTaskPost, doTaskGet)
+
+## Decisions Made
+
+- Preserved raw response bytes for `TaskResponse.FailureDetail` by copying `respData` via `append(json.RawMessage(nil), respData...)` rather than aliasing; the underlying `ReadLimitedBody` buffer is not guaranteed stable across request lifetimes and `json.RawMessage` needs stable bytes for later sanitization.
+- Left `asyncPollingEnabled` and `asyncMaxWait` at zero-value defaults. Per D-22 the option flag and max-wait are driven entirely by `WithAsyncPolling` (Plan 03). Defaulting them here would silently turn async on for callers who never opted in.
+- Kept `AsyncEmbedV2Request` separate from `EmbedV2Request` instead of overloading with a polymorphic `embedding_option` shape. The two endpoints are distinct contracts; sharing a type would leak the async footgun into sync callers.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Lint failures on unused async symbols**
+- **Found during:** Task 2 (post-implementation `make lint`)
+- **Issue:** golangci-lint's `unused` check flagged the four symbols (`asyncPollingEnabled`, `asyncMaxWait`, `doTaskPost`, `doTaskGet`) that are foundation scaffolding for Plans 26-02 and 26-03 in the same wave. The plan's acceptance criteria required `make lint` to exit 0.
+- **Fix:** Added `//nolint:unused` pragmas with comments citing the consumer plans. Chose this over removing the symbols because the symbols are load-bearing for the Wave 2 plans and churning them out-and-back-in is pure waste.
+- **Files modified:** `pkg/embeddings/twelvelabs/twelvelabs.go`
+- **Verification:** `make lint` exits 0; `go build -tags=ef` and `go test -tags=ef -run TestTwelveLabs` both pass.
+- **Committed in:** `0566ec2` (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** No scope change. The nolint annotations are a transient scaffolding concern that Plans 02/03 will eliminate naturally when they start consuming the symbols — the annotations can be removed at that point.
+
+## Issues Encountered
+
+- During Task 1 and Task 2 edits, the PreToolUse read-before-edit hook fired repeatedly even though the file had been read in-session. Working around this required re-reading slices of the file between edits. The edits themselves succeeded as expected.
+
+## User Setup Required
+
+None — no external service configuration or env-var changes in this plan.
+
+## Next Phase Readiness
+
+- Plan 02 (polling loop) can now consume `doTaskPost` / `doTaskGet` and the polling fields without any further type plumbing.
+- Plan 03 (option + config) can now wire `WithAsyncPolling(maxWait)` to set `asyncPollingEnabled` and `asyncMaxWait` on the client, and can round-trip the config keys.
+- Plans 02 and 03 can run in parallel in Wave 2 because they touch disjoint surfaces: Plan 02 adds a polling method on `TwelveLabsEmbeddingFunction`; Plan 03 adds the option and updates `GetConfig` / `NewTwelveLabsEmbeddingFunctionFromConfig`.
+
+## Verification Log
+
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` — exit 0
+- `go vet -tags=ef ./pkg/embeddings/twelvelabs/...` — exit 0
+- `make lint` — 0 issues
+- `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` — ok
+- Sanity run: `json.Unmarshal({"_id":"task_abc",...}, &TaskCreateResponse{})` populates `ID="task_abc"` and `Status="processing"`; `json.Marshal(&AsyncAudioInput{EmbeddingOption: []string{"audio"}})` produces `"embedding_option":["audio"]` as expected.
+
+## Self-Check: PASSED
+
+- File `pkg/embeddings/twelvelabs/twelvelabs.go` exists and contains `AsyncEmbedV2Request`, `TaskCreateResponse`, `TaskResponse`, `doTaskPost`, `doTaskGet`, `asyncPollingEnabled`, `asyncMaxWait`, `asyncPollInitial`, `asyncPollMultiplier`, `asyncPollCap`, `FailureDetail json.RawMessage`.
+- Commit `818c569` present in `git log`.
+- Commit `0566ec2` present in `git log`.
+
+---
+*Phase: 26-twelve-labs-async-embedding*
+*Completed: 2026-04-14*

--- a/.planning/phases/26-twelve-labs-async-embedding/26-02-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-02-PLAN.md
@@ -1,0 +1,416 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 02
+type: execute
+wave: 2
+depends_on: [26-01]
+files_modified:
+  - pkg/embeddings/twelvelabs/twelvelabs_async.go
+  - pkg/embeddings/twelvelabs/content.go
+autonomous: true
+requirements: [TLA-01, TLA-02, TLA-03]
+tags: [twelvelabs, embeddings, async, polling]
+
+must_haves:
+  truths:
+    - "pollTask polls via doTaskGet in a loop, handling processing/ready/failed/unknown status values per D-14/D-16."
+    - "Polling uses capped exponential backoff (initial=2s, multiplier=1.5, cap=60s) via time.NewTimer (not time.After) to avoid timer leaks."
+    - "maxWait is tracked via a deadline variable (time.Now().Add(maxWait)) independent of ctx — ctx.DeadlineExceeded and maxWait-expiry surface as distinguishable errors per D-20."
+    - "ctx.Done() cancels the polling loop immediately and wraps ctx.Err(), making errors.Is(err, context.Canceled) work per D-10/D-19."
+    - "Terminal 'failed' status surfaces an error containing task ID, status=failed, and a sanitized reason per D-17."
+    - "Audio and video modalities route to the async tasks path when asyncPollingEnabled is true; text and image always stay on the sync path per D-07/D-08."
+    - "When asyncPollingEnabled is false, all four modalities (including audio/video) continue to use the existing sync doPost path — zero behavior change for non-opt-in callers."
+  artifacts:
+    - path: "pkg/embeddings/twelvelabs/twelvelabs_async.go"
+      provides: "pollTask polling loop, contentToAsyncRequest builder, createTaskAndPoll orchestrator"
+      contains: "pollTask"
+    - path: "pkg/embeddings/twelvelabs/content.go"
+      provides: "Modified embedContent with modality-based routing to async or sync path"
+      contains: "asyncPollingEnabled"
+  key_links:
+    - from: "embedContent"
+      to: "createTaskAndPoll"
+      via: "modality + asyncPollingEnabled dispatch"
+      pattern: "asyncPollingEnabled.*ModalityAudio\\|asyncPollingEnabled.*ModalityVideo"
+    - from: "pollTask"
+      to: "doTaskGet"
+      via: "status discriminator polling"
+      pattern: "doTaskGet\\(ctx"
+    - from: "pollTask"
+      to: "ctx.Done()"
+      via: "select-case cancellation"
+      pattern: "case <-ctx.Done"
+    - from: "pollTask"
+      to: "time.NewTimer"
+      via: "leak-safe sleep (not time.After)"
+      pattern: "time.NewTimer"
+---
+
+<objective>
+Wire the async polling loop and modality-based routing so that, when `WithAsyncPolling` is enabled (Plan 03), audio and video content items flow through `POST /tasks` → poll `GET /tasks/{id}` → extract embedding. Text and image continue to use the existing sync `/embed-v2` path regardless of the opt-in flag (D-07). Implement `pollTask` with capped exponential backoff, independent `maxWait` timer, `ctx` cancellation, and the `processing/ready/failed/unknown` status discriminator (D-14, D-16). Place the async-specific code in a new file `twelvelabs_async.go` so Plan 03 (option + config) can modify `twelvelabs.go` without file conflicts.
+
+Purpose: TLA-01, TLA-02, TLA-03 behavior lands here. Plan 03 in parallel wires the public option and config round-trip; Plan 04 in Wave 3 adds tests. After this plan, a reader with a manually-constructed client (polling fields set directly, `asyncPollingEnabled=true`) could exercise the async path end-to-end.
+
+Output: `twelvelabs_async.go` exists with `pollTask`, `contentToAsyncRequest`, and `createTaskAndPoll`. `content.go` `embedContent` dispatches based on `asyncPollingEnabled` + modality. All existing tests still pass (routing is gated by the flag).
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+@.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
+@pkg/embeddings/twelvelabs/twelvelabs.go
+@pkg/embeddings/twelvelabs/content.go
+@CLAUDE.md
+
+<interfaces>
+<!-- From Plan 01 (already landed in Wave 1): -->
+```go
+// TwelveLabsClient fields added in Plan 01:
+asyncPollingEnabled bool
+asyncMaxWait        time.Duration
+asyncPollInitial    time.Duration
+asyncPollMultiplier float64
+asyncPollCap        time.Duration
+
+// Types added in Plan 01:
+type AsyncEmbedV2Request struct {
+    InputType string           `json:"input_type"`
+    ModelName string           `json:"model_name"`
+    Audio     *AsyncAudioInput `json:"audio,omitempty"`
+    Video     *AsyncVideoInput `json:"video,omitempty"`
+}
+type AsyncAudioInput struct {
+    MediaSource     MediaSource `json:"media_source"`
+    EmbeddingOption []string    `json:"embedding_option,omitempty"`
+}
+type AsyncVideoInput struct {
+    MediaSource MediaSource `json:"media_source"`
+}
+type TaskCreateResponse struct {
+    ID     string            `json:"_id"`
+    Status string            `json:"status"`
+    Data   []EmbedV2DataItem `json:"data,omitempty"`
+}
+type TaskResponse struct {
+    ID     string            `json:"_id"`
+    Status string            `json:"status"`
+    Data   []EmbedV2DataItem `json:"data,omitempty"`
+}
+
+// Helpers added in Plan 01:
+func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncEmbedV2Request) (*TaskCreateResponse, error)
+func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID string) (*TaskResponse, error)
+```
+
+<!-- Existing (do not break): -->
+```go
+func (e *TwelveLabsEmbeddingFunction) embedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error)
+func contentToRequest(content embeddings.Content, model string, audioOpt string) (*EmbedV2Request, error)
+func embeddingFromResponse(resp *EmbedV2Response) (embeddings.Embedding, error)
+func buildMediaSource(source *embeddings.BinarySource) (MediaSource, error)
+func float64sToFloat32s(in []float64) []float32
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Implement pollTask, contentToAsyncRequest, and createTaskAndPoll in twelvelabs_async.go</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs_async.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs.go (full file post-Plan-01 — understand the types and helpers Plan 01 added)
+    - pkg/embeddings/twelvelabs/content.go (buildMediaSource, existing contentToRequest)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-09 through D-20 — bounds, cancellation, backoff, status, error semantics)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pattern 3 polling skeleton, Pitfall 2 time.NewTimer leak, Pitfall 3 maxWait/ctx distinction, Pitfall 4 first-poll pause, Pitfall 5 embedding_option list)
+  </read_first>
+  <behavior>
+    - `contentToAsyncRequest` accepts a `Content` item with modality audio or video, returns an `*AsyncEmbedV2Request` with the appropriate input_type, model_name, and a single populated `Audio` or `Video` field. Other modalities (text, image) return an error — caller is expected to route only audio/video here.
+    - Audio input: `embedding_option` is a single-element list wrapping `audioOpt` (the existing `AudioEmbeddingOption` string). If `audioOpt` is empty, omit the field (empty slice → omitempty).
+    - `pollTask` behavior:
+      - Poll-first-sleep-second (Pitfall 4): call `doTaskGet` before the first backoff sleep.
+      - On `status == "ready"`: extract embedding from `data` (error if `data` is empty or has != 1 item) and return.
+      - On `status == "failed"`: return `errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, <sanitized reason>)`. Reason is the task response serialized as JSON and passed through `chttp.SanitizeErrorBody`.
+      - On `status == "processing"`: sleep with capped exponential backoff then loop.
+      - On any other status: return `errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, status)` per D-16.
+      - Use `time.NewTimer(wait)` and `timer.Stop()` on ctx branch — NEVER `time.After` (Pitfall 2).
+      - `ctx.Done()` wrapping: `return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")` — preserves `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` via `github.com/pkg/errors` (it embeds the wrapped error retrievable by `errors.Cause` / `errors.Is`).
+      - maxWait-expiry: distinct error message `errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)` — must NOT collapse with `context.DeadlineExceeded` (D-20, Pitfall 3). Do NOT derive a child `context.WithTimeout(ctx, maxWait)`; use `deadline := time.Now().Add(maxWait)` variable.
+      - maxWait-clamping: when computing `wait` before sleep, clamp to `time.Until(deadline)` so the timer fires exactly at the deadline, not past it.
+    - `createTaskAndPoll`:
+      - Builds the async request via `contentToAsyncRequest`.
+      - Calls `doTaskPost` → extracts task ID.
+      - If `TaskCreateResponse.Status == "ready"` AND `Data` is populated (extremely unlikely but allowed by the SDK), returns the embedding directly without polling (per RESEARCH Pattern 3 early-return guidance).
+      - Otherwise calls `pollTask(ctx, taskID, e.apiClient.asyncMaxWait)` and returns the embedding.
+  </behavior>
+  <action>
+    Create `pkg/embeddings/twelvelabs/twelvelabs_async.go` with package declaration `package twelvelabs` (no build tag — this is production code). Required imports: `context`, `encoding/json`, `time`, `github.com/pkg/errors`, `github.com/amikos-tech/chroma-go/pkg/commons/http` (as `chttp`), `github.com/amikos-tech/chroma-go/pkg/embeddings`.
+
+    Implement three functions:
+
+    ```go
+    // contentToAsyncRequest builds the tasks-endpoint body for audio/video content.
+    // See RESEARCH F-02 — the async endpoint uses embedding_option as []string.
+    func contentToAsyncRequest(content embeddings.Content, model string, audioOpt string) (*AsyncEmbedV2Request, error) {
+        if len(content.Parts) != 1 {
+            return nil, errors.Errorf("Twelve Labs requires exactly one part per Content item, got %d", len(content.Parts))
+        }
+        part := content.Parts[0]
+        req := &AsyncEmbedV2Request{ModelName: model}
+        switch part.Modality {
+        case embeddings.ModalityAudio:
+            ms, err := buildMediaSource(part.Source)
+            if err != nil {
+                return nil, errors.Wrap(err, "audio source")
+            }
+            req.InputType = "audio"
+            audio := &AsyncAudioInput{MediaSource: ms}
+            if audioOpt != "" {
+                audio.EmbeddingOption = []string{audioOpt} // wrap single-string sync option into list per F-02
+            }
+            req.Audio = audio
+        case embeddings.ModalityVideo:
+            ms, err := buildMediaSource(part.Source)
+            if err != nil {
+                return nil, errors.Wrap(err, "video source")
+            }
+            req.InputType = "video"
+            req.Video = &AsyncVideoInput{MediaSource: ms}
+        default:
+            return nil, errors.Errorf("async path only handles audio/video; got modality %q", part.Modality)
+        }
+        return req, nil
+    }
+
+    // pollTask loops GET /tasks/{id} until ready, failed, ctx-cancel, or maxWait-expiry.
+    // D-09/D-10/D-11/D-14/D-16/D-17/D-20 all land here.
+    func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID string, maxWait time.Duration) (*TaskResponse, error) {
+        deadline := time.Now().Add(maxWait)
+        interval := e.apiClient.asyncPollInitial
+        for {
+            resp, err := e.doTaskGet(ctx, taskID)
+            if err != nil {
+                return nil, err
+            }
+            switch resp.Status {
+            case "ready":
+                return resp, nil
+            case "failed":
+                reasonBytes, _ := json.Marshal(resp)
+                return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(reasonBytes))
+            case "processing":
+                // fall through to sleep
+            default:
+                return nil, errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, resp.Status)
+            }
+
+            remaining := time.Until(deadline)
+            if remaining <= 0 {
+                return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+            }
+            wait := interval
+            if wait > remaining {
+                wait = remaining
+            }
+            timer := time.NewTimer(wait)
+            select {
+            case <-ctx.Done():
+                timer.Stop()
+                return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+            case <-timer.C:
+            }
+
+            interval = nextBackoff(interval, e.apiClient.asyncPollMultiplier, e.apiClient.asyncPollCap)
+        }
+    }
+
+    func nextBackoff(cur time.Duration, mul float64, cap time.Duration) time.Duration {
+        next := time.Duration(float64(cur) * mul)
+        if next > cap {
+            next = cap
+        }
+        return next
+    }
+
+    // createTaskAndPoll builds the async request, creates the task, and polls to completion.
+    func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+        req, err := contentToAsyncRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
+        if err != nil {
+            return nil, err
+        }
+        created, err := e.doTaskPost(ctx, *req)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to create Twelve Labs async task")
+        }
+        if created.ID == "" {
+            return nil, errors.New("Twelve Labs async task create returned empty _id")
+        }
+        // Rare early-ready path (server finished before response round-trip returned).
+        if created.Status == "ready" && len(created.Data) > 0 {
+            return buildEmbeddingFromData(created.Data)
+        }
+        final, err := e.pollTask(ctx, created.ID, e.apiClient.asyncMaxWait)
+        if err != nil {
+            return nil, err
+        }
+        return buildEmbeddingFromData(final.Data)
+    }
+
+    // buildEmbeddingFromData mirrors embeddingFromResponse but operates on a raw data slice.
+    func buildEmbeddingFromData(data []EmbedV2DataItem) (embeddings.Embedding, error) {
+        if len(data) == 0 {
+            return nil, errors.New("no embedding returned from Twelve Labs task")
+        }
+        if len(data) > 1 {
+            return nil, errors.Errorf("expected 1 embedding from Twelve Labs task, got %d", len(data))
+        }
+        if len(data[0].Embedding) == 0 {
+            return nil, errors.New("empty embedding vector returned from Twelve Labs task")
+        }
+        return embeddings.NewEmbeddingFromFloat32(float64sToFloat32s(data[0].Embedding)), nil
+    }
+    ```
+
+    NOTE on `errors.Is(err, context.Canceled)` compatibility: `github.com/pkg/errors.Wrap` preserves the underlying error for `errors.Is` since Go 1.13 (the wrapped error implements `Unwrap` via `causer`). Do NOT switch to stdlib `fmt.Errorf(...%w...)` — this package consistently uses `pkg/errors` per CLAUDE.md conventions.
+
+    Run `make lint` and fix any issues.
+  </action>
+  <verify>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'func (e \*TwelveLabsEmbeddingFunction) pollTask' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func contentToAsyncRequest' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func (e \*TwelveLabsEmbeddingFunction) createTaskAndPoll' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'time.NewTimer' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'time.After(' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'case <-ctx.Done' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'terminal status=failed' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'unexpected status' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -q 'func (e \*TwelveLabsEmbeddingFunction) pollTask' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'func contentToAsyncRequest' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'func (e \*TwelveLabsEmbeddingFunction) createTaskAndPoll' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'time.NewTimer' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (Pitfall 2 compliance).
+    - `! grep -q 'time.After(' pkg/embeddings/twelvelabs/twelvelabs_async.go` — no `time.After` use in the polling loop.
+    - `grep -q 'case <-ctx.Done' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-20 distinct message).
+    - `grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'terminal status=failed' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-17 shape).
+    - `grep -q 'unexpected status' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-16 branch).
+    - `! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go` — Pitfall 3 guard (no ctx-derivation from maxWait).
+    - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `make lint` exits 0.
+  </acceptance_criteria>
+  <done>Async polling loop, task-request builder, and create+poll orchestrator compile, follow all RESEARCH pitfalls, and use the correct error shapes. Ready for routing.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Route audio/video through async path in content.go when asyncPollingEnabled</name>
+  <files>pkg/embeddings/twelvelabs/content.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/content.go (existing `embedContent` at line 130)
+    - pkg/embeddings/twelvelabs/twelvelabs_async.go (just landed in Task 1 — understand `createTaskAndPoll` contract)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-07, D-08 for routing rules)
+  </read_first>
+  <behavior>
+    - When `e.apiClient.asyncPollingEnabled == true` AND the content's single part is audio or video: dispatch to `createTaskAndPoll`.
+    - Otherwise: preserve existing behavior exactly — `contentToRequest` → `doPost` → `embeddingFromResponse`.
+    - Text and image modalities always take the sync path regardless of the flag (D-07).
+    - When `asyncPollingEnabled == false`, audio/video continue on the sync path (D-08 — today's behavior preserved; long media still fails as it does today unless the user opts in).
+    - No change to `EmbedContent` / `EmbedContents` public methods — only the internal `embedContent` dispatcher.
+    - The existing validation and capability checks at the top of `EmbedContent` / `EmbedContents` still run before dispatch.
+  </behavior>
+  <action>
+    Edit `pkg/embeddings/twelvelabs/content.go`. Modify ONLY the `embedContent` method (line 130). Do NOT touch `EmbedContent`, `EmbedContents`, `Capabilities`, `contentToRequest`, `buildMediaSource`, or `resolveBytes`.
+
+    Replace:
+    ```go
+    // embedContent sends a single Content item to the API and returns the embedding.
+    func (e *TwelveLabsEmbeddingFunction) embedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+        req, err := contentToRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
+        if err != nil {
+            return nil, err
+        }
+        resp, err := e.doPost(ctx, *req)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to embed content")
+        }
+        return embeddingFromResponse(resp)
+    }
+    ```
+
+    With:
+    ```go
+    // embedContent sends a single Content item to the API and returns the embedding.
+    // When asyncPollingEnabled is true and the modality is audio or video, the
+    // content routes through the tasks endpoint + polling loop (CONTEXT.md D-07).
+    // All other cases use the sync /embed-v2 path (D-08 — zero change for non-opt-in).
+    func (e *TwelveLabsEmbeddingFunction) embedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+        if e.apiClient.asyncPollingEnabled && len(content.Parts) == 1 {
+            switch content.Parts[0].Modality {
+            case embeddings.ModalityAudio, embeddings.ModalityVideo:
+                return e.createTaskAndPoll(ctx, content)
+            }
+        }
+        req, err := contentToRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
+        if err != nil {
+            return nil, err
+        }
+        resp, err := e.doPost(ctx, *req)
+        if err != nil {
+            return nil, errors.Wrap(err, "failed to embed content")
+        }
+        return embeddingFromResponse(resp)
+    }
+    ```
+
+    Run `make lint`.
+  </action>
+  <verify>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'asyncPollingEnabled' pkg/embeddings/twelvelabs/content.go && grep -q 'ModalityAudio, embeddings.ModalityVideo' pkg/embeddings/twelvelabs/content.go && grep -q 'createTaskAndPoll(ctx, content)' pkg/embeddings/twelvelabs/content.go && go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/... && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -q 'asyncPollingEnabled' pkg/embeddings/twelvelabs/content.go` matches.
+    - `grep -q 'ModalityAudio, embeddings.ModalityVideo' pkg/embeddings/twelvelabs/content.go` matches.
+    - `grep -q 'createTaskAndPoll(ctx, content)' pkg/embeddings/twelvelabs/content.go` matches.
+    - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `make lint` exits 0.
+    - `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` exits 0 — existing tests still pass because `asyncPollingEnabled` defaults to `false` and every current test leaves it false.
+  </acceptance_criteria>
+  <done>Routing branches on `asyncPollingEnabled` + audio/video; existing behavior preserved for text/image and for clients without the opt-in. Ready for Plan 03 to wire the public option.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Twelve Labs API → polling loop | Server-controlled `status` values and failure reasons flow into error text. |
+| caller's ctx → polling loop | Caller-controlled deadline/cancellation bounds the loop. |
+| `maxWait` config → polling loop | Caller-tunable duration bounds the loop independently of ctx. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-26-06 | I (Information Disclosure) | pollTask failed-status error | mitigate | Failure reason (entire `TaskResponse` JSON) flows through `chttp.SanitizeErrorBody` before landing in the error message. No raw server text bleeds into logs. |
+| T-26-07 | D (Denial of Service) | unbounded polling loop | mitigate | Three independent bounds: `ctx.Done()` (caller), `maxWait` deadline variable (SDK), `asyncPollCap=60s` per-poll (backoff). maxWait default of 30 min (Plan 03) prevents accidental `context.Background()` calls from hanging indefinitely. |
+| T-26-08 | D (Denial of Service) | timer leak | mitigate | `time.NewTimer` + `timer.Stop()` on ctx branch instead of `time.After` (Pitfall 2). Grep-enforced: `! grep 'time.After(' twelvelabs_async.go`. |
+| T-26-09 | T (Tampering) | malformed status field | mitigate | D-16 default branch — any status value not in {processing, ready, failed} returns a descriptive error rather than silently falling into the wrong terminal branch. |
+| T-26-10 | R (Repudiation) | indistinguishable timeout errors | mitigate | D-20 — maxWait-expiry surfaces as a distinct `errors.Errorf` message containing "async polling maxWait exceeded"; ctx deadlines surface as wrapped `context.DeadlineExceeded`. Callers can distinguish via `errors.Is` or message substring. |
+</threat_model>
+
+<verification>
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` passes.
+- `make lint` passes.
+- Existing `TestTwelveLabs*` suite still exits 0 (async path is flag-gated off by default).
+- All grep acceptance criteria match.
+- No `time.After` in the polling loop.
+- No `context.WithTimeout(ctx, maxWait)` (D-20 / Pitfall 3 compliance).
+</verification>
+
+<success_criteria>
+Polling loop, async request builder, and content.go routing are in place. A client with `asyncPollingEnabled=true` and polling fields populated would correctly create → poll → return or fail with distinguishable errors. Text/image content and non-opt-in callers see zero behavior change. Plan 03 (option + config) and Plan 04 (tests) can now proceed.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/26-twelve-labs-async-embedding/26-02-SUMMARY.md`.
+</output>

--- a/.planning/phases/26-twelve-labs-async-embedding/26-02-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-02-PLAN.md
@@ -16,8 +16,10 @@ must_haves:
     - "pollTask polls via doTaskGet in a loop, handling processing/ready/failed/unknown status values per D-14/D-16."
     - "Polling uses capped exponential backoff (initial=2s, multiplier=1.5, cap=60s) via time.NewTimer (not time.After) to avoid timer leaks."
     - "maxWait is tracked via a deadline variable (time.Now().Add(maxWait)) independent of ctx — ctx.DeadlineExceeded and maxWait-expiry surface as distinguishable errors per D-20."
-    - "ctx.Done() cancels the polling loop immediately and wraps ctx.Err(), making errors.Is(err, context.Canceled) work per D-10/D-19."
-    - "Terminal 'failed' status surfaces an error containing task ID, status=failed, and a sanitized reason per D-17."
+    - "Every HTTP call inside the polling loop is bounded by a per-call deadline of min(parent ctx deadline, SDK maxWait deadline) so a blocked doTaskGet/doTaskPost cannot outlive maxWait (D-09 hard bound, not a best-effort between-polls check)."
+    - "ctx.Done() cancels the polling loop immediately and wraps ctx.Err(); context.Canceled and context.DeadlineExceeded surface as distinct error messages so callers can tell them apart."
+    - "Terminal 'failed' status surfaces an error built from the raw server response body (TaskResponse.FailureDetail from Plan 01), sanitized via chttp.SanitizeErrorBody — the authentic server reason, not a re-marshaled subset (D-17)."
+    - "WithAudioEmbeddingOption(\"fused\") combined with async polling on audio content is rejected with a deterministic validation error; fused is not a valid async embedding_option value per RESEARCH F-02/A5 and the codebase does not silently drop or map it."
     - "Audio and video modalities route to the async tasks path when asyncPollingEnabled is true; text and image always stay on the sync path per D-07/D-08."
     - "When asyncPollingEnabled is false, all four modalities (including audio/video) continue to use the existing sync doPost path — zero behavior change for non-opt-in callers."
   artifacts:
@@ -123,24 +125,32 @@ func float64sToFloat32s(in []float64) []float32
   <name>Task 1: Implement pollTask, contentToAsyncRequest, and createTaskAndPoll in twelvelabs_async.go</name>
   <files>pkg/embeddings/twelvelabs/twelvelabs_async.go</files>
   <read_first>
-    - pkg/embeddings/twelvelabs/twelvelabs.go (full file post-Plan-01 — understand the types and helpers Plan 01 added)
+    - pkg/embeddings/twelvelabs/twelvelabs.go (full file post-Plan-01 — understand the types and helpers Plan 01 added, including TaskResponse.FailureDetail)
     - pkg/embeddings/twelvelabs/content.go (buildMediaSource, existing contentToRequest)
+    - pkg/embeddings/twelvelabs/option.go (existing WithAudioEmbeddingOption at line 76 accepts "audio"/"transcription"/"fused" — async path must reject "fused" explicitly)
+    - pkg/embeddings/multimodal.go (verify `embeddings.Part` type; there is no `embeddings.ContentPart`)
     - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-09 through D-20 — bounds, cancellation, backoff, status, error semantics)
-    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pattern 3 polling skeleton, Pitfall 2 time.NewTimer leak, Pitfall 3 maxWait/ctx distinction, Pitfall 4 first-poll pause, Pitfall 5 embedding_option list)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pattern 3 polling skeleton, Pitfall 2 time.NewTimer leak, Pitfall 3 maxWait/ctx distinction, Pitfall 4 first-poll pause, Pitfall 5 embedding_option list, F-02 / Assumption A5 for fused)
   </read_first>
   <behavior>
     - `contentToAsyncRequest` accepts a `Content` item with modality audio or video, returns an `*AsyncEmbedV2Request` with the appropriate input_type, model_name, and a single populated `Audio` or `Video` field. Other modalities (text, image) return an error — caller is expected to route only audio/video here.
     - Audio input: `embedding_option` is a single-element list wrapping `audioOpt` (the existing `AudioEmbeddingOption` string). If `audioOpt` is empty, omit the field (empty slice → omitempty).
+    - **Fused-on-async rejection (RESEARCH F-02 / Assumption A5):** when `audioOpt == "fused"` on the audio branch, `contentToAsyncRequest` returns a deterministic validation error `errors.New("Twelve Labs async path does not support audio embedding option \"fused\"; async endpoint only accepts \"audio\" and \"transcription\" (see RESEARCH F-02)")`. No silent drop, no silent map. Callers who need `fused` must disable `WithAsyncPolling` for those calls.
     - `pollTask` behavior:
       - Poll-first-sleep-second (Pitfall 4): call `doTaskGet` before the first backoff sleep.
+      - **Per-HTTP-call deadline (D-09 hard bound):** before every `doTaskGet` inside the loop, derive `callCtx, cancel := context.WithDeadline(ctx, httpDeadline)` where `httpDeadline = min(parentCtxDeadline, sdkMaxWaitDeadline)` — if parent ctx has no deadline, use the SDK maxWait deadline directly. Pass `callCtx` to `doTaskGet` and always `cancel()` after the call returns. This prevents a blocked HTTP request from running past `maxWait`.
+      - **Translating deadline-source back:** after `doTaskGet` returns an error, if the error wraps `context.DeadlineExceeded` AND the SDK-side `sdkMaxWaitDeadline` has fired (time.Now().After(sdkMaxWaitDeadline)), translate the error into the distinct maxWait error (same message shape as the between-polls case). If the parent ctx deadline fired first, return a wrapped `context.DeadlineExceeded` with the "async polling deadline exceeded" message. This preserves D-20 — callers can still distinguish SDK-enforced timeout from their own ctx deadline.
       - On `status == "ready"`: extract embedding from `data` (error if `data` is empty or has != 1 item) and return.
-      - On `status == "failed"`: return `errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, <sanitized reason>)`. Reason is the task response serialized as JSON and passed through `chttp.SanitizeErrorBody`.
+      - On `status == "failed"`: return `errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(resp.FailureDetail))`. Reason is the raw server response body (captured by `doTaskGet` into `TaskResponse.FailureDetail` per Plan 01), NOT the re-marshaled `TaskResponse` struct. This preserves undeclared server reason fields per D-17.
       - On `status == "processing"`: sleep with capped exponential backoff then loop.
       - On any other status: return `errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, status)` per D-16.
       - Use `time.NewTimer(wait)` and `timer.Stop()` on ctx branch — NEVER `time.After` (Pitfall 2).
-      - `ctx.Done()` wrapping: `return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")` — preserves `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` via `github.com/pkg/errors` (it embeds the wrapped error retrievable by `errors.Cause` / `errors.Is`).
-      - maxWait-expiry: distinct error message `errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)` — must NOT collapse with `context.DeadlineExceeded` (D-20, Pitfall 3). Do NOT derive a child `context.WithTimeout(ctx, maxWait)`; use `deadline := time.Now().Add(maxWait)` variable.
-      - maxWait-clamping: when computing `wait` before sleep, clamp to `time.Until(deadline)` so the timer fires exactly at the deadline, not past it.
+      - **Distinct ctx-cancel vs deadline wording (D-20):** in the select between sleep and ctx, branch on `ctx.Err()`:
+        - `context.Canceled` → `errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")`
+        - `context.DeadlineExceeded` → `errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")`
+        Both preserve `errors.Is(err, context.Canceled)` / `errors.Is(err, context.DeadlineExceeded)` via `github.com/pkg/errors` Unwrap support.
+      - maxWait-expiry (SDK-side): distinct error message `errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)` — must NOT collapse with `context.DeadlineExceeded` (D-20, Pitfall 3). Do NOT derive a child `context.WithTimeout(ctx, maxWait)` at the loop level; use `sdkMaxWaitDeadline := time.Now().Add(maxWait)` variable. Per-HTTP-call deadlines are separate and MUST cancel on the min of both.
+      - maxWait-clamping: when computing `wait` before sleep, clamp to `time.Until(sdkMaxWaitDeadline)` so the timer fires exactly at the deadline, not past it.
     - `createTaskAndPoll`:
       - Builds the async request via `contentToAsyncRequest`.
       - Calls `doTaskPost` → extracts task ID.
@@ -154,7 +164,8 @@ func float64sToFloat32s(in []float64) []float32
 
     ```go
     // contentToAsyncRequest builds the tasks-endpoint body for audio/video content.
-    // See RESEARCH F-02 — the async endpoint uses embedding_option as []string.
+    // See RESEARCH F-02 — the async endpoint uses embedding_option as []string
+    // and does NOT accept "fused" (only "audio" and "transcription").
     func contentToAsyncRequest(content embeddings.Content, model string, audioOpt string) (*AsyncEmbedV2Request, error) {
         if len(content.Parts) != 1 {
             return nil, errors.Errorf("Twelve Labs requires exactly one part per Content item, got %d", len(content.Parts))
@@ -163,6 +174,12 @@ func float64sToFloat32s(in []float64) []float32
         req := &AsyncEmbedV2Request{ModelName: model}
         switch part.Modality {
         case embeddings.ModalityAudio:
+            // RESEARCH F-02 / A5: "fused" is valid on the sync embedding_option
+            // string but is NOT a valid async embedding_option list value. Reject
+            // deterministically rather than silently dropping or mapping.
+            if audioOpt == "fused" {
+                return nil, errors.New("Twelve Labs async path does not support audio embedding option \"fused\"; async endpoint only accepts \"audio\" and \"transcription\" (see RESEARCH F-02). Disable WithAsyncPolling for fused-audio calls.")
+            }
             ms, err := buildMediaSource(part.Source)
             if err != nil {
                 return nil, errors.Wrap(err, "audio source")
@@ -188,27 +205,55 @@ func float64sToFloat32s(in []float64) []float32
 
     // pollTask loops GET /tasks/{id} until ready, failed, ctx-cancel, or maxWait-expiry.
     // D-09/D-10/D-11/D-14/D-16/D-17/D-20 all land here.
+    //
+    // Per-HTTP-call deadline: every doTaskGet is wrapped in a derived context
+    // bounded by min(parent ctx deadline, SDK maxWait deadline). This ensures
+    // a blocked HTTP request cannot outlive maxWait (D-09 hard bound). When the
+    // derived deadline fires, we inspect which source expired first and translate
+    // back into the appropriate distinct error message (D-20).
     func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID string, maxWait time.Duration) (*TaskResponse, error) {
-        deadline := time.Now().Add(maxWait)
+        sdkMaxWaitDeadline := time.Now().Add(maxWait)
         interval := e.apiClient.asyncPollInitial
         for {
-            resp, err := e.doTaskGet(ctx, taskID)
+            // Derive per-call deadline = min(parent ctx deadline, sdkMaxWaitDeadline).
+            callDeadline := sdkMaxWaitDeadline
+            if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(callDeadline) {
+                callDeadline = parentDL
+            }
+            callCtx, cancel := context.WithDeadline(ctx, callDeadline)
+            resp, err := e.doTaskGet(callCtx, taskID)
+            cancel()
             if err != nil {
+                // If the call was terminated because our derived deadline fired,
+                // figure out which source was responsible and return the distinct
+                // error (D-20). errors.Is works through pkg/errors wrapping.
+                if errors.Is(err, context.DeadlineExceeded) {
+                    if time.Now().After(sdkMaxWaitDeadline) {
+                        return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+                    }
+                    // Parent ctx deadline fired first.
+                    return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")
+                }
+                if errors.Is(err, context.Canceled) {
+                    return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+                }
                 return nil, err
             }
             switch resp.Status {
             case "ready":
                 return resp, nil
             case "failed":
-                reasonBytes, _ := json.Marshal(resp)
-                return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(reasonBytes))
+                // Use the raw server body captured by doTaskGet (Plan 01 FailureDetail)
+                // so the sanitized reason reflects the authentic server payload,
+                // not a re-marshaled subset of known fields.
+                return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(resp.FailureDetail))
             case "processing":
                 // fall through to sleep
             default:
                 return nil, errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, resp.Status)
             }
 
-            remaining := time.Until(deadline)
+            remaining := time.Until(sdkMaxWaitDeadline)
             if remaining <= 0 {
                 return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
             }
@@ -220,6 +265,11 @@ func float64sToFloat32s(in []float64) []float32
             select {
             case <-ctx.Done():
                 timer.Stop()
+                // Distinct wording for cancel vs deadline (D-20). errors.Is still
+                // unwraps to the stdlib sentinel for caller introspection.
+                if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+                    return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")
+                }
                 return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
             case <-timer.C:
             }
@@ -280,7 +330,7 @@ func float64sToFloat32s(in []float64) []float32
     Run `make lint` and fix any issues.
   </action>
   <verify>
-    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'func (e \*TwelveLabsEmbeddingFunction) pollTask' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func contentToAsyncRequest' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func (e \*TwelveLabsEmbeddingFunction) createTaskAndPoll' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'time.NewTimer' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'time.After(' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'case <-ctx.Done' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'terminal status=failed' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'unexpected status' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go && echo OK</automated>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'func (e \*TwelveLabsEmbeddingFunction) pollTask' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func contentToAsyncRequest' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'func (e \*TwelveLabsEmbeddingFunction) createTaskAndPoll' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'time.NewTimer' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'time.After(' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'case <-ctx.Done' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'async polling deadline exceeded' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'terminal status=failed' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'unexpected status' pkg/embeddings/twelvelabs/twelvelabs_async.go && ! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'context.WithDeadline(ctx, callDeadline)' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'fused' pkg/embeddings/twelvelabs/twelvelabs_async.go && grep -q 'resp.FailureDetail' pkg/embeddings/twelvelabs/twelvelabs_async.go && echo OK</automated>
   </verify>
   <acceptance_criteria>
     - `grep -q 'func (e \*TwelveLabsEmbeddingFunction) pollTask' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
@@ -289,11 +339,16 @@ func float64sToFloat32s(in []float64) []float32
     - `grep -q 'time.NewTimer' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (Pitfall 2 compliance).
     - `! grep -q 'time.After(' pkg/embeddings/twelvelabs/twelvelabs_async.go` — no `time.After` use in the polling loop.
     - `grep -q 'case <-ctx.Done' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
-    - `grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-20 distinct message).
-    - `grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches.
+    - `grep -q 'async polling maxWait' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-20 distinct SDK-timeout message).
+    - `grep -q 'async polling canceled' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (context.Canceled path).
+    - `grep -q 'async polling deadline exceeded' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (context.DeadlineExceeded path — distinct from Canceled per D-20).
     - `grep -q 'terminal status=failed' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-17 shape).
+    - `grep -q 'resp.FailureDetail' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches — failed branch sanitizes the raw server body preserved by Plan 01, not a re-marshaled struct (D-17 authenticity).
     - `grep -q 'unexpected status' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches (D-16 branch).
-    - `! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go` — Pitfall 3 guard (no ctx-derivation from maxWait).
+    - `! grep -q 'context.WithTimeout(ctx, maxWait)' pkg/embeddings/twelvelabs/twelvelabs_async.go` — Pitfall 3 guard (no ctx-derivation from maxWait at the loop level).
+    - `grep -q 'context.WithDeadline(ctx, callDeadline)' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches — per-HTTP-call deadline bounds in-flight work by min(parent-ctx, sdkMaxWait) so blocked HTTP requests cannot outlive maxWait (D-09 hard bound).
+    - `grep -q '"fused"' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches — deterministic rejection of `fused` audio option on the async path (RESEARCH F-02 / A5). The rejection error must include the string `fused`.
+    - `grep -q 'async endpoint only accepts' pkg/embeddings/twelvelabs/twelvelabs_async.go` matches — explicit validation error text for the fused rejection.
     - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
     - `make lint` exits 0.
   </acceptance_criteria>

--- a/.planning/phases/26-twelve-labs-async-embedding/26-02-SUMMARY.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-02-SUMMARY.md
@@ -1,0 +1,152 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 02
+subsystem: embeddings
+tags: [twelvelabs, embeddings, async, polling]
+
+# Dependency graph
+requires:
+  - phase: 26-twelve-labs-async-embedding
+    plan: 01
+    provides: AsyncEmbedV2Request/AsyncAudioInput/AsyncVideoInput types, TaskCreateResponse, TaskResponse with FailureDetail json.RawMessage, doTaskPost, doTaskGet, polling fields + backoff defaults
+provides:
+  - pollTask polling loop with capped exponential backoff (time.NewTimer, not time.After)
+  - Per-HTTP-call deadline = min(parent ctx, SDK maxWait) bounds blocked doTaskGet calls (D-09 hard bound)
+  - Distinct error messages for ctx.Canceled, ctx.DeadlineExceeded, and SDK maxWait expiry (D-20); errors.Is still unwraps to stdlib sentinels via pkg/errors
+  - Terminal status=failed uses raw server body from TaskResponse.FailureDetail → chttp.SanitizeErrorBody (D-17)
+  - D-16 default branch rejects unknown status values with descriptive error
+  - contentToAsyncRequest rejects audioOpt="fused" on the async path per RESEARCH F-02 / A5 — no silent drop, no silent map
+  - createTaskAndPoll orchestrates build → POST → optional early-ready short-circuit → poll → extract
+  - embedContent routes audio/video through async path when asyncPollingEnabled=true; text/image and flag-off callers unchanged
+affects: [26-03-option-and-config, 26-04-tests]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Per-call context.WithDeadline wrapping derived from min(parentCtxDeadline, sdkMaxWaitDeadline) so a blocked HTTP request cannot outlive the SDK-side bound"
+    - "Two-source deadline reconciliation — when a derived-deadline error fires, inspect sdkMaxWaitDeadline vs parent ctx to translate back into the distinct caller-facing error (D-20)"
+    - "Separate file for async-specific code (twelvelabs_async.go) to keep Plan 03's option/config churn on twelvelabs.go conflict-free in the same wave"
+
+key-files:
+  created:
+    - pkg/embeddings/twelvelabs/twelvelabs_async.go
+  modified:
+    - pkg/embeddings/twelvelabs/content.go
+
+key-decisions:
+  - "Renamed the nextBackoff cap parameter to backoffCap to avoid shadowing the Go builtin cap; semantics unchanged"
+  - "Applied //nolint:unused annotations to the async symbols in Task 1 (mirroring Plan 01's precedent) and removed them in Task 2 once content.go routing made them reachable. Zero out-and-back churn — Task 2 is a two-line delete of pragmas plus the routing switch"
+  - "Kept the fused-on-async rejection as an explicit error at contentToAsyncRequest rather than silently mapping it to 'audio' or 'transcription'; silent mapping would violate F-02 and produce results callers did not request"
+  - "Used two distinct error message substrings ('async polling canceled' vs 'async polling deadline exceeded' vs 'async polling maxWait %s exceeded') so callers can introspect via substring or errors.Is without collapsing the three timeout sources"
+
+patterns-established:
+  - "Polling loops use a time.NewTimer + timer.Stop() on ctx branch instead of time.After (Pitfall 2)"
+  - "SDK-side maxWait lives as a time.Time deadline variable, never as context.WithTimeout(ctx, maxWait) — keeps it distinguishable from caller ctx deadlines (Pitfall 3)"
+  - "Failure reasons sanitize the raw server body (json.RawMessage captured on success parse) rather than re-marshaling a known-fields struct subset"
+
+requirements-completed: [TLA-01, TLA-02, TLA-03]
+
+# Metrics
+duration: ~4min
+completed: 2026-04-14
+---
+
+# Phase 26 Plan 02: Async Polling Loop and Modality Routing Summary
+
+**Wired the Twelve Labs async polling loop and modality-based routing: audio/video + `asyncPollingEnabled=true` now flows through POST /tasks → poll GET /tasks/{id} → extract embedding, with three distinguishable timeout sources, per-HTTP-call deadline bounding, and raw-body failure sanitization. Text/image and non-opt-in callers see zero behavior change.**
+
+## Performance
+
+- **Duration:** ~4 min
+- **Started:** 2026-04-14T09:29:56Z
+- **Completed:** 2026-04-14T09:33:37Z
+- **Tasks:** 2
+- **Files created:** 1
+- **Files modified:** 1
+
+## Accomplishments
+
+- New file `pkg/embeddings/twelvelabs/twelvelabs_async.go` lands `contentToAsyncRequest`, `pollTask`, `nextBackoff`, `createTaskAndPoll`, and `buildEmbeddingFromData` — all deviation-rule compliant with D-09, D-11, D-14, D-16, D-17, D-20 and RESEARCH Pitfall 2/3/4/5 + F-02.
+- `pollTask` uses `time.NewTimer` with explicit `timer.Stop()` on the ctx branch (Pitfall 2) and clamps the per-iteration wait to the remaining `sdkMaxWaitDeadline` so the final timer fires at the deadline, not past it.
+- Per-HTTP-call deadline = `min(parentCtxDeadline, sdkMaxWaitDeadline)` means a blocked `doTaskGet` cannot outlive `maxWait` — D-09 is a hard bound, not a between-polls best-effort check.
+- Three timeout sources surface with distinct wording: `async polling canceled` (ctx.Canceled), `async polling deadline exceeded` (ctx.DeadlineExceeded), `async polling maxWait %s exceeded` (SDK-side). All three still unwrap to the correct stdlib sentinel via pkg/errors.
+- Terminal `status=failed` sanitizes `resp.FailureDetail` (the raw server body preserved in Plan 01) through `chttp.SanitizeErrorBody` — D-17 compliance, no re-marshaled subset.
+- `contentToAsyncRequest` rejects `audioOpt="fused"` with an explicit validation error pointing callers at `WithAsyncPolling` disabling for fused-audio calls (F-02 / A5).
+- `embedContent` in `content.go` now branches on `asyncPollingEnabled && len(content.Parts)==1 && (Modality in {Audio, Video})` → `createTaskAndPoll`; every other case preserves the existing `contentToRequest → doPost → embeddingFromResponse` sequence verbatim.
+- Existing `TestTwelveLabs*` suite exits 0 — flag-off is the default, and no test sets `asyncPollingEnabled=true` yet (Plan 04 will).
+
+## Task Commits
+
+1. **Task 1: Implement pollTask, contentToAsyncRequest, and createTaskAndPoll** — `ef31d06` (feat)
+2. **Task 2: Route audio/video through async path when asyncPollingEnabled** — `d6e0222` (feat)
+
+## Files Created/Modified
+
+- `pkg/embeddings/twelvelabs/twelvelabs_async.go` — new file; async request builder, polling loop, orchestrator, and embedding extractor
+- `pkg/embeddings/twelvelabs/content.go` — `embedContent` now dispatches audio/video to async path when the flag is on
+
+## Decisions Made
+
+- Kept the per-HTTP-call deadline derivation inline inside the loop rather than hoisting into a helper — the logic is ~5 lines and hoisting would require passing `sdkMaxWaitDeadline` and `ctx` across a boundary, obscuring the invariant that `callDeadline ≤ sdkMaxWaitDeadline` always.
+- Chose error translation *after* `doTaskGet` returns rather than wrapping the call in a goroutine-with-cancel pattern — simpler, preserves existing HTTP client timeouts, and keeps `errors.Is(err, context.DeadlineExceeded)` as the source of truth for which source fired.
+- Placed the fused-rejection inside `contentToAsyncRequest` (not at `embedContent` dispatch) so that any callable that builds an async request — including future test fixtures — hits the same validation gate.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Shadowed Go builtin `cap` in nextBackoff parameter**
+- **Found during:** Task 1 implementation (before first build)
+- **Issue:** The plan's reference code used `cap time.Duration` as the `nextBackoff` parameter name, which shadows Go's builtin `cap(...)`. Lint would flag this under `predeclared` / `shadow` rules and it is a known footgun even when lint doesn't catch it.
+- **Fix:** Renamed the parameter to `backoffCap`. Behavior unchanged; the comparison `next > backoffCap` is semantically identical.
+- **Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_async.go`
+- **Committed in:** `ef31d06` (Task 1)
+
+**2. [Rule 3 - Blocking] Transient `unused` lint on async symbols between Task 1 commit and Task 2 commit**
+- **Found during:** Task 1 post-implementation `make lint`
+- **Issue:** After Task 1 landed the async symbols without a consumer, `unused` fired on `contentToAsyncRequest`, `pollTask`, `nextBackoff`, `createTaskAndPoll`, and `buildEmbeddingFromData`. The plan's Task 1 acceptance requires `make lint` to exit 0.
+- **Fix:** Added `//nolint:unused` with comments citing Task 2 as the consumer. Removed all five annotations in Task 2's edits once content.go routing made the symbols reachable. This mirrors Plan 26-01's `//nolint:unused` pattern for the same intra-plan scaffolding concern.
+- **Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_async.go`
+- **Committed in:** `ef31d06` (add), `d6e0222` (remove)
+
+---
+
+**Total deviations:** 2 auto-fixed (both blocking)
+**Impact on plan:** No scope change. The `cap` rename is a builtin-shadow defense; the nolint add/remove is a transient scaffolding concern that the plan itself anticipated via the sequential task split.
+
+## Issues Encountered
+
+- `PreToolUse:Edit` read-before-edit hook fires on every Edit operation even within a single session after the file has been read. Each Edit required re-reading a slice of the file; the edits themselves all succeeded.
+
+## User Setup Required
+
+None — no environment variables, no external service configuration. Plan 03 will add the `WithAsyncPolling(maxWait)` option that flips `asyncPollingEnabled` on.
+
+## Next Phase Readiness
+
+- **Plan 26-03 (option + config)** can now safely add `WithAsyncPolling(maxWait)`, wire the config round-trip for `async_polling_enabled` + `async_max_wait`, and the routing + polling loop will activate immediately for audio/video callers who opt in.
+- **Plan 26-04 (tests)** can now mock the task endpoints, construct a client with `asyncPollingEnabled=true` + `asyncMaxWait=...` directly (or via Plan 03's option once landed), and exercise: happy path, ready-first-poll, failed with sanitized reason, maxWait expiry, ctx.Canceled vs ctx.DeadlineExceeded distinction, unknown-status rejection, fused-rejection, and the modality routing gate (text/image stay on sync even with the flag on).
+
+## Verification Log
+
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` — exit 0
+- `make lint` — 0 issues
+- `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` — ok (flag-off default preserved)
+- Task 1 grep acceptance (15 assertions): all pass
+- Task 2 grep acceptance (3 assertions): all pass
+- No `time.After(` in the polling loop
+- No `context.WithTimeout(ctx, maxWait)` at loop level (Pitfall 3 compliance)
+- `context.WithDeadline(ctx, callDeadline)` present per-call (D-09 hard bound)
+- `resp.FailureDetail` used on failed branch (D-17 authenticity)
+
+## Self-Check: PASSED
+
+- File `pkg/embeddings/twelvelabs/twelvelabs_async.go` exists and contains `contentToAsyncRequest`, `pollTask`, `nextBackoff`, `createTaskAndPoll`, `buildEmbeddingFromData`.
+- File `pkg/embeddings/twelvelabs/content.go` modified `embedContent` contains `asyncPollingEnabled`, `ModalityAudio, embeddings.ModalityVideo`, `createTaskAndPoll(ctx, content)`.
+- Commit `ef31d06` present in `git log`.
+- Commit `d6e0222` present in `git log`.
+
+---
+*Phase: 26-twelve-labs-async-embedding*
+*Completed: 2026-04-14*

--- a/.planning/phases/26-twelve-labs-async-embedding/26-03-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-03-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 03
+type: execute
+wave: 2
+depends_on: [26-01]
+files_modified:
+  - pkg/embeddings/twelvelabs/option.go
+  - pkg/embeddings/twelvelabs/twelvelabs.go
+autonomous: true
+requirements: [TLA-03]
+tags: [twelvelabs, embeddings, async, options, config-roundtrip]
+
+must_haves:
+  truths:
+    - "WithAsyncPolling(maxWait time.Duration) exists as a public Option and is the sole trigger for the async code path."
+    - "Passing maxWait=0 selects the 30-minute default per D-03."
+    - "Passing maxWait<0 returns a validation error instead of panicking or silently accepting."
+    - "GetConfig emits async_polling:true and async_max_wait_ms:<int64 ms> iff asyncPollingEnabled is true (D-21, D-22)."
+    - "NewTwelveLabsEmbeddingFunctionFromConfig reads async_polling + async_max_wait_ms and reconstructs WithAsyncPolling; missing keys leave the flag off (D-23)."
+    - "Config round-trip is lossless: build → GetConfig → FromConfig produces a client with identical asyncPollingEnabled and asyncMaxWait."
+  artifacts:
+    - path: "pkg/embeddings/twelvelabs/option.go"
+      provides: "WithAsyncPolling functional option"
+      contains: "func WithAsyncPolling"
+    - path: "pkg/embeddings/twelvelabs/twelvelabs.go"
+      provides: "GetConfig emits async keys; FromConfig reads them"
+      contains: "async_polling"
+  key_links:
+    - from: "WithAsyncPolling"
+      to: "TwelveLabsClient.asyncPollingEnabled / asyncMaxWait"
+      via: "option assignment"
+      pattern: "asyncPollingEnabled = true"
+    - from: "GetConfig"
+      to: "async_polling / async_max_wait_ms keys"
+      via: "conditional emit when enabled"
+      pattern: 'async_polling.*true'
+    - from: "NewTwelveLabsEmbeddingFunctionFromConfig"
+      to: "WithAsyncPolling"
+      via: "missing-keys = opt-in-off default"
+      pattern: "async_polling"
+---
+
+<objective>
+Wire the single public async option (`WithAsyncPolling`) and the config round-trip keys (`async_polling`, `async_max_wait_ms`). This is the user-visible surface for Phase 26 — everything else is internal. Plan 01 defined the fields and Plan 02 implemented the polling loop; Plan 03 turns the flag on from the outside and makes it survive a registry save/restore cycle (D-21 through D-23).
+
+Purpose: Without this plan, callers have no way to enable async polling from public API code. With this plan, the single-line opt-in (`WithAsyncPolling(30*time.Minute)`) is the sole trigger (D-03), and any EF rebuilt from a saved config behaves identically to the original.
+
+Output: `option.go` has `WithAsyncPolling`. `twelvelabs.go` `GetConfig` emits the two new keys conditionally; `NewTwelveLabsEmbeddingFunctionFromConfig` reads them. No behavior change for non-opt-in callers.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+@.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
+@pkg/embeddings/twelvelabs/option.go
+@pkg/embeddings/twelvelabs/twelvelabs.go
+@CLAUDE.md
+
+<interfaces>
+<!-- From Plan 01 (landed in Wave 1): -->
+```go
+type TwelveLabsClient struct {
+    // ...existing...
+    asyncPollingEnabled bool
+    asyncMaxWait        time.Duration
+    asyncPollInitial    time.Duration
+    asyncPollMultiplier float64
+    asyncPollCap        time.Duration
+}
+```
+
+<!-- Existing (do not break): -->
+```go
+type Option func(p *TwelveLabsClient) error
+
+func (e *TwelveLabsEmbeddingFunction) GetConfig() embeddings.EmbeddingFunctionConfig
+func NewTwelveLabsEmbeddingFunctionFromConfig(cfg embeddings.EmbeddingFunctionConfig) (*TwelveLabsEmbeddingFunction, error)
+
+// Existing option pattern (validation inside, errors.New for bad input):
+func WithAudioEmbeddingOption(opt string) Option {
+    return func(p *TwelveLabsClient) error {
+        // switch + validate + assign
+    }
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Add WithAsyncPolling option to option.go</name>
+  <files>pkg/embeddings/twelvelabs/option.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/option.go (existing option shapes — follow WithAudioEmbeddingOption pattern exactly)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-03, D-04)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md ("Code Examples" section — exact WithAsyncPolling code sample)
+  </read_first>
+  <behavior>
+    - `WithAsyncPolling(maxWait time.Duration) Option` sets `asyncPollingEnabled=true`.
+    - `maxWait == 0` → `asyncMaxWait = 30 * time.Minute` (D-03 default).
+    - `maxWait < 0` → return `errors.New("maxWait cannot be negative")`. The option should fail-fast on obviously wrong input rather than silently accept it (CLAUDE.md convention, existing options follow this pattern).
+    - `maxWait > 0` → `asyncMaxWait = maxWait`.
+    - Option is the ONLY new public export from this phase (D-04).
+  </behavior>
+  <action>
+    Edit `pkg/embeddings/twelvelabs/option.go`:
+
+    1. Add `"time"` to the import block (confirm it's not already there — currently it is NOT).
+
+    2. Append the new option at the end of the file:
+
+    ```go
+    // WithAsyncPolling enables the Twelve Labs tasks-endpoint code path for
+    // audio and video content. Passing maxWait=0 selects the 30-minute default
+    // (CONTEXT.md D-03). This is the sole public trigger for async — polling
+    // interval, backoff multiplier, and cap are internal (D-04).
+    func WithAsyncPolling(maxWait time.Duration) Option {
+        return func(p *TwelveLabsClient) error {
+            if maxWait < 0 {
+                return errors.New("maxWait cannot be negative")
+            }
+            p.asyncPollingEnabled = true
+            if maxWait == 0 {
+                p.asyncMaxWait = 30 * time.Minute
+            } else {
+                p.asyncMaxWait = maxWait
+            }
+            return nil
+        }
+    }
+    ```
+
+    Run `make lint`.
+  </action>
+  <verify>
+    <automated>go build ./pkg/embeddings/twelvelabs/... && grep -q 'func WithAsyncPolling(maxWait time.Duration) Option' pkg/embeddings/twelvelabs/option.go && grep -q 'maxWait cannot be negative' pkg/embeddings/twelvelabs/option.go && grep -q '30 \* time.Minute' pkg/embeddings/twelvelabs/option.go && grep -q 'asyncPollingEnabled = true' pkg/embeddings/twelvelabs/option.go && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -q 'func WithAsyncPolling(maxWait time.Duration) Option' pkg/embeddings/twelvelabs/option.go` matches — exact signature per D-03.
+    - `grep -q 'maxWait cannot be negative' pkg/embeddings/twelvelabs/option.go` matches.
+    - `grep -q '30 \* time.Minute' pkg/embeddings/twelvelabs/option.go` matches (default value).
+    - `grep -q 'asyncPollingEnabled = true' pkg/embeddings/twelvelabs/option.go` matches.
+    - `go build ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `make lint` exits 0.
+  </acceptance_criteria>
+  <done>WithAsyncPolling compiles, validates negative input, defaults to 30 min on zero, and toggles asyncPollingEnabled.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Wire async config keys into GetConfig and NewTwelveLabsEmbeddingFunctionFromConfig</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs.go (existing `GetConfig` ~line 269 and `NewTwelveLabsEmbeddingFunctionFromConfig` ~line 289 — follow the existing key-emission pattern)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-21, D-22, D-23)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pitfall 6 for round-trip idempotence — emit int64 ms, omit when flag off)
+  </read_first>
+  <behavior>
+    - `GetConfig` emits `"async_polling": true` AND `"async_max_wait_ms": <int64>` IFF `e.apiClient.asyncPollingEnabled == true`. When the flag is false, NEITHER key is emitted (D-22).
+    - The value of `async_max_wait_ms` is `int64(e.apiClient.asyncMaxWait / time.Millisecond)` — duration in milliseconds as `int64`, matching the CONTEXT.md D-21 wording.
+    - `NewTwelveLabsEmbeddingFunctionFromConfig` reads `async_polling` (expected type `bool`) and `async_max_wait_ms` (expected type `int64` for round-trip, but also accept `float64` since Go's `encoding/json` decodes numeric JSON into `interface{}` as `float64` — YAML/TOML registries may give int64 or int).
+    - If `async_polling == true` and `async_max_wait_ms` is present → append `WithAsyncPolling(time.Duration(ms) * time.Millisecond)`.
+    - If `async_polling == true` and `async_max_wait_ms` is missing → fallback to `WithAsyncPolling(0)` (reapplies the 30-min default) — defensive; should not happen with a well-formed round-trip.
+    - If `async_polling` is missing or false → do NOT append WithAsyncPolling (D-23).
+    - Type-assertion failures on either key → silently skip (do not surface as hard errors; existing from-config convention is permissive).
+  </behavior>
+  <action>
+    Edit `pkg/embeddings/twelvelabs/twelvelabs.go`:
+
+    1. In `GetConfig` (after the existing conditional `Insecure` emission block, before `return cfg`), append:
+
+    ```go
+    if e.apiClient.asyncPollingEnabled {
+        cfg["async_polling"] = true
+        cfg["async_max_wait_ms"] = e.apiClient.asyncMaxWait.Milliseconds() // int64
+    }
+    ```
+
+    Note: `time.Duration.Milliseconds()` returns `int64` — use it (cleaner than manual division).
+
+    2. In `NewTwelveLabsEmbeddingFunctionFromConfig` (after the existing `audio_embedding_option` block, before the final `return`), append:
+
+    ```go
+    if enabled, ok := cfg["async_polling"].(bool); ok && enabled {
+        var maxWait time.Duration
+        // Registries commonly decode JSON numbers as float64; accept int64 and int too.
+        switch v := cfg["async_max_wait_ms"].(type) {
+        case int64:
+            maxWait = time.Duration(v) * time.Millisecond
+        case int:
+            maxWait = time.Duration(v) * time.Millisecond
+        case float64:
+            maxWait = time.Duration(int64(v)) * time.Millisecond
+        }
+        opts = append(opts, WithAsyncPolling(maxWait))
+    }
+    ```
+
+    Confirm `"time"` is imported (it will be after Plan 01 added it in Task 1 — verify the import block).
+
+    Run `make lint`.
+  </action>
+  <verify>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'cfg\["async_polling"\] = true' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'async_max_wait_ms' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncMaxWait.Milliseconds()' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'cfg\["async_polling"\]\.(bool)' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'WithAsyncPolling(maxWait)' pkg/embeddings/twelvelabs/twelvelabs.go && go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/... && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -q 'cfg\["async_polling"\] = true' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'cfg\["async_max_wait_ms"\] = e.apiClient.asyncMaxWait.Milliseconds()' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'cfg\["async_polling"\]\.(bool)' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'WithAsyncPolling(maxWait)' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'async_max_wait_ms' pkg/embeddings/twelvelabs/twelvelabs.go` matches at least twice (emit + read).
+    - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `make lint` exits 0.
+    - `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` exits 0 — existing tests unchanged (no client in the test suite has `asyncPollingEnabled=true` yet; the default path continues to emit the same keys as before).
+  </acceptance_criteria>
+  <done>Config round-trip keys emit when enabled, omit when disabled, and FromConfig reconstructs the option. Ready for Plan 04 to verify with the config-round-trip test.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| caller → WithAsyncPolling | User-supplied `maxWait time.Duration` — untrusted input. |
+| saved config → FromConfig | Config map may come from persistent storage; types on reload can differ from types at save (JSON round-trip coerces int64 → float64). |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-26-11 | T (Tampering) | negative maxWait | mitigate | `WithAsyncPolling` rejects `maxWait < 0` with an explicit error. Prevents silent acceptance of a duration that would produce an immediately-expired deadline and a confusing maxWait-exceeded error on the first poll. |
+| T-26-12 | D (Denial of Service) | missing maxWait | mitigate | `maxWait == 0` selects 30-min default per D-03. A caller using `Collection.Add(context.Background(), ...)` can't accidentally block for 4 hours. |
+| T-26-13 | T (Tampering) | config type mismatch on reload | mitigate | FromConfig accepts `int64`, `int`, and `float64` for `async_max_wait_ms` to handle registries that round-trip numerics through JSON (`encoding/json` decodes into `float64`). Silently skips on unknown types rather than crashing. |
+| T-26-14 | I (Information Disclosure) | config leakage | accept | The async keys contain a boolean and an integer millisecond value — no secrets, no PII, no sensitive data. Safe to persist in registries. |
+</threat_model>
+
+<verification>
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` passes.
+- `make lint` passes.
+- Existing `TestTwelveLabs*` suite exits 0.
+- All grep acceptance criteria match.
+</verification>
+
+<success_criteria>
+A user can write `NewTwelveLabsEmbeddingFunction(WithAPIKey("..."), WithAsyncPolling(5*time.Minute))` and get an EF with `asyncPollingEnabled=true` and `asyncMaxWait=5m`. Calling `GetConfig()` on that EF emits both keys; calling `NewTwelveLabsEmbeddingFunctionFromConfig()` on that map produces an equivalent EF. An EF constructed without `WithAsyncPolling` emits neither key (D-22) and round-trips cleanly. Plan 04 can now add tests.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/26-twelve-labs-async-embedding/26-03-SUMMARY.md`.
+</output>

--- a/.planning/phases/26-twelve-labs-async-embedding/26-03-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-03-PLAN.md
@@ -17,7 +17,8 @@ must_haves:
     - "Passing maxWait=0 selects the 30-minute default per D-03."
     - "Passing maxWait<0 returns a validation error instead of panicking or silently accepting."
     - "GetConfig emits async_polling:true and async_max_wait_ms:<int64 ms> iff asyncPollingEnabled is true (D-21, D-22)."
-    - "NewTwelveLabsEmbeddingFunctionFromConfig reads async_polling + async_max_wait_ms and reconstructs WithAsyncPolling; missing keys leave the flag off (D-23)."
+    - "NewTwelveLabsEmbeddingFunctionFromConfig reads async_polling + async_max_wait_ms via embeddings.ConfigInt and reconstructs WithAsyncPolling; missing keys leave the flag off (D-23)."
+    - "Malformed async_max_wait_ms with async_polling=true does NOT silently fall back to WithAsyncPolling(0); the flag stays off rather than enabling a 30-minute default on broken config."
     - "Config round-trip is lossless: build → GetConfig → FromConfig produces a client with identical asyncPollingEnabled and asyncMaxWait."
   artifacts:
     - path: "pkg/embeddings/twelvelabs/option.go"
@@ -157,17 +158,20 @@ func WithAudioEmbeddingOption(opt string) Option {
   <files>pkg/embeddings/twelvelabs/twelvelabs.go</files>
   <read_first>
     - pkg/embeddings/twelvelabs/twelvelabs.go (existing `GetConfig` ~line 269 and `NewTwelveLabsEmbeddingFunctionFromConfig` ~line 289 — follow the existing key-emission pattern)
+    - pkg/embeddings/embedding.go (lines 672-688 — the `embeddings.ConfigInt(cfg, key) (int, bool)` helper that handles int/int64/float64 uniformly; use this instead of reimplementing numeric parsing)
     - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-21, D-22, D-23)
     - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pitfall 6 for round-trip idempotence — emit int64 ms, omit when flag off)
   </read_first>
   <behavior>
     - `GetConfig` emits `"async_polling": true` AND `"async_max_wait_ms": <int64>` IFF `e.apiClient.asyncPollingEnabled == true`. When the flag is false, NEITHER key is emitted (D-22).
-    - The value of `async_max_wait_ms` is `int64(e.apiClient.asyncMaxWait / time.Millisecond)` — duration in milliseconds as `int64`, matching the CONTEXT.md D-21 wording.
-    - `NewTwelveLabsEmbeddingFunctionFromConfig` reads `async_polling` (expected type `bool`) and `async_max_wait_ms` (expected type `int64` for round-trip, but also accept `float64` since Go's `encoding/json` decodes numeric JSON into `interface{}` as `float64` — YAML/TOML registries may give int64 or int).
-    - If `async_polling == true` and `async_max_wait_ms` is present → append `WithAsyncPolling(time.Duration(ms) * time.Millisecond)`.
-    - If `async_polling == true` and `async_max_wait_ms` is missing → fallback to `WithAsyncPolling(0)` (reapplies the 30-min default) — defensive; should not happen with a well-formed round-trip.
-    - If `async_polling` is missing or false → do NOT append WithAsyncPolling (D-23).
-    - Type-assertion failures on either key → silently skip (do not surface as hard errors; existing from-config convention is permissive).
+    - The value of `async_max_wait_ms` is `e.apiClient.asyncMaxWait.Milliseconds()` (int64) — matches CONTEXT.md D-21.
+    - `NewTwelveLabsEmbeddingFunctionFromConfig` reads `async_polling` (expected type `bool`). The `async_max_wait_ms` value is parsed via the existing helper `embeddings.ConfigInt(cfg, "async_max_wait_ms")` at `pkg/embeddings/embedding.go:674` (handles int / int64 / float64 uniformly — do NOT reimplement the switch).
+    - **Distinguish missing key from malformed value (review fix):**
+      - `async_polling` missing entirely → do nothing (async stays off).
+      - `async_polling` present but NOT a bool (e.g., `"true"` string) → do nothing (async stays off). Wrong type is treated as "do not enable" rather than defaulting on.
+      - `async_polling == true` AND `async_max_wait_ms` missing or malformed (ConfigInt returns `ok=false`) → do nothing. Do NOT call `WithAsyncPolling(0)` on malformed input, because that would silently enable async with the 30-minute default despite the caller providing a non-parseable value. A missing-AND-flag-on config is a broken round-trip; we err on the side of not enabling.
+      - `async_polling == true` AND `async_max_wait_ms` parses via `ConfigInt` with a non-negative value → append `WithAsyncPolling(time.Duration(ms) * time.Millisecond)`.
+      - `async_polling` false → do NOT append WithAsyncPolling (D-23).
   </behavior>
   <action>
     Edit `pkg/embeddings/twelvelabs/twelvelabs.go`:
@@ -183,36 +187,35 @@ func WithAudioEmbeddingOption(opt string) Option {
 
     Note: `time.Duration.Milliseconds()` returns `int64` — use it (cleaner than manual division).
 
-    2. In `NewTwelveLabsEmbeddingFunctionFromConfig` (after the existing `audio_embedding_option` block, before the final `return`), append:
+    2. In `NewTwelveLabsEmbeddingFunctionFromConfig` (after the existing `audio_embedding_option` block, before the final `return`), append — using the existing `embeddings.ConfigInt` helper so numeric-type handling is consistent with the rest of the package:
 
     ```go
+    // Only enable async when BOTH keys are present and parseable. A missing or
+    // malformed async_max_wait_ms with async_polling=true is treated as a broken
+    // round-trip — we deliberately do NOT fall back to WithAsyncPolling(0) (the
+    // 30-minute default) because that would silently enable a 30-minute blocking
+    // bound on config the caller didn't specify. Missing key → not enabled.
     if enabled, ok := cfg["async_polling"].(bool); ok && enabled {
-        var maxWait time.Duration
-        // Registries commonly decode JSON numbers as float64; accept int64 and int too.
-        switch v := cfg["async_max_wait_ms"].(type) {
-        case int64:
-            maxWait = time.Duration(v) * time.Millisecond
-        case int:
-            maxWait = time.Duration(v) * time.Millisecond
-        case float64:
-            maxWait = time.Duration(int64(v)) * time.Millisecond
+        if ms, ok := embeddings.ConfigInt(cfg, "async_max_wait_ms"); ok && ms >= 0 {
+            opts = append(opts, WithAsyncPolling(time.Duration(ms)*time.Millisecond))
         }
-        opts = append(opts, WithAsyncPolling(maxWait))
     }
     ```
 
-    Confirm `"time"` is imported (it will be after Plan 01 added it in Task 1 — verify the import block).
+    Confirm `"time"` is imported (it will be after Plan 01 added it in Task 1 — verify the import block). `embeddings.ConfigInt` is already accessible — this file already imports the `embeddings` package.
 
     Run `make lint`.
   </action>
   <verify>
-    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'cfg\["async_polling"\] = true' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'async_max_wait_ms' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncMaxWait.Milliseconds()' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'cfg\["async_polling"\]\.(bool)' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'WithAsyncPolling(maxWait)' pkg/embeddings/twelvelabs/twelvelabs.go && go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/... && echo OK</automated>
+    <automated>go build -tags=ef ./pkg/embeddings/twelvelabs/... && grep -q 'cfg\["async_polling"\] = true' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'async_max_wait_ms' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'asyncMaxWait.Milliseconds()' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'cfg\["async_polling"\]\.(bool)' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'embeddings.ConfigInt(cfg, "async_max_wait_ms")' pkg/embeddings/twelvelabs/twelvelabs.go && grep -q 'WithAsyncPolling(time.Duration(ms)' pkg/embeddings/twelvelabs/twelvelabs.go && go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/... && echo OK</automated>
   </verify>
   <acceptance_criteria>
     - `grep -q 'cfg\["async_polling"\] = true' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
     - `grep -q 'cfg\["async_max_wait_ms"\] = e.apiClient.asyncMaxWait.Milliseconds()' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
     - `grep -q 'cfg\["async_polling"\]\.(bool)' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
-    - `grep -q 'WithAsyncPolling(maxWait)' pkg/embeddings/twelvelabs/twelvelabs.go` matches.
+    - `grep -q 'embeddings.ConfigInt(cfg, "async_max_wait_ms")' pkg/embeddings/twelvelabs/twelvelabs.go` matches — FromConfig uses the existing shared numeric-parse helper (not a reimplemented switch).
+    - `grep -q 'WithAsyncPolling(time.Duration(ms)' pkg/embeddings/twelvelabs/twelvelabs.go` matches — WithAsyncPolling is only called when ConfigInt returned ok (no silent fallback to WithAsyncPolling(0) on malformed input).
+    - `! grep -q 'WithAsyncPolling(maxWait)' pkg/embeddings/twelvelabs/twelvelabs.go` — the old `WithAsyncPolling(maxWait)` sample (which enabled async with 30-min default on malformed input) must not appear.
     - `grep -q 'async_max_wait_ms' pkg/embeddings/twelvelabs/twelvelabs.go` matches at least twice (emit + read).
     - `go build -tags=ef ./pkg/embeddings/twelvelabs/...` exits 0.
     - `make lint` exits 0.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-03-SUMMARY.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-03-SUMMARY.md
@@ -1,0 +1,129 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 03
+subsystem: embeddings
+tags: [twelvelabs, embeddings, async, options, config-roundtrip]
+
+# Dependency graph
+requires:
+  - phase: 26-twelve-labs-async-embedding
+    provides: asyncPollingEnabled / asyncMaxWait fields on TwelveLabsClient (Plan 26-01)
+provides:
+  - WithAsyncPolling(maxWait time.Duration) Option — sole public async trigger (D-03, D-04)
+  - Negative maxWait rejected with "maxWait cannot be negative" error
+  - maxWait=0 selects 30-minute default
+  - GetConfig emits async_polling + async_max_wait_ms iff asyncPollingEnabled (D-21, D-22)
+  - NewTwelveLabsEmbeddingFunctionFromConfig round-trip via embeddings.ConfigInt (D-23)
+  - Malformed async_max_wait_ms with async_polling=true → async stays off (no silent 30-min default)
+affects: [26-04-content-routing-and-tests]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Functional Option that validates input and sets internal fields on the client (follows existing WithAudioEmbeddingOption pattern)"
+    - "Conditional config emission — async keys are omitted entirely when the feature is off so default-config round-trips stay byte-identical"
+    - "Missing-key-OR-malformed-value → do not enable feature (avoids silent 30-minute default when caller supplied broken input)"
+    - "Reuse shared embeddings.ConfigInt helper for numeric-type coercion across int / int64 / float64"
+
+key-files:
+  created: []
+  modified:
+    - pkg/embeddings/twelvelabs/option.go
+    - pkg/embeddings/twelvelabs/twelvelabs.go
+
+key-decisions:
+  - "Reject negative maxWait in WithAsyncPolling with errors.New instead of clamping — matches existing option validation style (WithAPIKey, WithModel) and prevents immediately-expired deadlines that would surface as confusing maxWait-exceeded errors on first poll."
+  - "Emit async_max_wait_ms using time.Duration.Milliseconds() which returns int64 directly — cleaner than manual division and matches CONTEXT D-21."
+  - "Treat malformed async_max_wait_ms with async_polling=true as a broken round-trip and leave async OFF rather than falling back to WithAsyncPolling(0) — the 30-minute default is a caller-opt-in value, not a fallback for bad data. Silent fallback would mask registry corruption."
+  - "Did NOT remove //nolint:unused from asyncPollingEnabled / asyncMaxWait in twelvelabs.go — the linter accepts the current state; Plan 26-02's polling loop consumes these fields directly, so the annotation will naturally drop when Plan 26-02 lands rather than churn twice."
+  - "Reused embeddings.ConfigInt at pkg/embeddings/embedding.go:674 instead of reimplementing a type switch — this helper already handles int/int64/float64 coercion for JSON round-trips (Pitfall 6)."
+
+patterns-established:
+  - "Option validates + sets client field directly; no allocation, no side-channel state"
+  - "Config emit-iff-enabled, read-iff-both-keys-valid, skip on missing-or-malformed"
+
+requirements-completed: [TLA-03]
+
+# Metrics
+duration: ~2min
+completed: 2026-04-14
+---
+
+# Phase 26 Plan 03: Async Option + Config Round-Trip Summary
+
+**Single public async trigger `WithAsyncPolling(maxWait)` plus lossless config round-trip via `async_polling` / `async_max_wait_ms` keys — the only user-visible surface Phase 26 exposes, wired without touching Plan 26-01's foundation fields or Plan 26-02's polling surface.**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-04-14T09:30:01Z
+- **Completed:** 2026-04-14T09:31:35Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+
+- `WithAsyncPolling(time.Duration)` added to `option.go` as the sole public trigger for async (D-03, D-04). Negative input → explicit validation error. Zero → 30-minute default. Positive → verbatim.
+- `GetConfig` now emits `async_polling: true` and `async_max_wait_ms: <int64 ms>` together, but only when the feature is enabled — non-opt-in callers see byte-identical configs to the pre-Phase-26 state (D-22).
+- `NewTwelveLabsEmbeddingFunctionFromConfig` reconstructs `WithAsyncPolling(maxWait)` from the two keys using the existing `embeddings.ConfigInt` helper so int / int64 / float64 all coerce correctly across a JSON round-trip (D-23).
+- Malformed `async_max_wait_ms` with `async_polling=true` deliberately leaves async OFF instead of falling back to `WithAsyncPolling(0)` — the 30-minute default is an opt-in value, not a recovery path for broken config.
+
+## Task Commits
+
+1. **Task 1: Add WithAsyncPolling option** — `4f24085` (feat)
+2. **Task 2: Wire async config keys into GetConfig and FromConfig** — `83e2e8e` (feat)
+
+## Files Created/Modified
+
+- `pkg/embeddings/twelvelabs/option.go` — added `"time"` import; appended `WithAsyncPolling` (20 lines).
+- `pkg/embeddings/twelvelabs/twelvelabs.go` — `GetConfig` appends two keys when `asyncPollingEnabled`; `NewTwelveLabsEmbeddingFunctionFromConfig` appends `WithAsyncPolling(ms)` when both keys parse cleanly (14 lines).
+
+## Decisions Made
+
+- Validated the `embeddings.ConfigInt` helper already exists at `pkg/embeddings/embedding.go:674` before following the plan's instruction to use it — confirmed the signature `(int, bool)` and that it handles `int`, `int64`, and `float64` cases. No need to reimplement numeric parsing.
+- Kept the `//nolint:unused` pragmas on the polling fields in Plan 26-01 because the linter is satisfied (0 issues). Plan 26-02's polling loop will consume the fields directly; removing the pragmas now would just re-churn them.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. All grep acceptance criteria matched on first run, build green, lint green, existing `TestTwelveLabs*` suite green.
+
+## Issues Encountered
+
+- PreToolUse read-before-edit hook fired after each Edit call despite the file being read in-session. Edits succeeded regardless; no workaround required.
+
+## User Setup Required
+
+None — no env-var or external service changes in this plan.
+
+## Next Phase Readiness
+
+- **Plan 26-04 (tests + content routing)** can now:
+  - Construct EFs with `WithAsyncPolling(5*time.Minute)` and assert `asyncPollingEnabled==true` / `asyncMaxWait==5m`.
+  - Assert `WithAsyncPolling(-1*time.Second)` returns `"maxWait cannot be negative"`.
+  - Assert `WithAsyncPolling(0)` sets `asyncMaxWait == 30*time.Minute`.
+  - Round-trip a config map: build → `GetConfig()` → `NewTwelveLabsEmbeddingFunctionFromConfig()` → compare `asyncPollingEnabled` and `asyncMaxWait`.
+  - Assert a config with `async_polling=true` but `async_max_wait_ms="not a number"` produces an EF with `asyncPollingEnabled==false`.
+  - Assert `GetConfig()` on a default (non-async) EF emits neither key.
+- No blocking dependency on Plan 26-02; these plans touched disjoint surfaces (option.go + GetConfig/FromConfig here vs. twelvelabs_async.go + content.go there).
+
+## Verification Log
+
+- `go build ./pkg/embeddings/twelvelabs/...` — exit 0
+- `go build -tags=ef ./pkg/embeddings/twelvelabs/...` — exit 0
+- `go vet -tags=ef ./pkg/embeddings/twelvelabs/...` — exit 0
+- `make lint` — 0 issues
+- `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` — ok (0.510s)
+- `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` — ok (0.309s)
+- All 8 grep acceptance criteria (Task 1: 4, Task 2: 7 positive + 1 negative `!grep`) matched.
+
+## Self-Check: PASSED
+
+- File `pkg/embeddings/twelvelabs/option.go` exists and contains `func WithAsyncPolling(maxWait time.Duration) Option`, `"maxWait cannot be negative"`, `30 * time.Minute`, `asyncPollingEnabled = true`.
+- File `pkg/embeddings/twelvelabs/twelvelabs.go` exists and contains `cfg["async_polling"] = true`, `asyncMaxWait.Milliseconds()`, `cfg["async_polling"].(bool)`, `embeddings.ConfigInt(cfg, "async_max_wait_ms")`, `WithAsyncPolling(time.Duration(ms)`.
+- Commit `4f24085` present in `git log`.
+- Commit `83e2e8e` present in `git log`.
+
+---
+*Phase: 26-twelve-labs-async-embedding*
+*Completed: 2026-04-14*

--- a/.planning/phases/26-twelve-labs-async-embedding/26-04-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-04-PLAN.md
@@ -1,0 +1,460 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 04
+type: execute
+wave: 3
+depends_on: [26-01, 26-02, 26-03]
+files_modified:
+  - pkg/embeddings/twelvelabs/twelvelabs_test.go
+autonomous: true
+requirements: [TLA-04]
+tags: [twelvelabs, embeddings, async, testing]
+
+must_haves:
+  truths:
+    - "Every D-26 flow has at least one dedicated test: task-create, poll-to-ready, poll-to-failed, ctx-cancel, maxWait-expiry, config-round-trip."
+    - "newTestEF (or a sibling newTestAsyncEF) enables async and sets ms-scale polling fields so tests run in <5s (D-24)."
+    - "Mock server fixtures emit `_id` (not `id`) in task responses to catch the Pitfall 1 alias gotcha."
+    - "TestTwelveLabsAsyncCtxCancel asserts errors.Is(err, context.Canceled) (or Cause-chain equivalent) — proves D-10/D-19."
+    - "TestTwelveLabsAsyncMaxWait asserts the error message contains 'async polling maxWait' AND is NOT context.DeadlineExceeded — proves D-20."
+    - "TestTwelveLabsAsyncSkipsTextImage proves text/image never call the tasks endpoint even when opt-in is on — proves D-07."
+    - "TestTwelveLabsAsyncConfigRoundTrip builds an EF with WithAsyncPolling, calls GetConfig, rebuilds via FromConfig, and asserts the rebuilt client has the same asyncPollingEnabled and asyncMaxWait."
+  artifacts:
+    - path: "pkg/embeddings/twelvelabs/twelvelabs_test.go"
+      provides: "Seven new async-focused tests under the existing `ef` build tag"
+      contains: "TestTwelveLabsAsync"
+  key_links:
+    - from: "tests"
+      to: "httptest.Server with attempt counter"
+      via: "deterministic polling fixtures"
+      pattern: "atomic.Int32"
+    - from: "tests"
+      to: "ms-scale polling fields"
+      via: "direct TwelveLabsClient field override"
+      pattern: "asyncPollInitial.*time.Millisecond"
+---
+
+<objective>
+Land TLA-04 coverage. Add seven tests under the existing `ef` build tag in `pkg/embeddings/twelvelabs/twelvelabs_test.go` exercising every D-26 flow plus the routing rule D-07 and the config round-trip D-23. Extend `newTestEF` (or add a sibling helper) so tests can enable async with ms-scale polling intervals, satisfying D-24 and keeping runtime under ~5 seconds. Use `httptest.Server` with an `atomic.Int32` attempt counter and emit `_id` (not `id`) in every task-response fixture to catch the Pitfall 1 footgun if it ever regresses.
+
+Purpose: The phase is shippable only when every required flow has an automated test. This plan closes TLA-04 and populates the Per-Task Verification Map in `26-VALIDATION.md`.
+
+Output: Seven new test functions, all green. `make test-ef` passes. `26-VALIDATION.md` Per-Task Verification Map filled in.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+@.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
+@.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
+@pkg/embeddings/twelvelabs/twelvelabs_test.go
+@pkg/embeddings/twelvelabs/twelvelabs.go
+@pkg/embeddings/twelvelabs/content.go
+@pkg/embeddings/twelvelabs/option.go
+@pkg/embeddings/twelvelabs/twelvelabs_async.go
+@CLAUDE.md
+
+<interfaces>
+<!-- From Plans 01/02/03: -->
+```go
+// Fields on TwelveLabsClient (unexported — same package, directly settable in tests):
+asyncPollingEnabled bool
+asyncMaxWait        time.Duration
+asyncPollInitial    time.Duration // default 2s — override to ms in tests
+asyncPollMultiplier float64       // default 1.5
+asyncPollCap        time.Duration // default 60s — override to ms in tests
+
+// Types to drive fixtures:
+type TaskCreateResponse struct { ID string `json:"_id"`; Status string `json:"status"`; Data []EmbedV2DataItem `json:"data,omitempty"` }
+type TaskResponse       struct { ID string `json:"_id"`; Status string `json:"status"`; Data []EmbedV2DataItem `json:"data,omitempty"` }
+
+// Option:
+func WithAsyncPolling(maxWait time.Duration) Option
+
+// Public embed methods to drive via content:
+func (e *TwelveLabsEmbeddingFunction) EmbedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error)
+
+// Content shape (from embeddings package):
+embeddings.Content{Parts: []embeddings.ContentPart{{Modality: embeddings.ModalityAudio, Source: &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/a.mp4"}}}}
+```
+
+<!-- Existing test helpers (do not break): -->
+```go
+// From twelvelabs_test.go:
+func newTestEF(serverURL string) *TwelveLabsEmbeddingFunction
+func newMockServer(t *testing.T, handler http.HandlerFunc) *httptest.Server
+func embedV2Response(embedding []float64) string
+func make512DimVector() []float64
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Add test helpers and four async behavior tests (create, poll-to-ready, poll-to-failed, unexpected-status)</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs_test.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs_test.go (full file — reuse `newTestEF`, `newMockServer`, `make512DimVector`)
+    - pkg/embeddings/twelvelabs/twelvelabs_async.go (confirm pollTask internal behavior)
+    - pkg/embeddings/twelvelabs/content.go (routing rule)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-24, D-26, D-27)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Validation Architecture section — fixture sketches)
+  </read_first>
+  <behavior>
+    - New helper `newTestAsyncEF(serverURL)` returns a `*TwelveLabsEmbeddingFunction` with: `asyncPollingEnabled=true`, `asyncMaxWait=5*time.Second`, `asyncPollInitial=1*time.Millisecond`, `asyncPollMultiplier=1.5`, `asyncPollCap=10*time.Millisecond`. Built by composition on `newTestEF` so changes to the sync helper propagate.
+    - New helper `audioContent(url)` returns a minimal `embeddings.Content` with a single audio URL part.
+    - `TestTwelveLabsAsyncTaskCreate`: mock server asserts `POST /tasks` was hit exactly once, `req.InputType == "audio"`, `req.Audio.EmbeddingOption == []string{"audio"}` (list shape!), responds with `_id: "task_abc", status: "processing"` on POST; responds with `_id: "task_abc", status: "ready", data: [{embedding: [...]}]` on the first GET. Embed returns a non-empty embedding. Attempt counter proves both endpoints were hit.
+    - `TestTwelveLabsAsyncPollToReady`: mock server returns `status: "processing"` on GETs 1-2, `status: "ready"` with `data` on GET 3. Assert `attempts == 4` total (1 POST + 3 GETs) and embedding is correct.
+    - `TestTwelveLabsAsyncPollToFailed`: mock server returns `status: "processing"` on GET 1, `status: "failed"` on GET 2. Assert returned error contains `"task [task_abc]"`, `"terminal status=failed"`, and the error is non-nil. Assert the error is NOT wrapped with `context.Canceled` or `context.DeadlineExceeded`.
+    - `TestTwelveLabsAsyncUnexpectedStatus`: mock server returns `status: "weird"`. Assert error contains `"unexpected status"` and `"weird"` and `"task_abc"`.
+  </behavior>
+  <action>
+    Append to `pkg/embeddings/twelvelabs/twelvelabs_test.go` (under the existing `//go:build ef` tag). Required new imports: `sync/atomic`, `time`, `context` (already there), `github.com/pkg/errors` (only if needed for `errors.Is`).
+
+    ```go
+    func newTestAsyncEF(serverURL string) *TwelveLabsEmbeddingFunction {
+        ef := newTestEF(serverURL)
+        ef.apiClient.asyncPollingEnabled = true
+        ef.apiClient.asyncMaxWait = 5 * time.Second
+        ef.apiClient.asyncPollInitial = 1 * time.Millisecond
+        ef.apiClient.asyncPollMultiplier = 1.5
+        ef.apiClient.asyncPollCap = 10 * time.Millisecond
+        return ef
+    }
+
+    func audioContent(url string) embeddings.Content {
+        return embeddings.Content{Parts: []embeddings.ContentPart{{
+            Modality: embeddings.ModalityAudio,
+            Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
+        }}}
+    }
+
+    func videoContent(url string) embeddings.Content {
+        return embeddings.Content{Parts: []embeddings.ContentPart{{
+            Modality: embeddings.ModalityVideo,
+            Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
+        }}}
+    }
+
+    // taskCreateJSON and taskGetJSON produce fixtures with the _id alias (Pitfall 1).
+    func taskCreateJSON(id, status string) string {
+        return fmt.Sprintf(`{"_id":%q,"status":%q}`, id, status)
+    }
+    func taskGetJSON(id, status string, data []float64) string {
+        if data == nil {
+            return fmt.Sprintf(`{"_id":%q,"status":%q}`, id, status)
+        }
+        b, _ := json.Marshal(data)
+        return fmt.Sprintf(`{"_id":%q,"status":%q,"data":[{"embedding":%s}]}`, id, status, b)
+    }
+
+    func TestTwelveLabsAsyncTaskCreate(t *testing.T) {
+        vec := make512DimVector()
+        var attempts atomic.Int32
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            attempts.Add(1)
+            w.Header().Set("Content-Type", "application/json")
+            switch {
+            case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tasks"):
+                var req AsyncEmbedV2Request
+                require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+                assert.Equal(t, "audio", req.InputType)
+                require.NotNil(t, req.Audio)
+                assert.Equal(t, []string{"audio"}, req.Audio.EmbeddingOption, "async endpoint requires embedding_option as []string (F-02)")
+                fmt.Fprint(w, taskCreateJSON("task_abc", "processing"))
+            case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/task_abc"):
+                fmt.Fprint(w, taskGetJSON("task_abc", "ready", vec))
+            default:
+                t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+            }
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+        require.NoError(t, err)
+        require.NotNil(t, emb)
+        assert.Equal(t, 512, emb.Len())
+        assert.GreaterOrEqual(t, attempts.Load(), int32(2), "expected at least 1 POST + 1 GET")
+    }
+
+    func TestTwelveLabsAsyncPollToReady(t *testing.T) {
+        vec := make512DimVector()
+        var gets atomic.Int32
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_ready", "processing"))
+                return
+            }
+            n := gets.Add(1)
+            if n < 3 {
+                fmt.Fprint(w, taskGetJSON("task_ready", "processing", nil))
+                return
+            }
+            fmt.Fprint(w, taskGetJSON("task_ready", "ready", vec))
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        emb, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+        require.NoError(t, err)
+        require.NotNil(t, emb)
+        assert.Equal(t, 512, emb.Len())
+        assert.Equal(t, int32(3), gets.Load(), "expected 3 GETs before ready")
+    }
+
+    func TestTwelveLabsAsyncPollToFailed(t *testing.T) {
+        var gets atomic.Int32
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_fail", "processing"))
+                return
+            }
+            n := gets.Add(1)
+            if n < 2 {
+                fmt.Fprint(w, taskGetJSON("task_fail", "processing", nil))
+                return
+            }
+            fmt.Fprint(w, taskGetJSON("task_fail", "failed", nil))
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+        require.Error(t, err)
+        assert.Nil(t, emb)
+        assert.Contains(t, err.Error(), "task_fail")
+        assert.Contains(t, err.Error(), "terminal status=failed")
+        assert.False(t, errors.Is(err, context.Canceled))
+        assert.False(t, errors.Is(err, context.DeadlineExceeded))
+    }
+
+    func TestTwelveLabsAsyncUnexpectedStatus(t *testing.T) {
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_weird", "processing"))
+                return
+            }
+            fmt.Fprint(w, taskGetJSON("task_weird", "weird", nil))
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        _, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+        require.Error(t, err)
+        assert.Contains(t, err.Error(), "unexpected status")
+        assert.Contains(t, err.Error(), "weird")
+        assert.Contains(t, err.Error(), "task_weird")
+    }
+    ```
+
+    NOTE on `errors.Is` vs `pkg/errors`: the package uses `github.com/pkg/errors`. For assertion, use stdlib `"errors"` package with `errors.Is` — `pkg/errors.Wrap` makes the wrapped value reachable via `errors.Is` from stdlib since Go 1.13. Import stdlib `"errors"` with an alias or qualified path if both are needed in the test file.
+
+    Run `make lint` and `go test -tags=ef -count=1 -run TestTwelveLabsAsync ./pkg/embeddings/twelvelabs/...` — all four tests must pass.
+  </action>
+  <verify>
+    <automated>go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(TaskCreate|PollToReady|PollToFailed|UnexpectedStatus)$' ./pkg/embeddings/twelvelabs/... && grep -q 'func newTestAsyncEF' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncTaskCreate' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncPollToReady' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncPollToFailed' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncUnexpectedStatus' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q '_id' pkg/embeddings/twelvelabs/twelvelabs_test.go && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(TaskCreate|PollToReady|PollToFailed|UnexpectedStatus)$' ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `grep -q 'func newTestAsyncEF' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncTaskCreate' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncPollToReady' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncPollToFailed' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncUnexpectedStatus' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -c '_id' pkg/embeddings/twelvelabs/twelvelabs_test.go` >= 4 — fixtures emit `_id`, not `id`.
+    - Total test runtime for these four tests < 3 seconds (sampling check, not a hard gate).
+    - `make lint` exits 0.
+  </acceptance_criteria>
+  <done>Core async flows (create, poll-to-ready, poll-to-failed, unexpected-status) covered and green.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Add ctx-cancel, maxWait-expiry, text/image-skip, and config-round-trip tests</name>
+  <files>pkg/embeddings/twelvelabs/twelvelabs_test.go</files>
+  <read_first>
+    - pkg/embeddings/twelvelabs/twelvelabs_test.go (the four tests just added in Task 1 — mirror the fixture pattern)
+    - .planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md (D-07, D-20, D-22, D-23)
+    - .planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md (Pitfall 3 for maxWait/ctx distinction)
+  </read_first>
+  <behavior>
+    - `TestTwelveLabsAsyncCtxCancel`: after first `processing` poll response, test calls `cancel()`. Assert returned error `errors.Is(err, context.Canceled) == true`. Use a context with `cancel := context.WithCancel(context.Background())` — do NOT use a deadline (keep this test distinct from maxWait).
+    - `TestTwelveLabsAsyncMaxWait`: set `ef.apiClient.asyncMaxWait = 50 * time.Millisecond`, server keeps returning `processing` forever. Use `context.Background()` (no caller deadline). Assert error message contains `"async polling maxWait"` AND `errors.Is(err, context.DeadlineExceeded) == false` — proves D-20's distinct-error requirement.
+    - `TestTwelveLabsAsyncSkipsTextImage`: `asyncPollingEnabled=true`, mock server only responds to `POST /` (sync endpoint) with a valid sync `EmbedV2Response`; if the test ever hits `/tasks`, fail the test. Embed a text content item, assert success. Repeat for image content. Proves D-07 — text/image always take the sync path.
+    - `TestTwelveLabsAsyncConfigRoundTrip`: builds an EF with `WithAPIKey("x")`, `WithAsyncPolling(7*time.Minute)`. Calls `GetConfig()`. Asserts `cfg["async_polling"] == true` and `cfg["async_max_wait_ms"]` is the int64 value `420000` (7 min in ms). Pre-populates `TWELVE_LABS_API_KEY=x` via `t.Setenv` so FromConfig can resolve the env-var-based key, adds `cfg["api_key_env_var"] = "TWELVE_LABS_API_KEY"`, then calls `NewTwelveLabsEmbeddingFunctionFromConfig(cfg)` — asserts no error, asserts the rebuilt EF has `asyncPollingEnabled == true` and `asyncMaxWait == 7*time.Minute`.
+    - Also add a sibling `TestTwelveLabsAsyncConfigOmitWhenDisabled`: EF constructed WITHOUT `WithAsyncPolling`; `cfg` map has NEITHER `async_polling` nor `async_max_wait_ms` keys — proves D-22.
+  </behavior>
+  <action>
+    Append to `pkg/embeddings/twelvelabs/twelvelabs_test.go`:
+
+    ```go
+    func TestTwelveLabsAsyncCtxCancel(t *testing.T) {
+        var gets atomic.Int32
+        cancelCh := make(chan struct{})
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_cancel", "processing"))
+                return
+            }
+            n := gets.Add(1)
+            if n == 1 {
+                close(cancelCh) // signal the test to cancel after the first poll response
+            }
+            fmt.Fprint(w, taskGetJSON("task_cancel", "processing", nil))
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        ef.apiClient.asyncPollInitial = 50 * time.Millisecond // slow enough that cancel wins
+        ef.apiClient.asyncPollCap = 50 * time.Millisecond
+
+        ctx, cancel := context.WithCancel(context.Background())
+        go func() {
+            <-cancelCh
+            cancel()
+        }()
+        _, err := ef.EmbedContent(ctx, audioContent("https://example.com/a.mp3"))
+        require.Error(t, err)
+        assert.True(t, errors.Is(err, context.Canceled), "expected ctx.Canceled wrapping, got %v", err)
+    }
+
+    func TestTwelveLabsAsyncMaxWait(t *testing.T) {
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_maxwait", "processing"))
+                return
+            }
+            fmt.Fprint(w, taskGetJSON("task_maxwait", "processing", nil))
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        ef.apiClient.asyncMaxWait = 50 * time.Millisecond
+
+        _, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+        require.Error(t, err)
+        assert.Contains(t, err.Error(), "async polling maxWait")
+        assert.False(t, errors.Is(err, context.DeadlineExceeded), "maxWait must surface distinct from ctx.DeadlineExceeded (D-20)")
+        assert.False(t, errors.Is(err, context.Canceled))
+    }
+
+    func TestTwelveLabsAsyncSkipsTextImage(t *testing.T) {
+        vec := make512DimVector()
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            if strings.Contains(r.URL.Path, "/tasks") {
+                t.Fatalf("text/image must not hit async endpoint; got %s %s", r.Method, r.URL.Path)
+            }
+            w.Header().Set("Content-Type", "application/json")
+            fmt.Fprint(w, embedV2Response(vec))
+        })
+
+        ef := newTestAsyncEF(srv.URL) // asyncPollingEnabled=true — but text/image skip async per D-07
+
+        // text
+        textContent := embeddings.Content{Parts: []embeddings.ContentPart{{Modality: embeddings.ModalityText, Text: "hello"}}}
+        emb, err := ef.EmbedContent(context.Background(), textContent)
+        require.NoError(t, err)
+        require.NotNil(t, emb)
+
+        // image (URL source)
+        imageContent := embeddings.Content{Parts: []embeddings.ContentPart{{
+            Modality: embeddings.ModalityImage,
+            Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/i.png"},
+        }}}
+        emb2, err := ef.EmbedContent(context.Background(), imageContent)
+        require.NoError(t, err)
+        require.NotNil(t, emb2)
+    }
+
+    func TestTwelveLabsAsyncConfigRoundTrip(t *testing.T) {
+        t.Setenv(APIKeyEnvVar, "round-trip-key")
+        ef, err := NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAsyncPolling(7*time.Minute))
+        require.NoError(t, err)
+
+        cfg := ef.GetConfig()
+        assert.Equal(t, true, cfg["async_polling"])
+        assert.Equal(t, int64(420000), cfg["async_max_wait_ms"], "7 min = 420000 ms as int64")
+
+        rebuilt, err := NewTwelveLabsEmbeddingFunctionFromConfig(cfg)
+        require.NoError(t, err)
+        assert.True(t, rebuilt.apiClient.asyncPollingEnabled)
+        assert.Equal(t, 7*time.Minute, rebuilt.apiClient.asyncMaxWait)
+    }
+
+    func TestTwelveLabsAsyncConfigOmitWhenDisabled(t *testing.T) {
+        t.Setenv(APIKeyEnvVar, "some-key")
+        ef, err := NewTwelveLabsEmbeddingFunction(WithEnvAPIKey())
+        require.NoError(t, err)
+
+        cfg := ef.GetConfig()
+        _, hasPolling := cfg["async_polling"]
+        _, hasWait := cfg["async_max_wait_ms"]
+        assert.False(t, hasPolling, "async_polling must be omitted when WithAsyncPolling is absent (D-22)")
+        assert.False(t, hasWait, "async_max_wait_ms must be omitted when WithAsyncPolling is absent (D-22)")
+    }
+    ```
+
+    Ensure the stdlib `"errors"` package is imported alongside the existing imports. If there's a naming clash with another `errors` import, alias stdlib as `stderrors "errors"` and use `stderrors.Is`.
+
+    Run the full `ef` test suite and confirm everything passes: `make test-ef` (or at minimum `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...`).
+
+    Finally, update `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` — replace the placeholder row in the Per-Task Verification Map with one row per task from Plans 01/02/03/04, each with the correct Automated Command. Check the Wave 0 Requirements boxes, set `nyquist_compliant: true` in frontmatter, and set Approval to "approved". Commit.
+  </action>
+  <verify>
+    <automated>go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(CtxCancel|MaxWait|SkipsTextImage|ConfigRoundTrip|ConfigOmitWhenDisabled)$' ./pkg/embeddings/twelvelabs/... && go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/... && grep -q 'func TestTwelveLabsAsyncCtxCancel' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncSkipsTextImage' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigRoundTrip' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigOmitWhenDisabled' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'nyquist_compliant: true' .planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(CtxCancel|MaxWait|SkipsTextImage|ConfigRoundTrip|ConfigOmitWhenDisabled)$' ./pkg/embeddings/twelvelabs/...` exits 0.
+    - Full `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` exits 0.
+    - `grep -q 'func TestTwelveLabsAsyncCtxCancel' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncSkipsTextImage' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncConfigRoundTrip' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncConfigOmitWhenDisabled' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'errors.Is(err, context.Canceled)' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches (ctx-cancel assertion).
+    - `grep -q 'errors.Is(err, context.DeadlineExceeded)' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — used in MaxWait test as a NEGATIVE assertion (D-20).
+    - `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` Per-Task Verification Map has >= 8 rows (one per task across Plans 01-04).
+    - `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` frontmatter has `nyquist_compliant: true`.
+    - `make lint` exits 0.
+    - Full `make test-ef` run exits 0 (sampling check — may be slower but must be green).
+  </acceptance_criteria>
+  <done>All D-26 flows plus the routing-skip rule and config omit-when-disabled have green tests. VALIDATION.md signed off. TLA-04 closed.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| httptest.Server → test code | Mock server is in-process; no real trust boundary, but fixture shape matters. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-26-15 | T (Tampering) | fixture drift — `id` vs `_id` | mitigate | Every task-response fixture helper (`taskCreateJSON`, `taskGetJSON`) emits `_id`. If production code ever regresses to `json:"id"`, the tests immediately fail because `doTaskGet` hits `/tasks/` (empty path) and returns a 404 — the regression is loud, not silent (Pitfall 1). |
+| T-26-16 | D (Denial of Service) | slow tests | mitigate | ms-scale polling (`asyncPollInitial=1ms`, `asyncPollCap=10ms`) and `asyncMaxWait=50ms` in maxWait test keep the full async suite under ~2s. |
+| T-26-17 | R (Repudiation) | indistinguishable timeout errors | mitigate | `TestTwelveLabsAsyncMaxWait` explicitly asserts `errors.Is(err, context.DeadlineExceeded) == false` — ratchets D-20 into the test suite so a future refactor that collapses the two error paths fails loudly. |
+</threat_model>
+
+<verification>
+- `make test-ef` exits 0 (full `ef`-tag suite including pre-existing tests).
+- All seven new `TestTwelveLabsAsync*` functions pass.
+- `make lint` exits 0.
+- `26-VALIDATION.md` Per-Task Verification Map fully populated; `nyquist_compliant: true`.
+- Total new-test runtime well under 5 seconds (per D-24 intent).
+</verification>
+
+<success_criteria>
+Phase 26 is provably green: every locked decision with observable behavior has a test, every D-26 flow is covered, the most dangerous footguns (missing `_id` alias, ctx/maxWait collapse, text/image incorrectly routed to async) have dedicated guards. Plan is mergeable as a feature-complete PR.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/26-twelve-labs-async-embedding/26-04-SUMMARY.md`.
+</output>

--- a/.planning/phases/26-twelve-labs-async-embedding/26-04-PLAN.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-04-PLAN.md
@@ -18,7 +18,10 @@ must_haves:
     - "TestTwelveLabsAsyncCtxCancel asserts errors.Is(err, context.Canceled) (or Cause-chain equivalent) — proves D-10/D-19."
     - "TestTwelveLabsAsyncMaxWait asserts the error message contains 'async polling maxWait' AND is NOT context.DeadlineExceeded — proves D-20."
     - "TestTwelveLabsAsyncSkipsTextImage proves text/image never call the tasks endpoint even when opt-in is on — proves D-07."
-    - "TestTwelveLabsAsyncConfigRoundTrip builds an EF with WithAsyncPolling, calls GetConfig, rebuilds via FromConfig, and asserts the rebuilt client has the same asyncPollingEnabled and asyncMaxWait."
+    - "TestTwelveLabsAsyncConfigRoundTrip builds an EF with WithAsyncPolling, calls GetConfig, rebuilds via FromConfig, and asserts the rebuilt client has the same asyncPollingEnabled, asyncMaxWait, AND APIKeyEnvVar (registry-reconstructed EF must preserve env-var-based key source)."
+    - "TestTwelveLabsAsyncFailedReasonSanitized proves the failed-task error contains the authentic server-provided reason (from raw response body) sanitized via chttp.SanitizeErrorBody — not a re-marshaled subset of known TaskResponse fields (D-17)."
+    - "TestTwelveLabsAsyncBlockedHTTPMaxWait proves that a blocked (hanging) GET /tasks/{id} cannot outlive maxWait; the derived per-HTTP-call deadline aborts the in-flight request and surfaces the distinct maxWait error (not context.DeadlineExceeded)."
+    - "TestTwelveLabsAsyncFusedRejected proves WithAudioEmbeddingOption(\"fused\") + WithAsyncPolling + audio content returns a deterministic validation error before any HTTP call to /tasks."
   artifacts:
     - path: "pkg/embeddings/twelvelabs/twelvelabs_test.go"
       provides: "Seven new async-focused tests under the existing `ef` build tag"
@@ -79,7 +82,7 @@ func WithAsyncPolling(maxWait time.Duration) Option
 func (e *TwelveLabsEmbeddingFunction) EmbedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error)
 
 // Content shape (from embeddings package):
-embeddings.Content{Parts: []embeddings.ContentPart{{Modality: embeddings.ModalityAudio, Source: &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/a.mp4"}}}}
+embeddings.Content{Parts: []embeddings.Part{{Modality: embeddings.ModalityAudio, Source: &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/a.mp4"}}}}
 ```
 
 <!-- Existing test helpers (do not break): -->
@@ -128,14 +131,14 @@ func make512DimVector() []float64
     }
 
     func audioContent(url string) embeddings.Content {
-        return embeddings.Content{Parts: []embeddings.ContentPart{{
+        return embeddings.Content{Parts: []embeddings.Part{{
             Modality: embeddings.ModalityAudio,
             Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
         }}}
     }
 
     func videoContent(url string) embeddings.Content {
-        return embeddings.Content{Parts: []embeddings.ContentPart{{
+        return embeddings.Content{Parts: []embeddings.Part{{
             Modality: embeddings.ModalityVideo,
             Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
         }}}
@@ -355,13 +358,13 @@ func make512DimVector() []float64
         ef := newTestAsyncEF(srv.URL) // asyncPollingEnabled=true — but text/image skip async per D-07
 
         // text
-        textContent := embeddings.Content{Parts: []embeddings.ContentPart{{Modality: embeddings.ModalityText, Text: "hello"}}}
+        textContent := embeddings.Content{Parts: []embeddings.Part{{Modality: embeddings.ModalityText, Text: "hello"}}}
         emb, err := ef.EmbedContent(context.Background(), textContent)
         require.NoError(t, err)
         require.NotNil(t, emb)
 
         // image (URL source)
-        imageContent := embeddings.Content{Parts: []embeddings.ContentPart{{
+        imageContent := embeddings.Content{Parts: []embeddings.Part{{
             Modality: embeddings.ModalityImage,
             Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/i.png"},
         }}}
@@ -383,6 +386,9 @@ func make512DimVector() []float64
         require.NoError(t, err)
         assert.True(t, rebuilt.apiClient.asyncPollingEnabled)
         assert.Equal(t, 7*time.Minute, rebuilt.apiClient.asyncMaxWait)
+        // APIKeyEnvVar must survive the round-trip so env-var-sourced EFs
+        // rebuilt from a registry still resolve the same way.
+        assert.Equal(t, APIKeyEnvVar, rebuilt.apiClient.APIKeyEnvVar)
     }
 
     func TestTwelveLabsAsyncConfigOmitWhenDisabled(t *testing.T) {
@@ -396,6 +402,90 @@ func make512DimVector() []float64
         assert.False(t, hasPolling, "async_polling must be omitted when WithAsyncPolling is absent (D-22)")
         assert.False(t, hasWait, "async_max_wait_ms must be omitted when WithAsyncPolling is absent (D-22)")
     }
+
+    // TestTwelveLabsAsyncFailedReasonSanitized proves the authentic server
+    // failure reason (from the raw response body, preserved in
+    // TaskResponse.FailureDetail by Plan 01) reaches the error — not a
+    // re-marshaled subset of known fields (D-17 review fix).
+    func TestTwelveLabsAsyncFailedReasonSanitized(t *testing.T) {
+        longReason := strings.Repeat("detailed server-side failure reason — ", 40) // ~1.5KB
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_failreason", "processing"))
+                return
+            }
+            // Respond with an extra server-only reason field NOT in TaskResponse.
+            // If the plan re-marshaled the parsed struct the reason would be lost.
+            fmt.Fprintf(w, `{"_id":"task_failreason","status":"failed","reason":%q,"error":{"code":"E_BAD_MEDIA","detail":%q}}`, longReason, longReason)
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        _, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+        require.Error(t, err)
+        assert.Contains(t, err.Error(), "task_failreason")
+        assert.Contains(t, err.Error(), "terminal status=failed")
+        // Authentic server reason substring must survive sanitization.
+        assert.Contains(t, err.Error(), "detailed server-side failure reason", "error must carry the server-provided reason from the raw body, not just the parsed TaskResponse fields")
+        // Sanitization must still cap the error size.
+        assert.Less(t, len(err.Error()), 4096, "sanitized error body must be truncated to a safe display length")
+    }
+
+    // TestTwelveLabsAsyncBlockedHTTPMaxWait proves the per-HTTP-call deadline
+    // added in Plan 02 actually unblocks an in-flight GET /tasks/{id} when
+    // maxWait fires. Without the per-call deadline, a blocked HTTP call would
+    // hang indefinitely regardless of maxWait (Plan 02 review fix).
+    func TestTwelveLabsAsyncBlockedHTTPMaxWait(t *testing.T) {
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            w.Header().Set("Content-Type", "application/json")
+            if r.Method == http.MethodPost {
+                fmt.Fprint(w, taskCreateJSON("task_block", "processing"))
+                return
+            }
+            // Block until the request's context is canceled by the per-call
+            // deadline. If the plan fails to bound the HTTP call, this select
+            // would block until the server closed and the test would hang until
+            // `go test` timeout — a loud failure.
+            <-r.Context().Done()
+        })
+
+        ef := newTestAsyncEF(srv.URL)
+        ef.apiClient.asyncMaxWait = 100 * time.Millisecond
+
+        start := time.Now()
+        _, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+        elapsed := time.Since(start)
+
+        require.Error(t, err)
+        // The distinct SDK-timeout message must fire, not ctx.DeadlineExceeded —
+        // parent ctx has no deadline, so maxWait is the only bound.
+        assert.Contains(t, err.Error(), "async polling maxWait")
+        assert.False(t, errors.Is(err, context.DeadlineExceeded), "SDK maxWait must not collapse into context.DeadlineExceeded (D-20)")
+        // Sanity-check the upper bound so a regression where maxWait is not
+        // enforced on in-flight HTTP work fails loudly.
+        assert.Less(t, elapsed, 2*time.Second, "maxWait must interrupt the blocked HTTP call; took %s", elapsed)
+    }
+
+    // TestTwelveLabsAsyncFusedRejected proves the async path rejects
+    // WithAudioEmbeddingOption("fused") deterministically (RESEARCH F-02 / A5
+    // review fix). The rejection must happen before any POST /tasks call.
+    func TestTwelveLabsAsyncFusedRejected(t *testing.T) {
+        srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+            t.Fatalf("no HTTP call expected for fused+async; got %s %s", r.Method, r.URL.Path)
+        })
+        _ = srv
+
+        ef := newTestAsyncEF(srv.URL)
+        // Apply the fused audio option by setting the field directly (the
+        // public option setter would also work; direct assignment keeps the
+        // test independent of option ordering).
+        ef.apiClient.AudioEmbeddingOption = "fused"
+
+        _, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+        require.Error(t, err)
+        assert.Contains(t, err.Error(), "fused")
+        assert.Contains(t, err.Error(), "async")
+    }
     ```
 
     Ensure the stdlib `"errors"` package is imported alongside the existing imports. If there's a naming clash with another `errors` import, alias stdlib as `stderrors "errors"` and use `stderrors.Is`.
@@ -405,7 +495,7 @@ func make512DimVector() []float64
     Finally, update `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` — replace the placeholder row in the Per-Task Verification Map with one row per task from Plans 01/02/03/04, each with the correct Automated Command. Check the Wave 0 Requirements boxes, set `nyquist_compliant: true` in frontmatter, and set Approval to "approved". Commit.
   </action>
   <verify>
-    <automated>go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(CtxCancel|MaxWait|SkipsTextImage|ConfigRoundTrip|ConfigOmitWhenDisabled)$' ./pkg/embeddings/twelvelabs/... && go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/... && grep -q 'func TestTwelveLabsAsyncCtxCancel' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncSkipsTextImage' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigRoundTrip' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigOmitWhenDisabled' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'nyquist_compliant: true' .planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md && echo OK</automated>
+    <automated>go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(CtxCancel|MaxWait|SkipsTextImage|ConfigRoundTrip|ConfigOmitWhenDisabled|FailedReasonSanitized|BlockedHTTPMaxWait|FusedRejected)$' ./pkg/embeddings/twelvelabs/... && go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/... && grep -q 'func TestTwelveLabsAsyncCtxCancel' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncSkipsTextImage' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigRoundTrip' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncConfigOmitWhenDisabled' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncFailedReasonSanitized' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncBlockedHTTPMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'func TestTwelveLabsAsyncFusedRejected' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'rebuilt.apiClient.APIKeyEnvVar' pkg/embeddings/twelvelabs/twelvelabs_test.go && grep -q 'nyquist_compliant: true' .planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md && echo OK</automated>
   </verify>
   <acceptance_criteria>
     - `go test -tags=ef -count=1 -run 'TestTwelveLabsAsync(CtxCancel|MaxWait|SkipsTextImage|ConfigRoundTrip|ConfigOmitWhenDisabled)$' ./pkg/embeddings/twelvelabs/...` exits 0.
@@ -415,8 +505,12 @@ func make512DimVector() []float64
     - `grep -q 'func TestTwelveLabsAsyncSkipsTextImage' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
     - `grep -q 'func TestTwelveLabsAsyncConfigRoundTrip' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
     - `grep -q 'func TestTwelveLabsAsyncConfigOmitWhenDisabled' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches.
+    - `grep -q 'func TestTwelveLabsAsyncFailedReasonSanitized' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — failure-reason preservation test added (D-17 review fix).
+    - `grep -q 'func TestTwelveLabsAsyncBlockedHTTPMaxWait' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — blocked-HTTP + maxWait test added (Plan 02 per-HTTP-call-deadline review fix).
+    - `grep -q 'func TestTwelveLabsAsyncFusedRejected' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — fused-async rejection test added (Plan 02 F-02 review fix).
+    - `grep -q 'rebuilt.apiClient.APIKeyEnvVar' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — ConfigRoundTrip also asserts APIKeyEnvVar survives the round-trip (Gemini review fix).
     - `grep -q 'errors.Is(err, context.Canceled)' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches (ctx-cancel assertion).
-    - `grep -q 'errors.Is(err, context.DeadlineExceeded)' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — used in MaxWait test as a NEGATIVE assertion (D-20).
+    - `grep -q 'errors.Is(err, context.DeadlineExceeded)' pkg/embeddings/twelvelabs/twelvelabs_test.go` matches — used in MaxWait + BlockedHTTPMaxWait tests as NEGATIVE assertions (D-20).
     - `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` Per-Task Verification Map has >= 8 rows (one per task across Plans 01-04).
     - `.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md` frontmatter has `nyquist_compliant: true`.
     - `make lint` exits 0.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-04-SUMMARY.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-04-SUMMARY.md
@@ -1,0 +1,111 @@
+---
+phase: 26-twelve-labs-async-embedding
+plan: 04
+subsystem: pkg/embeddings/twelvelabs
+tags: [twelvelabs, embeddings, async, testing]
+requires:
+  - 26-01 (async request/response types, doTaskPost, doTaskGet)
+  - 26-02 (pollTask + createTaskAndPoll + modality routing)
+  - 26-03 (WithAsyncPolling option + config round-trip)
+provides:
+  - Twelve async-focused unit tests covering every D-26 flow, D-07 routing, D-22 omit-when-disabled, and three review-fix guards
+affects:
+  - pkg/embeddings/twelvelabs/twelvelabs_test.go
+tech_stack_added:
+  - sync/atomic (test-only — attempt counters)
+  - stderrors "errors" (test-only — distinguished from pkg/errors)
+key_files_created: []
+key_files_modified:
+  - pkg/embeddings/twelvelabs/twelvelabs_test.go
+decisions:
+  - Used stdlib `errors` (aliased as `stderrors`) for `errors.Is` assertions; pkg/errors.Wrap is unwrappable via stdlib since Go 1.13 so both sentinel and wrapped errors are reachable.
+  - Direct field assignment on `ef.apiClient` to keep tests independent of option ordering (e.g. fused audio applied post-construction without going through `WithAudioEmbeddingOption`).
+  - `newTestAsyncEF` composes on `newTestEF` so sync-helper changes propagate automatically.
+metrics:
+  duration: ~12 minutes
+  tasks: 2
+  files: 1
+completed: 2026-04-14
+---
+
+# Phase 26 Plan 04: Async Test Coverage Summary
+
+Landed TLA-04. Added twelve new `TestTwelveLabsAsync*` functions in `pkg/embeddings/twelvelabs/twelvelabs_test.go` covering every D-26 flow (task-create, poll-to-ready, poll-to-failed, unexpected-status, ctx-cancel, maxWait-expiry), the D-07 text/image-skip rule, the D-22 config-omit-when-disabled rule, and the D-23 config round-trip (including APIKeyEnvVar preservation). Plus three review-fix guards: D-17 failure-reason sanitization, Plan 02 blocked-HTTP per-call deadline, and F-02 fused+async rejection.
+
+## What Was Built
+
+### Task 1 — Core async flows (commit `b323908`)
+Helpers + four behavior tests:
+- `newTestAsyncEF(serverURL)` — enables async with ms-scale intervals (`asyncPollInitial=1ms`, `asyncPollCap=10ms`, `asyncMaxWait=5s`) to keep the full async suite under ~1s.
+- `audioContent(url)` / `videoContent(url)` — minimal one-part multimodal content helpers.
+- `taskCreateJSON(id, status)` and `taskGetJSON(id, status, data)` — fixture emitters that always use the `_id` alias (Pitfall 1 guard).
+- `TestTwelveLabsAsyncTaskCreate` — asserts POST /tasks gets `InputType=audio`, `Audio.EmbeddingOption=[]string{"audio"}` (F-02 list shape), GET /tasks/{id} returns ready with data.
+- `TestTwelveLabsAsyncPollToReady` — asserts 3 GETs before ready, embedding materializes correctly.
+- `TestTwelveLabsAsyncPollToFailed` — asserts error contains `task_fail`, `terminal status=failed`, not wrapped with ctx sentinels.
+- `TestTwelveLabsAsyncUnexpectedStatus` — asserts error contains `unexpected status`, `weird`, `task_weird`.
+
+### Task 2 — Cancellation, deadlines, routing, config (commit `5e2b9ce`)
+- `TestTwelveLabsAsyncCtxCancel` — uses `context.WithCancel` + signaling channel to cancel after first poll; asserts `stderrors.Is(err, context.Canceled)`.
+- `TestTwelveLabsAsyncMaxWait` — 50ms maxWait, server always returns processing; asserts `"async polling maxWait"` in error AND `stderrors.Is(err, context.DeadlineExceeded) == false` (D-20 distinct error).
+- `TestTwelveLabsAsyncSkipsTextImage` — mock `t.Fatalf` on any `/tasks` hit; runs text + image embed, confirms both route through sync endpoint even with async enabled (D-07).
+- `TestTwelveLabsAsyncConfigRoundTrip` — builds EF with `WithEnvAPIKey` + `WithAsyncPolling(7*time.Minute)`, round-trips through `GetConfig` + `NewTwelveLabsEmbeddingFunctionFromConfig`, asserts `asyncPollingEnabled`, `asyncMaxWait=7m`, AND `APIKeyEnvVar` preservation.
+- `TestTwelveLabsAsyncConfigOmitWhenDisabled` — no `WithAsyncPolling` option → neither `async_polling` nor `async_max_wait_ms` appears in config map (D-22).
+- `TestTwelveLabsAsyncFailedReasonSanitized` — server returns `failed` with a ~1.5KB authentic `reason` field NOT in `TaskResponse` struct; asserts the reason substring survives because `doTaskGet` preserves the raw body via `FailureDetail`. Asserts final error < 4096 bytes (sanitizer cap).
+- `TestTwelveLabsAsyncBlockedHTTPMaxWait` — mock server hangs on GET /tasks/{id} waiting for `r.Context().Done()`; maxWait=100ms must interrupt the blocked HTTP call and surface the distinct `"async polling maxWait"` error (not `DeadlineExceeded`) within 2s.
+- `TestTwelveLabsAsyncFusedRejected` — mock server fatals on any HTTP call; sets `AudioEmbeddingOption="fused"`, audio content input; asserts rejection error contains both `"fused"` and `"async"` before any POST.
+
+## Per-Test Verification Map Alignment
+
+All rows in `26-VALIDATION.md` Per-Task Verification Map are populated and `nyquist_compliant: true` was already set by the planner. No VALIDATION.md edits required.
+
+## Test Results
+
+```
+=== RUN   TestTwelveLabsAsyncTaskCreate           --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncPollToReady          --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncPollToFailed         --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncUnexpectedStatus     --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncCtxCancel            --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncMaxWait              --- PASS (0.05s)
+=== RUN   TestTwelveLabsAsyncSkipsTextImage       --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncConfigRoundTrip      --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncConfigOmitWhenDisabled  --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncFailedReasonSanitized  --- PASS (0.00s)
+=== RUN   TestTwelveLabsAsyncBlockedHTTPMaxWait   --- PASS (0.10s)
+=== RUN   TestTwelveLabsAsyncFusedRejected        --- PASS (0.00s)
+PASS   ok  github.com/amikos-tech/chroma-go/pkg/embeddings/twelvelabs   0.631s
+```
+
+Full `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` exits 0 in ~0.46s. `make lint` clean (0 issues).
+
+## Commits
+
+| Task | Commit | Description |
+|------|--------|-------------|
+| 1 | `b323908` | test(26-04): add async task-create, poll-ready, poll-failed, unexpected-status tests |
+| 2 | `5e2b9ce` | test(26-04): add ctx-cancel, maxWait, skip-text-image, config round-trip, and review-fix tests |
+
+## Deviations from Plan
+
+None — plan executed exactly as written. The plan specified 7 tests but the actual count is 12 (4 core + 5 additional + 3 review-fix guards); all were in the plan body, the "seven" phrasing referenced the numbered set while the review-fix ones were explicitly required by frontmatter `must_haves.truths`. All 12 functions land in the file.
+
+## Authentication Gates
+
+None encountered — all tests use `httptest.Server`.
+
+## Key Decisions
+
+- **Aliasing stdlib errors as `stderrors`**: Explicitly marked both imports distinct to avoid ambiguity when reading assertions. `pkg/errors.Wrap`'s wrappers satisfy `stderrors.Is` via Go 1.13 unwrapping so this works transparently.
+- **`newTestAsyncEF` by composition**: Wraps `newTestEF` rather than duplicating the construction logic — keeps the two helpers in lockstep if the sync helper ever evolves.
+
+## Known Stubs
+
+None. All tests exercise real production code paths.
+
+## Self-Check: PASSED
+
+- File `pkg/embeddings/twelvelabs/twelvelabs_test.go` exists and contains all 12 `TestTwelveLabsAsync*` functions (grep-verified).
+- Commit `b323908` exists in git log (`test(26-04): add async task-create, poll-ready, poll-failed, unexpected-status tests`).
+- Commit `5e2b9ce` exists in git log (`test(26-04): add ctx-cancel, maxWait, skip-text-image, config round-trip, and review-fix tests`).
+- `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` exits 0.
+- `make lint` exits 0.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
@@ -11,7 +11,7 @@ Enable the Twelve Labs provider to embed long-running audio and video content (u
 **Framing:** timeout-bug-fix, not async-DX. The caller still blocks on a single call; the call now succeeds for media that would previously fail because the sync HTTP connection cannot be held open long enough server-side. No new async-shaped public surface, no interface changes, no impact on existing callers who do not opt in.
 
 **In scope:**
-- New internal code path hitting `POST /v1.3/embed-v2/tasks`, `GET /v1.3/embed-v2/tasks/{id}/status`, `GET /v1.3/embed-v2/tasks/{id}`
+- New internal code path hitting `POST /v1.3/embed-v2/tasks` and `GET /v1.3/embed-v2/tasks/{id}` (two endpoints per RESEARCH F-01 — there is no separate `/status` sub-path; the GET returns both status and data)
 - Single new functional option `WithAsyncPolling(maxWait time.Duration)` that gates the async path
 - Modality-based routing: when opt-in is present, audio and video go through the tasks endpoint; text and image stay on the sync `/embed-v2` path
 - Polling loop that respects `ctx.Deadline()` and the `maxWait` bound

--- a/.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-CONTEXT.md
@@ -1,0 +1,178 @@
+# Phase 26: Twelve Labs Async Embedding - Context
+
+**Gathered:** 2026-04-14
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Enable the Twelve Labs provider to embed long-running audio and video content (up to the Twelve Labs 4-hour limit) through the existing blocking `EmbedContent` / `Collection.Add` path by routing audio/video through the dedicated async task endpoints and polling to completion.
+
+**Framing:** timeout-bug-fix, not async-DX. The caller still blocks on a single call; the call now succeeds for media that would previously fail because the sync HTTP connection cannot be held open long enough server-side. No new async-shaped public surface, no interface changes, no impact on existing callers who do not opt in.
+
+**In scope:**
+- New internal code path hitting `POST /v1.3/embed-v2/tasks`, `GET /v1.3/embed-v2/tasks/{id}/status`, `GET /v1.3/embed-v2/tasks/{id}`
+- Single new functional option `WithAsyncPolling(maxWait time.Duration)` that gates the async path
+- Modality-based routing: when opt-in is present, audio and video go through the tasks endpoint; text and image stay on the sync `/embed-v2` path
+- Polling loop that respects `ctx.Deadline()` and the `maxWait` bound
+- Terminal state handling (ready, failed) with error messages that include the task ID and a sanitized reason
+- Colocated tests under the `ef` build tag covering create, poll-to-ready, poll-to-failed, and ctx-cancellation
+- Config round-trip keys for the new option so registry-rebuilt EFs behave identically
+
+**Out of scope:**
+- Any new public method, callback surface, task-handle type, or other shape that would expose async to callers beyond the single opt-in flag
+- Exporting a structured `*TaskFailedError` type (plain `errors.Errorf` is sufficient for Path 1 framing)
+- Changes to `EmbeddingFunction` or `ContentEmbeddingFunction` interface signatures
+- Unblocking `Collection.Add` semantics (it stays a blocking call; long media now just succeeds where it previously failed)
+- Parallel task dispatch, progress callbacks, fire-and-forget semantics, or batch throughput work
+- Exposing polling interval / backoff knobs as public options in v1
+- Using `POST /v1.3/embed-v2` for async detection (Twelve Labs does not document sync-to-async fallback on that endpoint; the tasks endpoint is a distinct contract)
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Endpoint strategy
+- **D-01:** Two-endpoint model (Framing A). Sync `/embed-v2` usage is unchanged. The new code path calls `POST /embed-v2/tasks` to create a task, `GET /embed-v2/tasks/{id}/status` to poll, and `GET /embed-v2/tasks/{id}` to retrieve the final embedding. The roadmap phrase "sync endpoint returns an async task response" was a premise drift — verified against Twelve Labs docs and the Fern-generated official Python SDK; the sync endpoint always returns `EmbeddingSuccessResponse` and never a task response.
+- **D-02:** Existing `POST /v1.3/embed-v2` behavior is not modified. Callers who do not opt in see zero behavioral change.
+
+### Public surface
+- **D-03:** One new functional option: `WithAsyncPolling(maxWait time.Duration) Option`. Passing `0` selects the default `maxWait` of 30 minutes. Presence of this option is the sole trigger for the async code path.
+- **D-04:** No other async-related options are exported in this phase. Polling interval, backoff multiplier, and cap are internal implementation details. If real-world usage later demonstrates the need for tuning, options can be added without breaking existing callers.
+- **D-05:** `EmbeddingFunction` and `ContentEmbeddingFunction` interface signatures are unchanged. No new public methods, types, callbacks, or task handles.
+- **D-06:** `Collection.Add` / `Collection.Query` semantics are unchanged. Callers experience the async path as a blocking `EmbedContent` call that may take longer than a single HTTP round-trip.
+
+### Routing
+- **D-07:** When `WithAsyncPolling` is present, audio and video modalities route through the tasks endpoint + polling. Text and image modalities always use the sync `/embed-v2` endpoint regardless of the option, because they have no duration concept and routing them through `/tasks` would add a task-create round-trip for zero benefit.
+- **D-08:** When `WithAsyncPolling` is absent, all modalities continue to use the sync endpoint (today's behavior); long audio/video that exceeds the Twelve Labs sync limit will fail exactly as it does today.
+
+### Bounds and cancellation
+- **D-09:** Total polling time is bounded by the minimum of `ctx.Deadline()` and `maxWait`. Whichever fires first terminates the poll. `ctx.Deadline()` is the canonical Go kill switch; `maxWait` is a belt-and-suspenders bound to protect callers who forget to set a deadline (a real DX footgun since `Collection.Add` opaquely threads the caller's context into the EF).
+- **D-10:** `ctx` cancellation mid-poll terminates the polling loop immediately and surfaces `context.Canceled` via the existing stdlib wrapping (no special handling required).
+
+### Polling schedule
+- **D-11:** Polling uses a hand-rolled capped exponential backoff: `initial=2s`, `multiplier=1.5`, `cap=60s`, no jitter. Values are unexported fields on `TwelveLabsClient` with defaults applied in `applyDefaults`.
+- **D-12:** No external polling/backoff dependency (e.g., `cenkalti/backoff`) is introduced. This is ~30 LoC of stdlib logic; adding a dep for it violates the codebase's minimal-dep convention.
+- **D-13:** No jitter in v1. Deterministic intervals make `ef`-tag tests straightforward; jitter can be added later if production load patterns warrant it.
+
+### Async response detection (inside the polling loop)
+- **D-14:** Task status is determined by the required `status` enum field on the task retrieval response: `processing` → continue polling with the next backoff step; `ready` → extract embedding from `data` and return; `failed` → terminate with a task-failure error. This matches the Fern-generated discriminator used by the official Twelve Labs Python/TypeScript SDKs.
+- **D-15:** HTTP status code (200 vs. 202) is not used as the async discriminator. Twelve Labs does not document 202 semantics for these endpoints, and relying on it would bake in an unverified contract.
+- **D-16:** Any unexpected `status` value (not one of the three known states) is treated as a malformed response and produces a descriptive error, not silently treated as either terminal state.
+
+### Error semantics
+- **D-17:** Terminal task failures surface as `errors.Errorf(...)` with a message that always includes the task ID, the terminal status, and a `chttp.SanitizeErrorBody`-truncated reason from the task response. No exported error type, no sentinel.
+  - Example shape: `Twelve Labs task [task_abc123] terminal status=failed: <sanitized reason>`
+- **D-18:** HTTP / transport errors during polling flow through the existing `errors.Wrap` / `errors.Errorf` pattern used elsewhere in `twelvelabs.go`. Error bodies from failed poll responses are sanitized via `chttp.SanitizeErrorBody` (Phase 25 convention).
+- **D-19:** `context.Canceled` and `context.DeadlineExceeded` propagate unchanged via stdlib wrapping. Callers can distinguish ctx cancellation from task failure from HTTP error using standard Go patterns (`errors.Is(err, context.Canceled)` etc.); no sdk-specific sentinel is needed.
+- **D-20:** `maxWait` expiration surfaces as a distinct error (not the stdlib `context.DeadlineExceeded`) so callers who hit the SDK-level bound rather than their own ctx deadline can tell the two apart from the error message.
+
+### Config round-trip
+- **D-21:** When `WithAsyncPolling` is enabled, `GetConfig` includes two new keys:
+  - `async_polling: true`
+  - `async_max_wait_ms: <int64 milliseconds>`
+- **D-22:** When `WithAsyncPolling` is absent, both keys are omitted from the config map (no `async_polling: false` noise).
+- **D-23:** `NewTwelveLabsEmbeddingFunctionFromConfig` reads these keys and reconstructs the option. Missing keys → opt-in is off, matching construction.
+
+### Test strategy
+- **D-24:** Tests use `net/http/httptest.Server` with an attempt counter, matching the existing `twelvelabs_test.go` conventions. The polling fields on `TwelveLabsClient` are set directly in test construction (like the existing `newTestEF` helper sets `BaseAPI` and `APIKey`) to millisecond-scale values so tests run in single-digit milliseconds.
+- **D-25:** No clock abstraction is introduced. No new external dependency (`benbjohnson/clock` or otherwise) is added for tests. The codebase has no clock interface today and adding one for a single polling loop is overkill.
+- **D-26:** Required test flows (TLA-04 coverage):
+  1. Task creation path: first `POST /tasks` succeeds, returns task ID
+  2. Poll-to-ready: N `processing` responses followed by `ready` + result retrieval returns the expected embedding
+  3. Poll-to-failed: `processing` → `failed` produces the expected error shape
+  4. `ctx` cancellation mid-poll: cancel after first `processing` response; loop exits with `context.Canceled`
+  5. `maxWait` expiration: `maxWait` set shorter than ctx deadline triggers the SDK-level timeout error (distinct message)
+  6. Config round-trip: `WithAsyncPolling` enabled → `GetConfig` emits the two new keys → rebuild → option reapplied
+- **D-27:** Tests live under the existing `ef` build tag in `pkg/embeddings/twelvelabs/`. No new test file layout is introduced unless existing files become unwieldy; prefer extending `twelvelabs_test.go`.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Milestone and requirement context
+- `.planning/ROADMAP.md` — Phase 26 goal, dependency on Phase 25, and success criteria for TLA-01..04 (note premise-drift on "sync endpoint returns async task" — superseded by D-01)
+- `.planning/REQUIREMENTS.md` — TLA-01 through TLA-04 requirement text
+- `.planning/PROJECT.md` — v0.4.2 milestone framing and issue `#479` scope
+
+### Twelve Labs API references
+- https://docs.twelvelabs.io/api-reference/create-embeddings-v2 — sync embed-v2 endpoint (baseline, unchanged)
+- https://docs.twelvelabs.io/api-reference/embed-v2/create-audio-video-embeddings — tasks endpoint create path
+- https://docs.twelvelabs.io/api-reference/embed-v2/retrieve-embeddings-task — task retrieval (result + status)
+- https://docs.twelvelabs.io/api-reference/embed-v2/retrieve-task-status — task status polling
+- https://docs.twelvelabs.io/docs/concepts/tasks — task lifecycle concepts
+- https://docs.twelvelabs.io/docs/guides/create-embeddings/audio — audio guide with duration notes
+- https://github.com/twelvelabs-io/twelvelabs-python — reference for `EmbeddingTaskResponse` shape and `status` discriminator
+
+### Prior locked decisions to carry forward
+- `.planning/phases/25-error-body-truncation/25-CONTEXT.md` — `chttp.SanitizeErrorBody` usage convention for all error-body-derived text (applies to failure reasons and polling HTTP errors)
+- `.planning/milestones/v0.4.1-phases/16-*` (if present) — original Twelve Labs provider context and capability model
+
+### Implementation targets
+- `pkg/embeddings/twelvelabs/twelvelabs.go` — `TwelveLabsClient`, `doPost`, and registration; polling fields and async detection live here
+- `pkg/embeddings/twelvelabs/content.go` — `contentToRequest`, `embedContent`, `EmbedContent`, `EmbedContents`; modality-based routing decision point
+- `pkg/embeddings/twelvelabs/option.go` — `Option` type and existing functional options; add `WithAsyncPolling` here
+- `pkg/embeddings/twelvelabs/twelvelabs_test.go` — existing `ef`-tag mock server tests; extend for async flows
+- `pkg/commons/http/` — `chttp.SanitizeErrorBody`, `chttp.ReadLimitedBody`, `chttp.ChromaGoClientUserAgent` (reuse, do not reinvent)
+
+### Repo conventions
+- `CLAUDE.md` — project conventions (radical simplicity, no panics in production, V2-first, build-tag segregation, minimal deps)
+- `.planning/codebase/TESTING.md` — `ef` build-tag expectations and test layout
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable assets
+- `chttp.ReadLimitedBody`, `chttp.SanitizeErrorBody`, `chttp.ChromaGoClientUserAgent` — reused verbatim for task endpoint HTTP handling and error-body sanitization
+- `embeddings.NewValidator()` — struct validation pattern, reuse for any new validated fields on `TwelveLabsClient`
+- `embeddingFromResponse` helper in `twelvelabs.go` — can be adapted (or a sibling helper added) for extracting the embedding from the task retrieval response body
+- `float64sToFloat32s` — direct reuse for float64→float32 conversion on task results
+
+### Established patterns
+- Functional options via `Option func(p *TwelveLabsClient) error` with validation inside each option
+- Config round-trip via `GetConfig()` + `NewTwelveLabsEmbeddingFunctionFromConfig` — new keys must be readable and writable on both sides and must omit defaults to keep config maps lean
+- Test construction bypasses the public API: `newTestEF` builds a `TwelveLabsEmbeddingFunction` with a hand-crafted `TwelveLabsClient` — the same approach works for setting ms-scale polling intervals in tests
+- Error messages wrap with `errors.Wrap` / `errors.Errorf` from `github.com/pkg/errors`; no stdlib `%w` wrapping in this package (don't mix)
+- `resolveModel(ctx)` pattern: context-keyed per-request overrides — not needed for polling but good reference if per-call async overrides are ever considered in a future phase
+
+### Integration points
+- `content.go` modality switch in `contentToRequest` is the natural decision point for "sync vs. tasks-endpoint" routing — branch on `part.Modality` + `apiClient.asyncPollingEnabled`
+- `doPost` currently handles sync POST; the async path needs a parallel `doTaskPost` + `doTaskGet` pair or a unified helper, as long as URL construction stays clear
+- `Capabilities()` continues to report `SupportsBatch: false, SupportsMixedPart: false` — async doesn't change capability semantics
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Async is framed as a **timeout-bug-fix**, not async-DX. This explicitly rejected framing is recorded because it shaped every other decision: the public surface stayed minimal, no task handles were added, polling remained hidden, and test coverage was scoped to the four required flows rather than DX richness.
+- The `/embed-v2` sync endpoint is intentionally **not** altered to detect-and-redirect to the tasks endpoint. Twelve Labs does not document a sync-to-async fallback, and building one on top of 4xx error-code sniffing would tie the SDK to an undocumented server contract.
+- `maxWait` existing alongside `ctx.Deadline` is intentional belt-and-suspenders. The common footgun is `Collection.Add(context.Background(), ...)`: without `maxWait`, that would silently block for up to 4 hours. With `maxWait`, the SDK can't accidentally hang for hours just because the caller forgot a deadline.
+- The `status` field is the authoritative async discriminator (D-14). The HTTP-202 interpretation from ad-hoc web searches is speculative and not in the docs.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Callback-based async surface** — user floated during discussion ("allow users to pass a callback such that the add/embed calls return immediately and the callback gets the results when ready"). Explicitly deferred: changes the `EmbeddingFunction` contract, cross-cuts all providers, too large for a Twelve Labs phase. Future phase should approach this as an SDK-wide architecture question.
+- **Path 2 — expose task lifecycle on the package (`CreateEmbeddingTask` + `TaskHandle`)** — would deliver real async DX for direct package users while leaving `Collection.Add` unchanged. Explicitly deferred in favor of Path 1. Worth revisiting if users start reporting that "blocking for 45 minutes on a single call" is the actual pain rather than "long media fails at all".
+- **Path 3 — architecture ADR before any code** — rejected for this phase; the underlying server timeout pain is real enough to justify shipping Path 1 now.
+- **Parallel task dispatch / batch throughput improvements** — async-task-endpoint does not help here; each task is still one input. Throughput work is its own concern (parallel goroutines dispatching sync calls) and belongs in a separate phase if requested.
+- **Exposed polling knobs** (`WithAsyncPollInterval`, `WithAsyncPollBackoff`) — deliberately internal in v1. Add later only if users demonstrate a need.
+- **Structured `*TaskFailedError` exported type** — considered and rejected (D-17) to keep the surface minimal. Revisit if callers need programmatic access to task ID / status / reason beyond log-message parsing.
+- **Jitter in backoff** — deferred; deterministic polling makes tests simpler. Add later if server load patterns warrant it.
+- **Clock abstraction for tests** — deferred. Short intervals via direct field override are sufficient; no package-wide clock interface is justified by this single polling loop.
+
+</deferred>
+
+---
+
+*Phase: 26-twelve-labs-async-embedding*
+*Context gathered: 2026-04-14*

--- a/.planning/phases/26-twelve-labs-async-embedding/26-DISCUSSION-LOG.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-DISCUSSION-LOG.md
@@ -1,0 +1,138 @@
+# Phase 26: Twelve Labs Async Embedding - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-04-14
+**Phase:** 26-twelve-labs-async-embedding
+**Areas discussed:** Framing (premise check), API surface, Polling schedule, Async status detection, Opt-in vs auto polling, Error semantics, Test strategy
+
+**Advisor mode:** active (USER-PROFILE.md present; calibration tier = full_maturity / thorough-evaluator)
+
+---
+
+## 0. Framing / Premise Check (not in original gray-area list)
+
+Surfaced by advisor research: the phase goal in ROADMAP.md ("sync endpoint returns an async task response") did not match the actual Twelve Labs API contract. The `POST /v1.3/embed-v2` endpoint always returns `EmbeddingSuccessResponse` — there is no sync-to-async fallback. Async work happens on the distinct `POST /v1.3/embed-v2/tasks` endpoint.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| A. Two-endpoint model | Sync `/embed-v2` unchanged; new code path calls `/embed-v2/tasks` + poll | ✓ |
+| B. "Try sync, fall back to async" | Detect a specific 4xx on sync and retry via tasks endpoint | |
+
+**User's choice:** A (Framing A — two-endpoint model).
+**Notes:** User questioned whether the audio/video modality split made sense for large text/image batches; this surfaced that async isn't a batching primitive but a latency-decoupling one. Led to a deeper discussion of what async should actually deliver at the DX level.
+
+---
+
+## 1. Path framing (what does Phase 26 actually deliver?)
+
+After the modality discussion, it became clear that "hidden polling in EmbedContent" doesn't deliver true async DX — it just extends the blocking wait. Three honest paths were laid out.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Path 1 — timeout bug-fix | Hidden polling inside existing EmbedContent; long media just works; no new public async surface | ✓ |
+| Path 2 — expose task lifecycle | Add package-level `CreateEmbeddingTask` + `TaskHandle.Wait/Status/Result`; real async for direct users; Collection.Add still sync-only | |
+| Path 3 — defer and write ADR | Write design doc first, ship no code this phase | |
+
+**User's choice:** Path 1.
+**Notes:** User wanted to unlock TwelveLabs' long-media capability this milestone; Path 2 is deferred pending evidence that callers need fire-and-forget / parallel dispatch. Callback-pattern idea floated by user during discussion was explicitly deferred (cross-cutting interface change).
+
+---
+
+## 2. Async routing trigger (under Path 1 + Framing A)
+
+Once Path 1 was locked, the routing trigger question simplified.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| A2a. Modality-based | Audio+video always async when opt-in enabled; text/image always sync | ✓ |
+| A2b. Sync-first, async fallback | Try `/embed-v2`, fall back to `/tasks` on duration error | |
+| A2c. Per-request context key | `ContextWithAsyncPolling(ctx, maxWait)` on any call | |
+| A2d. Always-on when opt-in | All modalities route through `/tasks` when enabled | |
+
+**User's choice:** A2a.
+**Notes:** Text/image have no duration concept on Twelve Labs; routing them through `/tasks` would add a task-create round-trip for zero benefit. A2b depends on undocumented error-code sniffing.
+
+---
+
+## 3. Public surface / API delta
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Minimal: single `WithAsyncPolling(maxWait)` option, everything else hidden | One knob; polling intervals, detection, error shape all internal | ✓ |
+| Rich: expose polling interval/backoff options + structured error type | More knobs, more programmatic access | |
+
+**User's choice:** Minimal.
+**Notes:** User explicitly locked this: "I want users to explicitly use WithAsyncPolling flag to trigger the async flow and all the rest of the details are hidden." This drove D-07 (plain `errors.Errorf` instead of exported `*TaskFailedError`) and kept polling fields unexported.
+
+---
+
+## 4. Polling schedule
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Fixed interval (e.g., 5s) | Matches TwelveLabs Python SDK; simplest | |
+| Hand-rolled capped exponential (2s → 60s, mult 1.5, no jitter) | Matches AssemblyAI shape; no deps; ~30 LoC | ✓ |
+| `cenkalti/backoff` v4 | Battle-tested but adds dep | |
+| Linear ramp | Non-standard | |
+| Server-hinted (Retry-After) | Not supported by TwelveLabs | |
+
+**User's choice:** Hand-rolled capped exponential; internal constants, not exposed as options.
+**Notes:** Aligns with codebase's stdlib-first ethos; ctx.Deadline + maxWait are the only user-visible kill switches.
+
+---
+
+## 5. Async status detection (inside polling loop)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `status` enum field on task response | `processing` / `ready` / `failed` — matches official SDK Fern discriminator | ✓ |
+| HTTP status code (200 vs 202) | Not documented by TwelveLabs; speculative | |
+| `id` field presence | Weaker discriminator than `status` | |
+| Separate Go methods per endpoint (no detection) | Bigger surface; unnecessary under Path 1 | |
+
+**User's choice:** `status` enum.
+**Notes:** Unknown status values treated as malformed (D-16), not silently coerced.
+
+---
+
+## 6. Error semantics (terminal task failures)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Plain `errors.Errorf` with task ID + status + sanitized reason in message | No new exported surface; matches existing `twelvelabs.go:185` style | ✓ |
+| Sentinel `ErrTwelveLabsTaskFailed` + `%w` wrap | Enables `errors.Is` but conflicts with package's pkg/errors.Wrap style | |
+| Structured `*TaskFailedError{TaskID, Status, Reason}` + `errors.As` | Programmatic access but exports a new type | |
+| Hybrid sentinel + struct | Covers both patterns but largest surface | |
+
+**User's choice:** Plain `errors.Errorf`.
+**Notes:** Changed from initial structured-type recommendation after user's "hide all details except WithAsyncPolling" instruction. If callers later need programmatic access, add the type in a follow-up.
+
+---
+
+## 7. Test strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Short intervals via direct field override (ms-scale in tests, seconds in prod) | Matches existing `newTestEF` pattern; no new deps | ✓ |
+| Internal clock interface with fake/real impls | Fully deterministic but adds abstraction for one loop | |
+| `benbjohnson/clock` external dep | Overkill; dep rot risk | |
+| Package-var sleep seam | Anti-pattern; blocks `t.Parallel` | |
+
+**User's choice:** Short intervals via direct field override.
+**Notes:** Polling fields added as unexported struct fields on `TwelveLabsClient`, set directly in test construction like existing `BaseAPI` / `APIKey`.
+
+---
+
+## Deferred Ideas
+
+Captured in CONTEXT.md `<deferred>` section:
+- Callback-based async surface (user-floated, cross-cuts interface contract)
+- Path 2 (exposed `TaskHandle` lifecycle) — revisit if "blocking for 45 minutes" becomes a complaint
+- Path 3 (design ADR before code) — rejected in favor of shipping Path 1 now
+- Parallel task dispatch / batch throughput (separate concern, async doesn't solve it)
+- Exposed polling knobs (internal in v1)
+- Structured `*TaskFailedError` exported type
+- Jitter in backoff
+- Clock abstraction for tests

--- a/.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md
@@ -1,0 +1,745 @@
+# Phase 26: Twelve Labs Async Embedding - Research
+
+**Researched:** 2026-04-14
+**Domain:** Twelve Labs embed-v2 async task API integration into an existing Go embedding provider
+**Confidence:** HIGH
+
+## Summary
+
+CONTEXT.md locks 27 implementation decisions before research. This document validates those decisions against the live Fern-generated official Twelve Labs Python SDK (the authoritative source for the API contract) and against the existing `pkg/embeddings/twelvelabs` code. Almost every decision is confirmed; two material deltas require the planner's attention and one has been corrected against stale documentation URLs.
+
+**Material flags for the planner (detail in "Flags for Planner" below):**
+
+1. **Only TWO task endpoints exist, not three.** CONTEXT.md D-01 lists `POST /embed-v2/tasks`, `GET /embed-v2/tasks/{id}/status`, and `GET /embed-v2/tasks/{id}`. The official Python SDK only uses `POST /embed-v2/tasks` and `GET /embed-v2/tasks/{id}` — the retrieve endpoint already returns `status` plus `data` in a single response, so polling and retrieval collapse to one GET. A `/status` sub-path is not exposed in the SDK reference or the generated raw client.
+2. **The async `AudioInputRequest` body shape differs from the sync body shape.** Sync `/embed-v2` uses `embedding_option: string` (single value). Async `/embed-v2/tasks` uses `embedding_option: list[string]` plus `embedding_scope: list[string]` plus `embedding_type: list[string]`. The provider's existing `AudioInput.EmbeddingOption string` field cannot be reused as-is for the task endpoint.
+3. **CONTEXT.md doc URLs 404.** The `docs.twelvelabs.io/api-reference/embed-v2/*` paths in the Canonical References block return "Page Not Found". The correct path prefix is `docs.twelvelabs.io/v1.3/api-reference/create-embeddings-v2/*` (verified via the Python SDK's embedded doc links).
+
+**Primary recommendation:** Implement two new internal helpers (`createTask` + `retrieveTask`), poll via the retrieve endpoint alone, and add a small async-specific request type for the tasks body. Otherwise, follow CONTEXT.md verbatim.
+
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** Two-endpoint model (Framing A). Sync `/embed-v2` usage is unchanged. The new code path calls `POST /embed-v2/tasks` to create a task, `GET /embed-v2/tasks/{id}/status` to poll, and `GET /embed-v2/tasks/{id}` to retrieve the final embedding. The roadmap phrase "sync endpoint returns an async task response" was a premise drift — verified against Twelve Labs docs and the Fern-generated official Python SDK; the sync endpoint always returns `EmbeddingSuccessResponse` and never a task response.
+  > **Research flag:** the `/status` sub-endpoint does not exist in the Python SDK — see Flag F-01. The planner should collapse poll + retrieve into a single GET unless a deeper doc source contradicts the SDK.
+- **D-02:** Existing `POST /v1.3/embed-v2` behavior is not modified. Callers who do not opt in see zero behavioral change.
+- **D-03:** One new functional option: `WithAsyncPolling(maxWait time.Duration) Option`. Passing `0` selects the default `maxWait` of 30 minutes. Presence of this option is the sole trigger for the async code path.
+- **D-04:** No other async-related options are exported in this phase.
+- **D-05:** `EmbeddingFunction` and `ContentEmbeddingFunction` interface signatures are unchanged.
+- **D-06:** `Collection.Add` / `Collection.Query` semantics are unchanged.
+- **D-07:** When `WithAsyncPolling` is present, audio and video modalities route through the tasks endpoint; text and image always use sync.
+- **D-08:** When `WithAsyncPolling` is absent, all modalities continue to use the sync endpoint.
+- **D-09:** Total polling time is bounded by `min(ctx.Deadline(), maxWait)`.
+- **D-10:** `ctx` cancellation mid-poll terminates the loop immediately and surfaces `context.Canceled`.
+- **D-11:** Polling uses capped exponential backoff: `initial=2s`, `multiplier=1.5`, `cap=60s`, no jitter. Unexported fields on `TwelveLabsClient` with defaults in `applyDefaults`.
+- **D-12:** No external polling/backoff dependency.
+- **D-13:** No jitter in v1.
+- **D-14:** Task status is determined by the `status` enum on the task retrieval response: `processing` → continue; `ready` → extract embedding; `failed` → terminate with error.
+- **D-15:** HTTP status code (200 vs. 202) is NOT used as the async discriminator.
+- **D-16:** Any unexpected `status` value produces a descriptive error.
+- **D-17:** Terminal task failures surface as `errors.Errorf(...)` including task ID, status, and `chttp.SanitizeErrorBody`-truncated reason. No exported error type.
+- **D-18:** HTTP/transport errors flow through the existing `errors.Wrap` / `errors.Errorf` pattern; error bodies sanitized via `chttp.SanitizeErrorBody`.
+- **D-19:** `context.Canceled` and `context.DeadlineExceeded` propagate unchanged.
+- **D-20:** `maxWait` expiration surfaces as a distinct error (not stdlib `context.DeadlineExceeded`).
+- **D-21:** When `WithAsyncPolling` is enabled, `GetConfig` includes `async_polling: true` and `async_max_wait_ms: <int64 ms>`.
+- **D-22:** When absent, both keys are omitted.
+- **D-23:** `NewTwelveLabsEmbeddingFunctionFromConfig` reads these keys and reconstructs the option.
+- **D-24:** Tests use `httptest.Server` with attempt counters; polling fields set directly in test construction to ms-scale values.
+- **D-25:** No clock abstraction.
+- **D-26:** Required test flows (TLA-04 coverage): task-create, poll-to-ready, poll-to-failed, ctx-cancellation, maxWait expiration, config round-trip.
+- **D-27:** Tests live under the `ef` build tag; prefer extending `twelvelabs_test.go`.
+
+### Claude's Discretion
+
+None called out explicitly in CONTEXT.md — every meaningful design choice is locked. Claude's remaining discretion is naming of internal helpers, internal struct layouts, and fixture shape in tests.
+
+### Deferred Ideas (OUT OF SCOPE)
+
+- Callback-based async surface
+- Path 2 / `CreateEmbeddingTask` + `TaskHandle` public API
+- Path 3 / architecture ADR before code
+- Parallel task dispatch / batch throughput
+- Exposed polling knobs (`WithAsyncPollInterval`, `WithAsyncPollBackoff`)
+- Structured `*TaskFailedError` exported type
+- Jitter in backoff
+- Clock abstraction for tests
+
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| TLA-01 | Twelve Labs provider detects async task responses and enters a polling loop | The *trigger* is opt-in via `WithAsyncPolling` + audio/video modality, not a sync-endpoint response shape. See "Routing decision point" below. |
+| TLA-02 | Async polling respects caller context for cancellation and timeout | Polling helper receives `ctx` and uses `select { case <-ctx.Done(): ... case <-time.After(...): ... }`. `maxWait` bound is tracked via `time.Now()` arithmetic, not a derived ctx (D-20 requires distinct maxWait error). |
+| TLA-03 | Async polling handles terminal states (ready, failed) with appropriate error messages | The `EmbeddingTaskResponse.status` enum is `"processing" | "ready" | "failed"` (verified in Python SDK `embedding_task_response_status.py`). |
+| TLA-04 | Tests cover async task creation, polling, completion, failure, and context cancellation | D-26 enumerates six flows; Validation Architecture section below maps each to a concrete httptest server + attempt-counter assertion. |
+
+## Standard Stack
+
+### Core (no new dependencies)
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Go stdlib `net/http` | go 1.22+ | HTTP client for task endpoints | Already used by `doPost` in twelvelabs.go — extend, don't add |
+| Go stdlib `context` | go 1.22+ | Ctx threading + cancellation | Standard Go pattern; `select { case <-ctx.Done(): }` loop |
+| Go stdlib `time` | go 1.22+ | Polling timers, maxWait bound | `time.NewTimer` (not `time.After` inside loops to avoid leak on ctx cancel) |
+| `github.com/pkg/errors` | existing | Error wrapping | Existing package convention; don't mix with stdlib `%w` in this package |
+| `chttp` (`pkg/commons/http`) | internal | `SanitizeErrorBody`, `ReadLimitedBody`, `ChromaGoClientUserAgent` | Phase 25 convention — reuse verbatim |
+
+### Supporting (existing code to extend)
+
+| File | Touch type | Reason |
+|------|------------|--------|
+| `pkg/embeddings/twelvelabs/twelvelabs.go` | MODIFY | Add polling fields on `TwelveLabsClient`, defaults in `applyDefaults`, task-endpoint helpers, config round-trip |
+| `pkg/embeddings/twelvelabs/content.go` | MODIFY | Branch `embedContent` on `asyncPollingEnabled && (audio|video)` to route to task helper |
+| `pkg/embeddings/twelvelabs/option.go` | MODIFY | Add `WithAsyncPolling(maxWait time.Duration) Option` |
+| `pkg/embeddings/twelvelabs/twelvelabs_test.go` | MODIFY | Extend `newTestEF` construction pattern for ms-scale polling; add six flows from D-26 |
+
+### Alternatives Considered
+
+| Instead of | Could Use | Tradeoff | Decision |
+|------------|-----------|----------|----------|
+| Hand-rolled backoff loop | `github.com/cenkalti/backoff/v4` | Proven library, but adds dep | D-12 rejects — ~30 LoC stdlib is fine |
+| Clock interface for tests | `github.com/benbjohnson/clock` | Deterministic fake-clock tests | D-25 rejects — direct field override on `TwelveLabsClient` is sufficient |
+| Separate `/status` + `/retrieve` polling | One GET per poll that carries both | Two round-trips per poll vs one | **Research finding:** the SDK uses one GET — collapse to one. See F-01 below. |
+| Structured `*TaskFailedError` export | Sentinel-style `errors.Is`-compatible | Cleaner caller code | D-17 rejects for minimal surface |
+
+**Installation:** none — zero new deps (verified against CONTEXT.md D-12 and the existing `go.mod`; nothing added).
+
+**Version verification:**
+- Twelve Labs base path prefix: `https://api.twelvelabs.io/v1.3/embed-v2` (existing `defaultBaseAPI` in `twelvelabs.go:18`). [VERIFIED: codebase read]
+- Python SDK HTTP paths: `embed-v2/tasks` (POST, GET list) and `embed-v2/tasks/{task_id}` (GET). [VERIFIED: raw_client.py L82, L198, L280]
+- No registry version check needed; no new package.
+
+## Architecture Patterns
+
+### Recommended File Layout
+
+No new files required. Prefer extending existing files:
+
+```
+pkg/embeddings/twelvelabs/
+├── twelvelabs.go         # TwelveLabsClient + polling fields + doTaskPost/doTaskGet + pollTask
+├── content.go            # routing branch in embedContent
+├── option.go             # WithAsyncPolling
+├── twelvelabs_test.go    # extended with six new flows under `ef` build tag
+```
+
+If `twelvelabs.go` crosses ~500 LoC, split the async-specific helpers into `twelvelabs_async.go` (same package, same build tag story). This is a judgment call for the planner — D-27 prefers minimal file growth.
+
+### Pattern 1: Async request body shape
+
+The async `POST /embed-v2/tasks` body uses a RICHER shape than the sync body. The existing `AudioInput` / `VideoInput` types in `twelvelabs.go` are scoped to sync.
+
+**Sync `AudioInput` shape today** (`twelvelabs.go:113-116`):
+```go
+type AudioInput struct {
+    MediaSource     MediaSource `json:"media_source"`
+    EmbeddingOption string      `json:"embedding_option,omitempty"` // single string
+}
+```
+
+**Async body shape required by `POST /embed-v2/tasks`** [VERIFIED: Python SDK `audio_input_request.py`]:
+```go
+// Required for the tasks endpoint only.
+type AsyncAudioInput struct {
+    MediaSource     MediaSource `json:"media_source"`
+    StartSec        *float64    `json:"start_sec,omitempty"`
+    EndSec          *float64    `json:"end_sec,omitempty"`
+    EmbeddingOption []string    `json:"embedding_option,omitempty"` // list: "audio" | "transcription"
+    EmbeddingScope  []string    `json:"embedding_scope,omitempty"` // list: "clip" | "asset"
+    EmbeddingType   []string    `json:"embedding_type,omitempty"` // list: "separate_embedding" | "fused_embedding"
+}
+type AsyncVideoInput struct {
+    MediaSource     MediaSource `json:"media_source"`
+    StartSec        *float64    `json:"start_sec,omitempty"`
+    EndSec          *float64    `json:"end_sec,omitempty"`
+    EmbeddingOption []string    `json:"embedding_option,omitempty"`
+    EmbeddingScope  []string    `json:"embedding_scope,omitempty"`
+    EmbeddingType   []string    `json:"embedding_type,omitempty"`
+}
+type AsyncEmbedV2Request struct {
+    InputType string           `json:"input_type"`             // "audio" | "video"
+    ModelName string           `json:"model_name"`             // "marengo3.0"
+    Audio     *AsyncAudioInput `json:"audio,omitempty"`
+    Video     *AsyncVideoInput `json:"video,omitempty"`
+}
+```
+
+**For Phase 26's radical-simplicity brief:** a minimal body (only `media_source`, plus `embedding_option: ["audio"]` mapped from the existing string `AudioEmbeddingOption`) is sufficient to satisfy TLA-01..04. The planner should decide whether to expose the extra fields now or defer them. Recommendation: defer — emit only `media_source` for video and `media_source + embedding_option: [<string>]` (wrapping the existing single-value option into a one-element list) for audio. This keeps the phase scoped to the bug fix and avoids widening the public option surface. [ASSUMED] that Twelve Labs accepts a minimal async body — verify by hitting the endpoint once in a spike, or defer verification to integration testing.
+
+### Pattern 2: Task-retrieve response shape
+
+**Response shape of `GET /embed-v2/tasks/{task_id}`** [VERIFIED: Python SDK `embedding_task_response.py`]:
+
+```go
+type TaskResponse struct {
+    ID       string            `json:"_id"`              // Pydantic alias: id -> _id
+    Status   string            `json:"status"`           // "processing" | "ready" | "failed"
+    Data     []EmbedV2DataItem `json:"data,omitempty"`   // null when processing/failed
+    Metadata json.RawMessage   `json:"metadata,omitempty"`
+    // created_at / updated_at are present but not needed for this phase
+}
+```
+
+Reusing the existing `EmbedV2DataItem` type works because `EmbeddingData.embedding` is `list[float]` in both sync and async responses.
+
+**Response shape of `POST /embed-v2/tasks`** [VERIFIED: Python SDK `tasks_create_response.py`]:
+
+```go
+type TaskCreateResponse struct {
+    ID     string `json:"_id"`     // task id (Pydantic alias id -> _id)
+    Status string `json:"status"`  // always "processing" on create
+    Data   []EmbedV2DataItem `json:"data,omitempty"` // almost always null on create
+}
+```
+
+The `_id` JSON alias is non-obvious — miss it and the task ID comes back empty.
+
+### Pattern 3: Polling loop
+
+**Recommended skeleton** (pseudocode, not prescriptive layout):
+
+```go
+func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID string, maxWait time.Duration) (*TaskResponse, error) {
+    deadline := time.Now().Add(maxWait)
+    interval := e.apiClient.asyncPollInitial // e.g., 2s
+    for {
+        resp, err := e.doTaskGet(ctx, taskID)
+        if err != nil {
+            return nil, err // HTTP / transport error, already wrapped
+        }
+        switch resp.Status {
+        case "ready":
+            return resp, nil
+        case "failed":
+            return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(...reasonBytes...))
+        case "processing":
+            // fall through to sleep
+        default:
+            return nil, errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, resp.Status)
+        }
+        // sleep with ctx + maxWait awareness
+        remaining := time.Until(deadline)
+        if remaining <= 0 {
+            return nil, errors.Errorf("Twelve Labs task [%s] maxWait %s exceeded", taskID, maxWait)
+        }
+        wait := interval
+        if wait > remaining {
+            wait = remaining
+        }
+        timer := time.NewTimer(wait)
+        select {
+        case <-ctx.Done():
+            timer.Stop()
+            return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+        case <-timer.C:
+        }
+        interval = nextBackoff(interval, e.apiClient.asyncPollMultiplier, e.apiClient.asyncPollCap)
+    }
+}
+```
+
+Key correctness points the planner must enforce:
+
+- **`time.NewTimer` not `time.After`** inside a loop — `time.After` leaks a timer per iteration if `ctx.Done()` wins the `select`. Stop the timer on the ctx branch.
+- **Poll first, sleep second.** `POST /tasks` itself returns `status: "processing"`; the first poll after create should not sleep 2s before the first check. Either (a) return early if the `TaskCreateResponse.status == "ready"` (extremely unlikely but documented as possible in the SDK type), or (b) start the polling loop immediately.
+- **`maxWait` is absolute, not per-poll.** Compute `deadline := time.Now().Add(maxWait)` once, before the loop.
+- **Two distinct timeout errors** — ctx deadline exceeded vs. maxWait exceeded (D-20) — must surface distinguishable messages. Ctx fires through stdlib wrapping; maxWait fires through `errors.Errorf` with a distinct message (e.g., "maxWait 30m0s exceeded").
+
+### Pattern 4: Modality-based routing branch
+
+The natural decision point is the `embedContent` method in `content.go:130-140`:
+
+```go
+func (e *TwelveLabsEmbeddingFunction) embedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+    // existing: contentToRequest -> doPost -> embeddingFromResponse
+    //
+    // new branch: if e.apiClient.asyncPollingEnabled && (modality == audio || video),
+    //             use the async path.
+}
+```
+
+Rather than branching inside `embedContent`, a cleaner split is:
+
+- `contentToRequest` keeps building the sync request (unchanged).
+- A new `contentToAsyncRequest` builds the tasks-endpoint body for audio/video.
+- `embedContent` checks `e.apiClient.asyncPollingEnabled` + `part.Modality` once, then dispatches to either `doPost` or `createTaskAndPoll`.
+
+This keeps the modality switch in one place and preserves the existing code for non-audio/video paths.
+
+### Anti-Patterns to Avoid
+
+- **Do not call `/embed-v2` first and inspect the response for async hints.** D-01 explicitly rejects this. The sync endpoint will reject audio/video > 10 min with a 400; do not try to recover.
+- **Do not use `time.After` in the poll loop.** Classic Go timer-leak pitfall.
+- **Do not create a new HTTP client** — reuse `e.apiClient.Client` so the caller's `WithHTTPClient` continues to work.
+- **Do not panic on polling misconfiguration.** Fall back to defaults in `applyDefaults` silently.
+- **Do not set `Retry-After` handling.** The docs do not specify a `Retry-After` header on 429, and polling cadence is governed by the backoff schedule. [VERIFIED: Twelve Labs rate-limits docs page via WebFetch]
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Error-body truncation | Custom bytes.Truncate | `chttp.SanitizeErrorBody` | Phase 25 convention, handles utf8 boundaries, panic recovery |
+| Reading HTTP body safely | `io.ReadAll` | `chttp.ReadLimitedBody` | Enforces the 200 MB cap |
+| User-Agent string | Raw string literal | `chttp.ChromaGoClientUserAgent` | Single source of truth |
+| Struct validation | Custom `reflect` checks | `embeddings.NewValidator()` | Existing pattern in `validate()` |
+| Secret handling | Raw `string` | `embeddings.Secret` via `NewSecret` | Existing pattern on `TwelveLabsClient.APIKey` |
+
+**Key insight:** Phase 25 already did the work of making error surfaces safe. Do not reintroduce raw-body error messages. Every path that includes body text in an error MUST route through `chttp.SanitizeErrorBody`.
+
+## Common Pitfalls
+
+### Pitfall 1: Missing `_id` JSON alias on task responses
+
+**What goes wrong:** Parsing the task-create or task-retrieve response into a struct with `ID string \`json:"id"\`` silently decodes an empty string because the Twelve Labs API uses `_id` (Mongo-style) — the Python SDK aliases it in Pydantic. Tests that mock with `{"id": "..."}` instead of `{"_id": "..."}` will pass while production polls against `""`.
+
+**Why it happens:** The public Twelve Labs docs examples tend to show `id` in prose but the wire format uses `_id`. [VERIFIED: Python SDK `embedding_task_response.py` L20, `tasks_create_response.py` L14]
+
+**How to avoid:** Use `json:"_id"` in Go structs. Mirror this in test fixtures — every mock response for the create and retrieve endpoints MUST emit `_id`.
+
+**Warning signs:** Polling immediately loops forever against `GET /embed-v2/tasks//` (note the empty path segment) and the server 404s.
+
+### Pitfall 2: `time.After` timer leak in polling loop
+
+**What goes wrong:** Every `time.After(interval)` allocates a fresh timer that lives until the interval expires. In a loop with ctx cancellation winning the `select`, those timers accumulate until GC at interval-completion time. Not a crash, but a leak detectable under `-race` + long cancellation tests.
+
+**How to avoid:** Use `time.NewTimer(interval)` and call `timer.Stop()` on the ctx-done branch.
+
+**Warning signs:** `go vet` does not catch this. A slow `TestCtxCancel` run is the tell.
+
+### Pitfall 3: `ctx.Deadline()` interaction with `maxWait`
+
+**What goes wrong:** D-09 requires bounding by `min(ctx.Deadline(), maxWait)`. A naive implementation uses `ctx.WithTimeout(maxWait)` which ALSO reduces `ctx.Deadline()`, making D-20 (distinct maxWait error) impossible because both fire as `context.DeadlineExceeded`.
+
+**How to avoid:** Do NOT derive a child ctx from `maxWait`. Track `maxWaitDeadline := time.Now().Add(maxWait)` independently; check it in the poll loop via `time.Now().After(maxWaitDeadline)` and emit a distinct error. Let the caller's original `ctx` carry only the caller's deadline.
+
+### Pitfall 4: First-poll pause
+
+**What goes wrong:** A naive `for { sleep; poll }` loop waits 2 seconds before the first status check. This is annoying in tests (hard to set millisecond-scale polling) and adds 2 seconds of latency for small tasks that finished quickly on the server.
+
+**How to avoid:** `for { poll; if terminal return; sleep }` — poll, then sleep.
+
+### Pitfall 5: Different `embedding_option` shape between sync and async
+
+**What goes wrong:** The existing `AudioInput.EmbeddingOption` is a single string. Copying that struct into the tasks body produces an invalid request shape and a 400 from the server with a message about "expected array, got string".
+
+**How to avoid:** Introduce a dedicated `AsyncAudioInput` / `AsyncVideoInput` or at minimum send `embedding_option: []string{apiClient.AudioEmbeddingOption}` (wrap in a slice). Tests should assert the wire shape explicitly. [VERIFIED: Python SDK `audio_input_request.py` vs `audio_input.py` would show the diff — the async variant expects a list.]
+
+### Pitfall 6: Config round-trip skipping `false`
+
+**What goes wrong:** When `WithAsyncPolling` is absent, emitting `"async_polling": false` in `GetConfig` round-trips cleanly but violates D-22. When present, omitting `async_max_wait_ms` drops the caller's tuning. When `maxWait == 0` (default sentinel), the saved config loses the information that the option was even enabled.
+
+**How to avoid:** Track `asyncPollingEnabled bool` on `TwelveLabsClient` separately from `asyncMaxWait time.Duration`. `GetConfig` emits both keys iff `asyncPollingEnabled == true`. `NewTwelveLabsEmbeddingFunctionFromConfig` treats missing keys as "off" (D-23). For round-trip idempotence: if `asyncPollingEnabled && asyncMaxWait == 0`, emit `async_max_wait_ms: 1800000` (30 min default) — do not emit `0`, which would round-trip back to "use default" and produce the same end state but make diffs noisy.
+
+## Runtime State Inventory
+
+Not a rename/refactor/migration phase. Section omitted.
+
+## Environment Availability
+
+This is a code/test-only phase. No external CLI, runtime, service, or tool is invoked during execution beyond what already powers `go test`. Existing test infrastructure (`httptest.Server`, `testify/require`, `testify/assert`) is already in use in `twelvelabs_test.go`. No fallback analysis needed.
+
+**Skip rationale:** Phase is purely Go package code + tests; no external dependencies introduced (D-12 prohibits new deps).
+
+## Code Examples
+
+### Adding the option (verified pattern from `option.go`)
+
+```go
+// Source: existing pattern in pkg/embeddings/twelvelabs/option.go
+func WithAsyncPolling(maxWait time.Duration) Option {
+    return func(p *TwelveLabsClient) error {
+        p.asyncPollingEnabled = true
+        if maxWait == 0 {
+            p.asyncMaxWait = 30 * time.Minute
+        } else if maxWait < 0 {
+            return errors.New("maxWait cannot be negative")
+        } else {
+            p.asyncMaxWait = maxWait
+        }
+        return nil
+    }
+}
+```
+
+### Extending `applyDefaults` (verified against `twelvelabs.go:44-57`)
+
+```go
+// Source: extend existing applyDefaults
+func applyDefaults(c *TwelveLabsClient) {
+    // ... existing defaults ...
+    if c.asyncPollInitial == 0 {
+        c.asyncPollInitial = 2 * time.Second
+    }
+    if c.asyncPollMultiplier == 0 {
+        c.asyncPollMultiplier = 1.5
+    }
+    if c.asyncPollCap == 0 {
+        c.asyncPollCap = 60 * time.Second
+    }
+}
+```
+
+### doTaskPost pattern (mirror of existing `doPost` in `twelvelabs.go:157-197`)
+
+```go
+// Source: mirror pkg/embeddings/twelvelabs/twelvelabs.go doPost
+func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncEmbedV2Request) (*TaskCreateResponse, error) {
+    reqJSON, err := json.Marshal(req)
+    if err != nil {
+        return nil, errors.Wrap(err, "failed to marshal async task request")
+    }
+    url := strings.TrimRight(e.apiClient.BaseAPI, "/") + "/tasks"
+    httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqJSON))
+    if err != nil {
+        return nil, errors.Wrap(err, "failed to create HTTP request")
+    }
+    httpReq.Header.Set("x-api-key", e.apiClient.APIKey.Value())
+    httpReq.Header.Set("Content-Type", "application/json")
+    httpReq.Header.Set("Accept", "application/json")
+    httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+
+    resp, err := e.apiClient.Client.Do(httpReq)
+    if err != nil {
+        return nil, errors.Wrapf(err, "failed to send task request to %s", url)
+    }
+    defer resp.Body.Close()
+
+    respData, err := chttp.ReadLimitedBody(resp.Body)
+    if err != nil {
+        return nil, errors.Wrap(err, "failed to read response body")
+    }
+    if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+        // reuse the parsed-then-raw fallback pattern from doPost
+        var apiErr EmbedV2ErrorResponse
+        if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
+            return nil, errors.Errorf("Twelve Labs task create error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+        }
+        return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, url, chttp.SanitizeErrorBody(respData))
+    }
+    var taskResp TaskCreateResponse
+    if err := json.Unmarshal(respData, &taskResp); err != nil {
+        return nil, errors.Wrap(err, "failed to unmarshal task create response")
+    }
+    return &taskResp, nil
+}
+```
+
+URL construction note: the existing `BaseAPI` default is `https://api.twelvelabs.io/v1.3/embed-v2`. Appending `/tasks` yields `https://api.twelvelabs.io/v1.3/embed-v2/tasks` — the SDK-verified path. `GET /tasks/{id}` similarly becomes `BaseAPI + "/tasks/" + url.PathEscape(taskID)`.
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Sync-endpoint-returns-task-ID hypothesis | Dedicated `/embed-v2/tasks` POST + retrieve | Always was the contract; roadmap had a premise drift | D-01 corrected the research premise before research ran |
+| Poll via `/status` + retrieve via `/tasks/{id}` | Single `GET /tasks/{id}` returns both | Per SDK generated 2024+ | Collapses polling to one endpoint (Flag F-01) |
+| `Retry-After` header for 429 | Not specified by Twelve Labs | n/a | No special retry logic needed for rate limits in this phase |
+
+**Deprecated/outdated:**
+- None.
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | A minimal async request body (`media_source` only for video; `media_source + embedding_option: ["audio"]` for audio) is accepted by `POST /embed-v2/tasks`. | Pattern 1 | If rejected, planner must widen the async body struct to include `embedding_scope`/`embedding_type` defaults. Verifiable with a one-shot manual curl against the live endpoint. |
+| A2 | The `GET /embed-v2/tasks/{id}` response's `data` field is always populated when `status == "ready"` and always `null` when `status == "processing"` or `"failed"`. | Pattern 2 | If partially populated on `processing`, the naive "return on ready" check still works, but tests should assert explicitly. SDK docstrings support this behavior. |
+| A3 | A failed task's reason text lives in the response body (likely as a top-level `error`/`message` field on `EmbeddingTaskResponse` due to Pydantic `extra="allow"`). | Pattern 3, Pitfall 1 | The SDK doesn't name a specific failure-message field, so the provider should extract `status` + whatever extra string fields are present and sanitize them. Minimally, include the raw response body via `SanitizeErrorBody(respData)` when `status == "failed"`. |
+| A4 | Two-endpoint model (create + retrieve) is sufficient; the `/status` endpoint listed in D-01 is not required. | Summary, Flag F-01 | If Twelve Labs exposes `/status` as a lighter-weight poll target (smaller response), using `/tasks/{id}` wastes bandwidth by carrying the full `data` array on every poll. For task polling where `data` is `null` until `ready`, the difference is negligible. |
+| A5 | `marengo3.0` accepts the existing `AudioEmbeddingOption` values (`audio`, `transcription`, `fused`) when wrapped in a list for the async endpoint. Note: `fused` is NOT a valid async `embedding_option` — the async SDK type lists only `audio` and `transcription`; `fused` is represented via `embedding_type: ["fused_embedding"]`. | Pitfall 5 | If the existing option value is `"fused"` and the user enables async polling for audio, the naive wrap-in-list produces an invalid async request. Planner must either reject `fused` when async is enabled for audio, or transform `fused` into the correct async representation. |
+
+**All five assumptions are verifiable** with a single authenticated curl against the live API or by inspecting a richer slice of the Python SDK source. They do not block planning, but they are the claims most likely to bite at integration time.
+
+## Flags for Planner
+
+These are premise-breaking or scope-adjacent discoveries. They are raised for planner review without reopening locked decisions.
+
+### F-01 (HIGH priority): D-01 lists three endpoints; only two exist
+
+**Evidence:** The Fern-generated Python SDK raw client ([twelvelabs-python/src/twelvelabs/embed/v_2/tasks/raw_client.py](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/embed/v_2/tasks/raw_client.py)) defines only three methods: `list`, `create`, and `retrieve`. The `retrieve` method calls `GET embed-v2/tasks/{task_id}` and parses the response as `EmbeddingTaskResponse`, which carries the `status` discriminator AND the `data` array. There is no method hitting `/embed-v2/tasks/{id}/status`.
+
+**Ground truth (Python SDK, `reference.md` lines 4294-4298):**
+> 1. Create a task using this endpoint. The platform returns a task ID.
+> 2. Poll for the status of the task using the GET method of the `/embed-v2/tasks/{task_id}` endpoint. Wait until the status is `ready`.
+> 3. Retrieve the embeddings from the response when the status is `ready` using the GET method of the `/embed-v2/tasks/{task_id}` endpoint.
+
+Both steps 2 and 3 use the same endpoint.
+
+**Impact:** The implementation needs only `doTaskPost` + `doTaskGet`. No separate `/status` helper. This SIMPLIFIES the phase.
+
+**Recommendation:** Planner should relax D-01 to reflect the two-endpoint reality. This does not reopen any decision beyond the endpoint list — all other invariants in D-01 (sync endpoint untouched, async opt-in via separate endpoint, no sync-endpoint detection) hold.
+
+### F-02 (MEDIUM priority): Async request body shape differs from sync
+
+**Evidence:** See Pattern 1 above; `audio_input_request.py` in the async tasks SDK uses `embedding_option: list[str]` vs the sync `audio_input.py` using a single string. The existing Go `AudioInput` type cannot be reused verbatim.
+
+**Impact:** A minimum of one new request struct (`AsyncEmbedV2Request`) is required, plus either separate `AsyncAudioInput`/`AsyncVideoInput` types or on-the-fly wrapping of `[]string{apiClient.AudioEmbeddingOption}`. Small but not zero.
+
+**Recommendation:** Planner should include a task step for introducing the async request types explicitly and mapping the existing `AudioEmbeddingOption` into the list shape. Document the mapping of `fused` (Assumption A5) in code or reject it with a validation error when async is enabled.
+
+### F-03 (LOW priority): Canonical References doc URLs are 404
+
+**Evidence:** Every URL in CONTEXT.md's `<canonical_refs>` block under "Twelve Labs API references" that matches `docs.twelvelabs.io/api-reference/embed-v2/*` returns "Page Not Found" when fetched. The live prefix appears to be `docs.twelvelabs.io/v1.3/api-reference/create-embeddings-v2/*` (the Python SDK's doc links use this form).
+
+**Impact:** Future researchers or reviewers clicking those links won't reach content. This is a doc-rot issue, not a design issue.
+
+**Recommendation:** When the planner writes plan docs, prefer the SDK source (`github.com/twelvelabs-io/twelvelabs-python/src/twelvelabs/...`) over the `docs.twelvelabs.io` URLs for API contracts. The SDK is generated from the OpenAPI spec and is the stable ground truth.
+
+### F-04 (LOW priority): `Retry-After` not documented
+
+**Evidence:** Twelve Labs rate-limits docs page lists `X-RateLimit-Request-Remaining` and `X-RateLimit-Duration-Remaining` headers but does not document a `Retry-After` header on 429 responses. [VERIFIED: docs.twelvelabs.io/docs/get-started/rate-limits via WebFetch]
+
+**Impact:** The polling loop should NOT attempt to honor `Retry-After`. If a 429 fires during polling, the existing backoff (which already includes the `cap=60s` ceiling) is the correct response. Add a single inline comment documenting this.
+
+**Recommendation:** Treat 429 during polling as a transient error, wrap with `errors.Errorf` like other HTTP failures, and continue the loop. The capped exponential backoff naturally limits burst traffic.
+
+## Open Questions
+
+None of these block planning — the planner can proceed and have each answered during implementation or UAT.
+
+1. **Does `POST /embed-v2/tasks` accept a minimal body (`media_source` only for video)?**
+   - What we know: Python SDK exposes many optional fields; required fields are `input_type`, `model_name`, and `audio` or `video` with `media_source`.
+   - What's unclear: whether the server rejects when optional embedding/scope/type arrays are empty.
+   - Recommendation: Start with minimal body; if the live endpoint rejects, widen in a follow-up before merge.
+
+2. **What does a `failed` task response body contain beyond `status`?**
+   - What we know: Pydantic v2 `extra="allow"` on `EmbeddingTaskResponse` means the shape can include undeclared fields.
+   - What's unclear: the exact field name for the failure reason (`error`, `message`, `failure_reason`?).
+   - Recommendation: In the failed-state error message, include the sanitized full response body via `chttp.SanitizeErrorBody(respData)`. This handles any field name without guessing.
+
+3. **Does `_id` appear consistently across both create and retrieve responses?**
+   - What we know: Python SDK aliases `id -> _id` in both `EmbeddingTaskResponse` and `TasksCreateResponse`.
+   - What's unclear: whether Mongo-to-wire translation changes across API versions.
+   - Recommendation: Always use `json:"_id"` in Go struct tags; test fixtures use `_id`.
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | `go test` via `gotestsum`, with `github.com/stretchr/testify/{require,assert}` assertions |
+| Config file | No config — build tags gate which suites run. See `CLAUDE.md` commands. |
+| Quick run command | `go test -tags=ef -count=1 -run TestTwelveLabsAsync ./pkg/embeddings/twelvelabs/...` |
+| Full suite command | `make test-ef` |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| TLA-01 | Task creation path — `POST /tasks` succeeds, task ID captured, polling loop entered for audio/video when opt-in is on | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncTaskCreate ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-01 | Text/image modalities skip the async path even when `WithAsyncPolling` is set | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncSkipsTextImage ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-02 | Polling respects `ctx.Cancel()` mid-poll and returns `context.Canceled` | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncCtxCancel ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-02 | `maxWait` bound fires with a distinct (non-`context.DeadlineExceeded`) error message | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncMaxWait ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-03 | N `processing` responses followed by `ready` returns the expected embedding | unit (httptest, attempt counter) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncPollToReady ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-03 | `processing` → `failed` produces an error containing task ID, "failed", and a sanitized reason | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncPollToFailed ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-03 | Unexpected status value produces a clear error (D-16) | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncUnexpectedStatus ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+| TLA-04 | All of the above pass as a group | test group | `go test -tags=ef -count=1 -run TestTwelveLabsAsync ./pkg/embeddings/twelvelabs/...` | EXISTS |
+| (D-21/D-22/D-23) | `GetConfig` emits `async_polling` + `async_max_wait_ms` when enabled, omits when disabled; rebuild applies option | unit (no HTTP) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncConfigRoundTrip ./pkg/embeddings/twelvelabs/...` | EXISTS (extend `twelvelabs_test.go`) |
+
+### Sample Fixture Sketches (one per D-26 flow)
+
+**Flow 1: Task creation + poll-to-ready**
+
+```go
+func TestTwelveLabsAsyncPollToReady(t *testing.T) {
+    vec := make512DimVector()
+    var attempts atomic.Int32
+    srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        switch {
+        case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tasks"):
+            fmt.Fprint(w, `{"_id":"task_abc","status":"processing"}`)
+        case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/task_abc"):
+            n := attempts.Add(1)
+            if n < 3 {
+                fmt.Fprint(w, `{"_id":"task_abc","status":"processing"}`)
+                return
+            }
+            resp := map[string]any{
+                "_id":    "task_abc",
+                "status": "ready",
+                "data":   []map[string]any{{"embedding": vec}},
+            }
+            _ = json.NewEncoder(w).Encode(resp)
+        default:
+            http.Error(w, "unexpected", http.StatusBadRequest)
+        }
+    })
+
+    ef := newTestEF(srv.URL)
+    ef.apiClient.asyncPollingEnabled = true
+    ef.apiClient.asyncMaxWait = 5 * time.Second
+    ef.apiClient.asyncPollInitial = 1 * time.Millisecond
+    ef.apiClient.asyncPollMultiplier = 1.0
+    ef.apiClient.asyncPollCap = 5 * time.Millisecond
+
+    emb, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+    require.NoError(t, err)
+    assert.Equal(t, 512, emb.Len())
+    assert.Equal(t, int32(3), attempts.Load())
+}
+```
+
+**Flow 2: Poll-to-failed** — same structure, third response is `{"_id":"task_abc","status":"failed","error":"unsupported codec"}`. Assertion: `err.Error()` contains `task_abc`, `failed`, and `unsupported codec` (post-sanitization).
+
+**Flow 3: ctx cancellation** — handler always returns `processing`. Test calls `ctx, cancel := context.WithCancel(ctx)` and `cancel()` from a goroutine after attempts reaches 1. Assertion: `errors.Is(err, context.Canceled)`.
+
+**Flow 4: maxWait expiration** — handler always returns `processing`. `asyncMaxWait` set to 50 ms with 10 ms polling. Assertion: `err.Error()` contains `maxWait`, does NOT contain `context.DeadlineExceeded`.
+
+**Flow 5: unexpected status** — handler returns `{"_id":"task_abc","status":"zombie"}`. Assertion: `err.Error()` contains `unexpected status`, `zombie`, and `task_abc`.
+
+**Flow 6: config round-trip** — construct an EF with `WithAsyncPolling(45*time.Minute)`, call `GetConfig`, assert `cfg["async_polling"] == true && cfg["async_max_wait_ms"] == int64(2700000)`. Rebuild via `NewTwelveLabsEmbeddingFunctionFromConfig`, assert `restored.apiClient.asyncPollingEnabled == true` and `restored.apiClient.asyncMaxWait == 45*time.Minute`. Additionally: when option is absent, assert `_, ok := cfg["async_polling"]; !ok` and `_, ok := cfg["async_max_wait_ms"]; !ok` (D-22).
+
+**Flow 7 (bonus, optional): sync-path regression** — assert that text + image with `WithAsyncPolling` set still hit `/embed-v2` (not `/embed-v2/tasks`), enforced by a test server that returns 400 on any `/tasks` path.
+
+### Observable Assertions Per Flow
+
+| Flow | HTTP counter | Error shape | Response shape |
+|------|-------------|-------------|----------------|
+| 1 poll-to-ready | attempt count > 1 (proves polling happened) | `err == nil` | `emb.Len() == expected dim` |
+| 2 poll-to-failed | attempt count > 1 | `err` contains task ID + `failed` + reason | n/a |
+| 3 ctx cancel | attempt count >= 1 | `errors.Is(err, context.Canceled)` == true | n/a |
+| 4 maxWait | attempt count >= 1 | `err` contains `maxWait`, does not match `context.DeadlineExceeded` via `errors.Is` | n/a |
+| 5 unexpected status | attempt count == 1 | `err` contains `unexpected status` + value + task ID | n/a |
+| 6 config round-trip | zero HTTP (no server) | n/a | map keys match D-21 / D-22 |
+
+### Sampling Rate
+
+- **Per task commit:** `go test -tags=ef -count=1 -run TestTwelveLabsAsync ./pkg/embeddings/twelvelabs/... -timeout 30s` (expected < 5 s wall clock given ms-scale polling)
+- **Per wave merge:** `make test-ef` (full provider suite)
+- **Phase gate:** `make test-ef && make lint` green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+
+None. The existing test infrastructure covers all phase requirements:
+- `newTestEF` helper exists in `twelvelabs_test.go` (lines 26-36). Extend to inject polling fields.
+- `newMockServer` helper exists.
+- `embedV2Response` fixture helper exists.
+- `atomic.Int32` counters are idiomatic for attempt tracking (stdlib — no new import required for tests that already use `sync/atomic`).
+
+New helpers to ADD (small, inline in `twelvelabs_test.go`):
+- `videoContent(url string) embeddings.Content` — builds a one-part video Content with URL source.
+- `audioContent(url string) embeddings.Content` — same for audio.
+- `taskResponseJSON(status, err string, data []float64) string` — builds a task-response fixture with correct `_id` alias.
+
+These are all ~5-line helpers that can live at the top of `twelvelabs_test.go`.
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | yes | Reuse existing `x-api-key` header pattern from `doPost`; never log the key. `embeddings.Secret` already wraps the key. |
+| V3 Session Management | no | No session state — every call carries the API key header. |
+| V4 Access Control | no | Authorization is enforced server-side by Twelve Labs. |
+| V5 Input Validation | yes | Validate `maxWait >= 0` in `WithAsyncPolling`. Validate async request body types before send. |
+| V6 Cryptography | yes | HTTPS required (existing `validate()` check at `twelvelabs.go:67-70` — do not weaken for task endpoints). |
+| V8 Data Protection | yes | Task IDs and media URLs may be sensitive; do not include full response bodies in error logs beyond `SanitizeErrorBody` truncation (512 runes). |
+| V9 Communications | yes | TLS-only via existing `Insecure` gate; polling reuses same `*http.Client`. |
+| V11 Business Logic | yes | `maxWait` protects against unbounded blocking — explicit footgun mitigation. |
+
+### Known Threat Patterns for chroma-go + Twelve Labs async
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| API key leakage via error message on failed poll | Information Disclosure | Already mitigated — `doPost` never includes headers in error strings; task-endpoint helpers inherit this via the `doPost` mirror pattern. |
+| Oversized response body (malicious server) | Denial of Service | Reuse `chttp.ReadLimitedBody` (200 MB cap) |
+| Unbounded polling causing goroutine pile-up | Denial of Service | `maxWait` + ctx deadline both bound polling time (D-09) |
+| Timer leaks under ctx cancellation | Denial of Service (slow) | Use `time.NewTimer` + `timer.Stop()` (Pitfall 2) |
+| Error body containing user-controlled content echoed to caller logs | Information Disclosure | `chttp.SanitizeErrorBody` truncates to 512 runes with recovery (Phase 25) |
+| Poll loop panicking on malformed JSON | Availability | `json.Unmarshal` returns error; the existing non-panic pattern (`CLAUDE.md` Panic Prevention) is preserved. |
+| Task ID treated as trusted (path injection) | Tampering | `url.PathEscape(taskID)` when constructing `GET /tasks/{id}` — the task ID comes from a Twelve Labs response but defense-in-depth is cheap. |
+
+## Project Constraints (from CLAUDE.md)
+
+- **V2-first:** This phase touches `pkg/embeddings/twelvelabs/` which is shared infra consumed by V2. No V1 impact. Compliant.
+- **No panics in production code:** The new polling helper MUST use error returns, not panics. Timer-based code uses `time.NewTimer` (no panic path). `json.Unmarshal` returns errors. Compliant.
+- **No `Must*` functions:** None required. Compliant.
+- **`errors.Wrap` / `errors.Errorf` from `pkg/errors`:** All new error paths use this (consistent with existing `twelvelabs.go`). Do NOT introduce stdlib `%w` wrapping in this package. Compliant.
+- **Conventional commits:** Commit prefix `feat(twelvelabs): ...` or `fix(twelvelabs): ...`. Phase 26 aligns with a `feat` since it adds a new capability. Applicable.
+- **Build tags:** New tests live under `ef` build tag (D-27). Compliant.
+- **Minimal dependencies:** Zero new deps (D-12). Compliant.
+- **Lint before commit:** `make lint` is phase-gate. Already in Validation Architecture.
+- **Cloud test bar (from MEMORY):** The completion bar is that cloud integration tests exercising the new code path end-to-end pass. Phase 26 is provider-internal and does not touch Cloud API, BUT the `ef`-gated live Twelve Labs test in `twelvelabs_live_test.go` (if it exists) should be considered for a live-key smoke. Planner should check whether a live-async test is feasible given free-tier rate limits (RPM 8; 4-hour task duration makes even one live test expensive). Acceptable to defer live-cloud verification for TLA-* given the httptest-based unit coverage.
+- **Radical simplicity (CLAUDE.md):** Two-endpoint model (not three), minimal async body, extend existing files rather than creating new ones. Compliant.
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- [twelvelabs-python SDK — tasks raw client](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/embed/v_2/tasks/raw_client.py) — endpoint paths, methods, status code handling
+- [twelvelabs-python SDK — EmbeddingTaskResponse](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/types/embedding_task_response.py) — response shape, `_id` alias, `data` nullability
+- [twelvelabs-python SDK — TasksCreateResponse](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/embed/v_2/tasks/types/tasks_create_response.py) — create-response shape, status enum = `"processing"`
+- [twelvelabs-python SDK — embedding_task_response_status](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/types/embedding_task_response_status.py) — full status enum `"processing" | "ready" | "failed"`
+- [twelvelabs-python SDK — EmbeddingData](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/types/embedding_data.py) — `data[].embedding: list[float]`
+- [twelvelabs-python SDK — AudioInputRequest](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/src/twelvelabs/types/audio_input_request.py) — async body shape with list-typed fields
+- [twelvelabs-python SDK — reference.md](https://github.com/twelvelabs-io/twelvelabs-python/blob/main/reference.md) — `reference.md` lines 3984, 4260, 4294-4298, 4399-4474 confirm two-endpoint polling flow
+- Repo codebase reads — existing patterns, file locations, helper signatures
+  - `pkg/embeddings/twelvelabs/twelvelabs.go`
+  - `pkg/embeddings/twelvelabs/content.go`
+  - `pkg/embeddings/twelvelabs/option.go`
+  - `pkg/embeddings/twelvelabs/twelvelabs_test.go`
+  - `pkg/commons/http/utils.go`, `constants.go`, `errors.go`
+  - `.planning/codebase/TESTING.md`, `CONVENTIONS.md`
+
+### Secondary (MEDIUM confidence)
+
+- [Twelve Labs rate-limits docs](https://docs.twelvelabs.io/docs/get-started/rate-limits) — verified no `Retry-After` mention, confirmed `X-RateLimit-*` header names (via WebFetch summary)
+- [Twelve Labs create-embeddings-v2 sync doc](https://docs.twelvelabs.io/api-reference/create-embeddings-v2) — verified sync endpoint description distinguishes 10-min limit → tasks endpoint for longer media (via WebSearch citation)
+
+### Tertiary (LOW confidence)
+
+- None retained. Earlier WebFetch attempts against `docs.twelvelabs.io/api-reference/embed-v2/*` returned 404 and are excluded from this research.
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack: HIGH — zero new deps, all from stdlib + existing packages.
+- Architecture (two-endpoint polling loop): HIGH — verified in generated SDK code.
+- Pitfalls (timer leak, `_id` alias, shape divergence, maxWait/ctx split): HIGH — verified from SDK source + direct codebase read.
+- Error semantics (sanitization, status enum, unexpected-value handling): HIGH — Phase 25 convention + SDK enum.
+- Request body for tasks endpoint (minimal-body hypothesis): MEDIUM — Assumption A1 not verified with a live server call; SDK shows many optional fields, server behavior for omitted fields is inferred not confirmed.
+- Failed-task reason field name: LOW — not declared in SDK types (Pydantic `extra="allow"`); mitigation is to sanitize the full response body (Assumption A3).
+
+**Research date:** 2026-04-14
+**Valid until:** 2026-05-14 (30 days — Twelve Labs API is stable; Marengo 3.0 reindex was announced for mid-March 2026 and is already in effect).
+
+## RESEARCH COMPLETE
+
+**Phase:** 26 - twelve-labs-async-embedding
+**Confidence:** HIGH
+
+### Key Findings
+
+- Only two task endpoints exist, not three. `GET /embed-v2/tasks/{task_id}` returns both status AND data; no `/status` sub-path is used by the official Python SDK. This SIMPLIFIES the implementation relative to CONTEXT.md D-01. (Flag F-01)
+- Async request body differs from sync body: `embedding_option` is `list[string]` (async) vs `string` (sync). A dedicated `AsyncEmbedV2Request` / `AsyncAudioInput` / `AsyncVideoInput` type is needed, or the existing single-value option must be wrapped in a list. (Flag F-02)
+- Task response uses `_id` (Mongo-style) not `id` as the JSON field for the task identifier. Miss this and polling hits `GET /tasks//` (empty segment). Tests must emit `_id` in fixtures.
+- Status enum is exactly `"processing" | "ready" | "failed"` (D-14 is correct). Unexpected values should be a distinct error (D-16 is correct).
+- `maxWait` must be tracked independently from the caller's `ctx` (do NOT derive a child ctx from `maxWait`), otherwise D-20's distinct-error requirement cannot be satisfied.
+
+### File Created
+
+`/Users/tazarov/GolandProjects/chroma-go/.planning/phases/26-twelve-labs-async-embedding/26-RESEARCH.md`
+
+### Confidence Assessment
+
+| Area | Level | Reason |
+|------|-------|--------|
+| Standard Stack | HIGH | Zero new deps; all existing packages. |
+| Architecture | HIGH | Verified against Fern-generated official SDK source. |
+| Pitfalls | HIGH | `_id` alias, timer leaks, and body-shape divergence are concrete and sourced. |
+| Minimal async body acceptance | MEDIUM | Assumption A1 requires a live call or spike to prove. |
+| Failed-task reason field | LOW | Pydantic `extra="allow"` hides exact field name; mitigation via full-body sanitization. |
+
+### Open Questions
+
+- Minimum required fields for `POST /embed-v2/tasks` (can we send only `media_source`?).
+- Exact JSON field name of the failure reason on a `failed` task response.
+- Whether the live Twelve Labs environment accepts `fused` as an async audio `embedding_option` or whether we must reject it at option time.
+
+### Ready for Planning
+
+Research complete. Planner can now create PLAN.md files. Recommended first plan step: address Flag F-01 (collapse to two endpoints) and Flag F-02 (introduce async-specific request types) in the shared task-endpoint helper, then layer polling + routing + tests. Planner should treat the five assumptions in the Assumptions Log as items to verify via code review or optional UAT — none block implementation.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW-FIX.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW-FIX.md
@@ -1,0 +1,67 @@
+---
+phase: 26-twelve-labs-async-embedding
+fixed_at: 2026-04-14T00:00:00Z
+review_path: .planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
+iteration: 1
+findings_in_scope: 2
+fixed: 2
+skipped: 0
+status: all_fixed
+---
+
+# Phase 26: Code Review Fix Report
+
+**Fixed at:** 2026-04-14
+**Source review:** .planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
+**Iteration:** 1
+
+**Summary:**
+- Findings in scope: 2 (Critical=0, Warning=2)
+- Fixed: 2
+- Skipped: 0
+
+Info-level findings (IN-01 .. IN-04) were intentionally out of scope per the
+`critical_warning` fix scope.
+
+## Fixed Issues
+
+### WR-01: Task-create call is not bounded by `maxWait`
+
+**Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_async.go`, `pkg/embeddings/twelvelabs/option.go`
+**Commit:** 598f823
+**Applied fix:**
+- In `createTaskAndPoll`, wrap `e.doTaskPost` in a derived context bounded by
+  `min(parent ctx deadline, sdk maxWait deadline)` — same pattern used per-call
+  inside `pollTask`. The `cancel()` is invoked unconditionally after the call.
+- On error, translate `context.DeadlineExceeded` into the distinct SDK message
+  `Twelve Labs async task create maxWait %s exceeded` when `sdkMaxWaitDeadline`
+  has elapsed, and into `Twelve Labs async task create deadline exceeded` when
+  the parent ctx fired first. `context.Canceled` translates to a distinct
+  cancel message. Other errors retain the original `failed to create Twelve
+  Labs async task` wrap to preserve the prior surface for non-deadline
+  failures.
+- Updated the `WithAsyncPolling` godoc to state explicitly that `maxWait` is a
+  hard upper bound on the **whole async operation** (create + polling), not
+  just polling, matching the new behavior and the D-09 design note.
+
+### WR-02: No regression test for `doTaskPost` non-2xx error path
+
+**Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_test.go`
+**Commit:** 7322514
+**Applied fix:** Added three regression tests modeled on the existing sync
+`doPost` error-path coverage:
+- `TestTwelveLabsAsyncTaskCreateError` — structured `{message,code}` 4xx body;
+  asserts the wrap text `task create error` and message contents survive.
+- `TestTwelveLabsAsyncTaskCreateErrorSanitizesStructuredMessage` — long
+  structured message body; asserts the `[truncated]` suffix appears and the
+  full long body does not.
+- `TestTwelveLabsAsyncTaskCreateErrorRawFallback` — non-JSON 5xx body;
+  asserts the `unexpected status` raw-fallback branch fires with truncation.
+
+All three pass under `go test -tags=ef`.
+
+---
+
+_Fixed: 2026-04-14_
+_Fixer: Claude (gsd-code-fixer)_
+_Iteration: 1_

--- a/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW-FIX.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW-FIX.md
@@ -3,8 +3,8 @@ phase: 26-twelve-labs-async-embedding
 fixed_at: 2026-04-14T00:00:00Z
 review_path: .planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
 iteration: 1
-findings_in_scope: 2
-fixed: 2
+findings_in_scope: 1
+fixed: 1
 skipped: 0
 status: all_fixed
 ---
@@ -16,52 +16,31 @@ status: all_fixed
 **Iteration:** 1
 
 **Summary:**
-- Findings in scope: 2 (Critical=0, Warning=2)
-- Fixed: 2
+- Findings in scope: 1 (Critical=0, Warning=1)
+- Fixed: 1
 - Skipped: 0
-
-Info-level findings (IN-01 .. IN-04) were intentionally out of scope per the
-`critical_warning` fix scope.
 
 ## Fixed Issues
 
-### WR-01: Task-create call is not bounded by `maxWait`
+### WR-01: HTTP client timeouts can erase the error or panic the async path
 
-**Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_async.go`, `pkg/embeddings/twelvelabs/option.go`
-**Commit:** 598f823
+**Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_async.go`, `pkg/embeddings/twelvelabs/twelvelabs_test.go`
+**Commit:** `abf8b62`
+
 **Applied fix:**
-- In `createTaskAndPoll`, wrap `e.doTaskPost` in a derived context bounded by
-  `min(parent ctx deadline, sdk maxWait deadline)` — same pattern used per-call
-  inside `pollTask`. The `cancel()` is invoked unconditionally after the call.
-- On error, translate `context.DeadlineExceeded` into the distinct SDK message
-  `Twelve Labs async task create maxWait %s exceeded` when `sdkMaxWaitDeadline`
-  has elapsed, and into `Twelve Labs async task create deadline exceeded` when
-  the parent ctx fired first. `context.Canceled` translates to a distinct
-  cancel message. Other errors retain the original `failed to create Twelve
-  Labs async task` wrap to preserve the prior surface for non-deadline
-  failures.
-- Updated the `WithAsyncPolling` godoc to state explicitly that `maxWait` is a
-  hard upper bound on the **whole async operation** (create + polling), not
-  just polling, matching the new behavior and the D-09 design note.
+- Guarded both async timeout-translation branches so `ctx.Err()` is only wrapped when the parent context actually expired.
+- When a caller-supplied `WithHTTPClient(...)` timeout fires before either the SDK `maxWait` deadline or the parent context, the SDK now preserves the original transport timeout as a non-nil error instead of collapsing to `nil`.
+- The polling path now returns a wrapped timeout error instead of `(nil, nil)`, which prevents `createTaskAndPoll` from dereferencing a nil task result.
 
-### WR-02: No regression test for `doTaskPost` non-2xx error path
+**Regression coverage added:**
+- `TestTwelveLabsAsyncTaskCreateClientTimeoutReturnsError`
+- `TestTwelveLabsAsyncPollClientTimeoutReturnsErrorWithoutPanic`
 
-**Files modified:** `pkg/embeddings/twelvelabs/twelvelabs_test.go`
-**Commit:** 7322514
-**Applied fix:** Added three regression tests modeled on the existing sync
-`doPost` error-path coverage:
-- `TestTwelveLabsAsyncTaskCreateError` — structured `{message,code}` 4xx body;
-  asserts the wrap text `task create error` and message contents survive.
-- `TestTwelveLabsAsyncTaskCreateErrorSanitizesStructuredMessage` — long
-  structured message body; asserts the `[truncated]` suffix appears and the
-  full long body does not.
-- `TestTwelveLabsAsyncTaskCreateErrorRawFallback` — non-JSON 5xx body;
-  asserts the `unexpected status` raw-fallback branch fires with truncation.
-
-All three pass under `go test -tags=ef`.
+**Verification:**
+- `go test -tags=ef ./pkg/embeddings/twelvelabs`
 
 ---
 
 _Fixed: 2026-04-14_
-_Fixer: Claude (gsd-code-fixer)_
+_Fixer: Codex_
 _Iteration: 1_

--- a/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
@@ -11,9 +11,9 @@ files_reviewed_list:
   - pkg/embeddings/twelvelabs/twelvelabs_test.go
 findings:
   critical: 0
-  warning: 2
-  info: 4
-  total: 6
+  warning: 1
+  info: 0
+  total: 1
 status: issues_found
 ---
 
@@ -26,108 +26,51 @@ status: issues_found
 
 ## Summary
 
-Phase 26 adds async polling for the Twelve Labs `/tasks` endpoint (audio/video modalities) while leaving text/image on the sync `/embed-v2` path. The implementation is well-structured and correctly handles the documented pitfalls:
-
-- **Mongo-style `_id` alias** — correctly modeled on both `TaskCreateResponse.ID` and `TaskResponse.ID`, with fixture helpers in the tests using the `_id` wire form (Pitfall 1 guarded).
-- **Fused+async rejection** — deterministic rejection lives in `contentToAsyncRequest` before any HTTP call, with a dedicated regression test (`TestTwelveLabsAsyncFusedRejected`) asserting no HTTP call fires.
-- **Per-HTTP-call deadline** — the polling loop wraps every `doTaskGet` in a `context.WithDeadline(ctx, min(parentDL, sdkMaxWaitDeadline))`, and `TestTwelveLabsAsyncBlockedHTTPMaxWait` proves a blocked HTTP call is unblocked at `maxWait` without collapsing into `context.DeadlineExceeded` (D-20).
-- **Failure-reason sanitization** — `doTaskGet` copies `respData` into `TaskResponse.FailureDetail` via `append(json.RawMessage(nil), respData...)`, preserving the authentic server body rather than re-marshaling the parsed struct; `TestTwelveLabsAsyncFailedReasonSanitized` covers this end-to-end (D-17).
-- **Context propagation** — `context.WithDeadline` cleanup via `cancel()` is invoked unconditionally after every `doTaskGet`, and the `select` block uses `timer.Stop()` before returning from cancel. No goroutine or timer leaks.
-- **Config round-trip** — `WithAsyncPolling` disabled by default; rebuilding from config requires both keys present and parseable (good "refuse broken input rather than silently apply 30-min default").
-
-Two warnings below concern scope gaps around the `doTaskPost` (create) call — it is not bounded by `maxWait` and its failure path has no regression test. Four info-level items cover minor design observations and a small dead branch. Nothing rises to critical.
+Phase 26's async Twelve Labs path is generally well-structured: audio/video routing is isolated, the create and poll requests are both bounded by derived deadlines, and the new tests cover the intended happy-path and cancellation behaviors. The one material regression is in the timeout translation logic: transport-level `context.DeadlineExceeded` errors from caller-supplied HTTP clients are treated as if they always came from either the SDK `maxWait` deadline or the parent context, which is not true.
 
 ## Warnings
 
-### WR-01: Task-create call is not bounded by `maxWait`
+### WR-01: HTTP client timeouts can erase the error or panic the async path
 
-**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:142`
-**Issue:** `createTaskAndPoll` calls `e.doTaskPost(ctx, *req)` with the caller's parent context only. The polling loop correctly caps each GET by `min(parentDL, sdkMaxWaitDeadline)`, but the initial POST to `/tasks` has no SDK-side upper bound. A user who sets `WithAsyncPolling(30 * time.Second)` with a context that has no deadline reasonably expects the whole operation to finish in ~30s, but a blocked create call will hang until the underlying `http.Client` transport times out (default: forever). This also weakens the guarantee advertised in the CONTEXT D-09 design note that `maxWait` is a hard bound. The blocked-HTTP regression test (`TestTwelveLabsAsyncBlockedHTTPMaxWait`) only exercises the GET path — a POST that blocks forever would not be caught.
+**Files:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:77-82`, `pkg/embeddings/twelvelabs/twelvelabs_async.go:158-163`
 
-**Fix:** Wrap the create call with the same derived deadline pattern used in `pollTask`, and add a regression test that blocks the POST handler similarly:
+**Issue:** Both timeout-translation branches assume every `context.DeadlineExceeded` returned from `doTaskGet` or `doTaskPost` came from either:
+
+1. the SDK's derived `maxWait` deadline, or
+2. the caller's parent `ctx`.
+
+That assumption breaks as soon as the caller uses the supported `WithHTTPClient(...)` option with a client-level timeout or transport deadline. In that case `Client.Do(...)` returns an error that satisfies `errors.Is(err, context.DeadlineExceeded)`, but `ctx.Err()` is still `nil` and the SDK `maxWait` deadline has not elapsed yet.
+
+The current code then executes `errors.Wrap(ctx.Err(), "...")`. With `github.com/pkg/errors`, `errors.Wrap(nil, "...")` returns `nil`, so the timeout is silently erased.
+
+**Observed consequences (reproduced locally against the current code):**
+
+- Slow `POST /tasks` with `WithHTTPClient(&http.Client{Timeout: 50 * time.Millisecond})` returns `emb=nil, err=nil`.
+- Slow `GET /tasks/{id}` with the same client returns `(nil, nil)` from `pollTask`, after which `createTaskAndPoll` panics on `buildEmbeddingFromData(final.Data)` because `final == nil`.
+
+**Why this matters:** `WithHTTPClient` is part of the public API, so this is a realistic integration path, not a synthetic edge case. Any consumer that adds a client timeout for safety can get silent success on task creation or a nil-pointer panic during polling.
+
+**Fix:** Only wrap `ctx.Err()` when it is actually non-nil. Otherwise preserve the original transport error or return a dedicated timeout error for client-level deadlines. For example:
+
 ```go
-func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
-    req, err := contentToAsyncRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
-    if err != nil {
-        return nil, err
-    }
-    sdkDeadline := time.Now().Add(e.apiClient.asyncMaxWait)
-    createDeadline := sdkDeadline
-    if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(createDeadline) {
-        createDeadline = parentDL
-    }
-    createCtx, cancel := context.WithDeadline(ctx, createDeadline)
-    created, err := e.doTaskPost(createCtx, *req)
-    cancel()
-    if err != nil {
-        // translate deadline errors the same way pollTask does so maxWait
-        // on the create call surfaces as the distinct SDK error, not raw
-        // context.DeadlineExceeded (D-20).
-        ...
-    }
-    ...
-}
-```
-If the decision is that `maxWait` deliberately bounds *polling only*, document that explicitly in the `WithAsyncPolling` godoc and keep the current behavior — but the current docstring ("hard bound" in the review context) implies whole-operation scope.
-
-### WR-02: No regression test for `doTaskPost` non-2xx error path
-
-**File:** `pkg/embeddings/twelvelabs/twelvelabs_test.go` (coverage gap)
-**Issue:** `doTaskPost` has the same structured-error-then-raw-fallback logic as `doPost` (twelvelabs.go:290-296), but the test suite only covers the sync `doPost` error paths (`TestTwelveLabsAPIError*` family). A regression that breaks the create-error branch — for example, forgetting to sanitize or returning the wrong wrap — would go undetected until a real Twelve Labs 4xx arrives in production.
-
-**Fix:** Add a test that returns a structured error on POST `/tasks` and asserts both the message text and the sanitization suffix, mirroring `TestTwelveLabsAPIErrorSanitizesStructuredMessage`:
-```go
-func TestTwelveLabsAsyncTaskCreateError(t *testing.T) {
-    srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json")
-        w.WriteHeader(http.StatusBadRequest)
-        fmt.Fprint(w, `{"message":"invalid media source","code":"E_BAD_SRC"}`)
-    })
-    ef := newTestAsyncEF(srv.URL)
-    _, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
-    require.Error(t, err)
-    assert.Contains(t, err.Error(), "task create error")
-    assert.Contains(t, err.Error(), "invalid media source")
+if errors.Is(err, context.DeadlineExceeded) {
+	if !time.Now().Before(sdkMaxWaitDeadline) {
+		return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, errors.Wrap(ctxErr, "Twelve Labs async polling deadline exceeded")
+	}
+	return nil, errors.Wrap(err, "Twelve Labs async polling request timed out")
 }
 ```
 
-## Info
+Apply the same pattern to the task-create branch, then add two regressions:
 
-### IN-01: `AsyncAudioInput.EmbeddingOption` nil-branch is effectively unreachable
-
-**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:36-38`
-**Issue:** `applyDefaults` always sets `AudioEmbeddingOption` to `"audio"` when empty (twelvelabs.go:63-65), so `audioOpt == ""` never happens at `contentToAsyncRequest` call sites. The `if audioOpt != ""` guard is dead defensive code — harmless but suggests either removing it or testing the pass-through-nil path by constructing a client that bypasses `applyDefaults`.
-**Fix:** Either drop the guard (`audio.EmbeddingOption = []string{audioOpt}` unconditionally) or leave a comment noting it's belt-and-suspenders for direct struct construction in tests.
-
-### IN-02: `createTaskAndPoll` early-ready path handles `Data == nil` inconsistently
-
-**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:149-152`
-**Issue:** The early-ready shortcut requires *both* `Status == "ready"` *and* `len(Data) > 0`. If the server returns `status=ready` with empty data in the create response (rare but possible per F-01 — the create endpoint is documented to sometimes return `ready`), the code falls through to `pollTask`, which will issue a GET against an already-terminal task. Likely fine because the GET will return the same ready+data payload, but it wastes a round-trip and subtly diverges from the "rare early-ready" comment's intent.
-**Fix:** Either treat `ready` with empty data as an error (defensive: "task reported ready with no data") or accept the extra GET as harmless and document why.
-
-### IN-03: `WithAsyncPolling` sets `asyncPollingEnabled` before validating `maxWait`
-
-**File:** `pkg/embeddings/twelvelabs/option.go:106-117`
-**Issue:** The negative-`maxWait` branch returns an error after the option has already mutated `p.asyncPollingEnabled = true` — wait, checking the ordering: actually the negative check is *first* (line 107-109), then the mutation. My apologies; re-reading confirms the order is correct. Leaving this as an observation: the construction in `NewTwelveLabsClient` discards the partial client on any option error, so even if ordering were reversed there would be no observable effect.
-**Fix:** None required.
-
-### IN-04: `pollTask` backoff has no jitter
-
-**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:128-134`
-**Issue:** `nextBackoff` is a deterministic exponential with a cap. When many goroutines share a Twelve Labs deployment (e.g., a worker pool processing a video batch), synchronized polling cycles are possible (thundering herd at each interval boundary). CONTEXT D-04 frames the backoff as internal and un-tunable, which is fine for now, but adding +/- 20% jitter is the standard defense and costs nothing.
-**Fix:** Optional future hardening — add jitter:
-```go
-func nextBackoff(cur time.Duration, mul float64, cap time.Duration) time.Duration {
-    next := time.Duration(float64(cur) * mul)
-    if next > cap { next = cap }
-    // Full jitter per AWS architecture blog recommendation:
-    return time.Duration(rand.Int63n(int64(next)))
-}
-```
-Not required for v1 — document as deliberate omission.
+- delayed `POST /tasks` with a short custom HTTP client timeout must return a non-nil error
+- delayed `GET /tasks/{id}` with a short custom HTTP client timeout must return a non-nil error and must not panic
 
 ---
 
 _Reviewed: 2026-04-14_
-_Reviewer: Claude (gsd-code-reviewer)_
+_Reviewer: Codex_
 _Depth: standard_

--- a/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-REVIEW.md
@@ -1,0 +1,133 @@
+---
+phase: 26-twelve-labs-async-embedding
+reviewed: 2026-04-14T00:00:00Z
+depth: standard
+files_reviewed: 5
+files_reviewed_list:
+  - pkg/embeddings/twelvelabs/content.go
+  - pkg/embeddings/twelvelabs/option.go
+  - pkg/embeddings/twelvelabs/twelvelabs.go
+  - pkg/embeddings/twelvelabs/twelvelabs_async.go
+  - pkg/embeddings/twelvelabs/twelvelabs_test.go
+findings:
+  critical: 0
+  warning: 2
+  info: 4
+  total: 6
+status: issues_found
+---
+
+# Phase 26: Code Review Report
+
+**Reviewed:** 2026-04-14
+**Depth:** standard
+**Files Reviewed:** 5
+**Status:** issues_found
+
+## Summary
+
+Phase 26 adds async polling for the Twelve Labs `/tasks` endpoint (audio/video modalities) while leaving text/image on the sync `/embed-v2` path. The implementation is well-structured and correctly handles the documented pitfalls:
+
+- **Mongo-style `_id` alias** — correctly modeled on both `TaskCreateResponse.ID` and `TaskResponse.ID`, with fixture helpers in the tests using the `_id` wire form (Pitfall 1 guarded).
+- **Fused+async rejection** — deterministic rejection lives in `contentToAsyncRequest` before any HTTP call, with a dedicated regression test (`TestTwelveLabsAsyncFusedRejected`) asserting no HTTP call fires.
+- **Per-HTTP-call deadline** — the polling loop wraps every `doTaskGet` in a `context.WithDeadline(ctx, min(parentDL, sdkMaxWaitDeadline))`, and `TestTwelveLabsAsyncBlockedHTTPMaxWait` proves a blocked HTTP call is unblocked at `maxWait` without collapsing into `context.DeadlineExceeded` (D-20).
+- **Failure-reason sanitization** — `doTaskGet` copies `respData` into `TaskResponse.FailureDetail` via `append(json.RawMessage(nil), respData...)`, preserving the authentic server body rather than re-marshaling the parsed struct; `TestTwelveLabsAsyncFailedReasonSanitized` covers this end-to-end (D-17).
+- **Context propagation** — `context.WithDeadline` cleanup via `cancel()` is invoked unconditionally after every `doTaskGet`, and the `select` block uses `timer.Stop()` before returning from cancel. No goroutine or timer leaks.
+- **Config round-trip** — `WithAsyncPolling` disabled by default; rebuilding from config requires both keys present and parseable (good "refuse broken input rather than silently apply 30-min default").
+
+Two warnings below concern scope gaps around the `doTaskPost` (create) call — it is not bounded by `maxWait` and its failure path has no regression test. Four info-level items cover minor design observations and a small dead branch. Nothing rises to critical.
+
+## Warnings
+
+### WR-01: Task-create call is not bounded by `maxWait`
+
+**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:142`
+**Issue:** `createTaskAndPoll` calls `e.doTaskPost(ctx, *req)` with the caller's parent context only. The polling loop correctly caps each GET by `min(parentDL, sdkMaxWaitDeadline)`, but the initial POST to `/tasks` has no SDK-side upper bound. A user who sets `WithAsyncPolling(30 * time.Second)` with a context that has no deadline reasonably expects the whole operation to finish in ~30s, but a blocked create call will hang until the underlying `http.Client` transport times out (default: forever). This also weakens the guarantee advertised in the CONTEXT D-09 design note that `maxWait` is a hard bound. The blocked-HTTP regression test (`TestTwelveLabsAsyncBlockedHTTPMaxWait`) only exercises the GET path — a POST that blocks forever would not be caught.
+
+**Fix:** Wrap the create call with the same derived deadline pattern used in `pollTask`, and add a regression test that blocks the POST handler similarly:
+```go
+func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+    req, err := contentToAsyncRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
+    if err != nil {
+        return nil, err
+    }
+    sdkDeadline := time.Now().Add(e.apiClient.asyncMaxWait)
+    createDeadline := sdkDeadline
+    if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(createDeadline) {
+        createDeadline = parentDL
+    }
+    createCtx, cancel := context.WithDeadline(ctx, createDeadline)
+    created, err := e.doTaskPost(createCtx, *req)
+    cancel()
+    if err != nil {
+        // translate deadline errors the same way pollTask does so maxWait
+        // on the create call surfaces as the distinct SDK error, not raw
+        // context.DeadlineExceeded (D-20).
+        ...
+    }
+    ...
+}
+```
+If the decision is that `maxWait` deliberately bounds *polling only*, document that explicitly in the `WithAsyncPolling` godoc and keep the current behavior — but the current docstring ("hard bound" in the review context) implies whole-operation scope.
+
+### WR-02: No regression test for `doTaskPost` non-2xx error path
+
+**File:** `pkg/embeddings/twelvelabs/twelvelabs_test.go` (coverage gap)
+**Issue:** `doTaskPost` has the same structured-error-then-raw-fallback logic as `doPost` (twelvelabs.go:290-296), but the test suite only covers the sync `doPost` error paths (`TestTwelveLabsAPIError*` family). A regression that breaks the create-error branch — for example, forgetting to sanitize or returning the wrong wrap — would go undetected until a real Twelve Labs 4xx arrives in production.
+
+**Fix:** Add a test that returns a structured error on POST `/tasks` and asserts both the message text and the sanitization suffix, mirroring `TestTwelveLabsAPIErrorSanitizesStructuredMessage`:
+```go
+func TestTwelveLabsAsyncTaskCreateError(t *testing.T) {
+    srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.WriteHeader(http.StatusBadRequest)
+        fmt.Fprint(w, `{"message":"invalid media source","code":"E_BAD_SRC"}`)
+    })
+    ef := newTestAsyncEF(srv.URL)
+    _, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+    require.Error(t, err)
+    assert.Contains(t, err.Error(), "task create error")
+    assert.Contains(t, err.Error(), "invalid media source")
+}
+```
+
+## Info
+
+### IN-01: `AsyncAudioInput.EmbeddingOption` nil-branch is effectively unreachable
+
+**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:36-38`
+**Issue:** `applyDefaults` always sets `AudioEmbeddingOption` to `"audio"` when empty (twelvelabs.go:63-65), so `audioOpt == ""` never happens at `contentToAsyncRequest` call sites. The `if audioOpt != ""` guard is dead defensive code — harmless but suggests either removing it or testing the pass-through-nil path by constructing a client that bypasses `applyDefaults`.
+**Fix:** Either drop the guard (`audio.EmbeddingOption = []string{audioOpt}` unconditionally) or leave a comment noting it's belt-and-suspenders for direct struct construction in tests.
+
+### IN-02: `createTaskAndPoll` early-ready path handles `Data == nil` inconsistently
+
+**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:149-152`
+**Issue:** The early-ready shortcut requires *both* `Status == "ready"` *and* `len(Data) > 0`. If the server returns `status=ready` with empty data in the create response (rare but possible per F-01 — the create endpoint is documented to sometimes return `ready`), the code falls through to `pollTask`, which will issue a GET against an already-terminal task. Likely fine because the GET will return the same ready+data payload, but it wastes a round-trip and subtly diverges from the "rare early-ready" comment's intent.
+**Fix:** Either treat `ready` with empty data as an error (defensive: "task reported ready with no data") or accept the extra GET as harmless and document why.
+
+### IN-03: `WithAsyncPolling` sets `asyncPollingEnabled` before validating `maxWait`
+
+**File:** `pkg/embeddings/twelvelabs/option.go:106-117`
+**Issue:** The negative-`maxWait` branch returns an error after the option has already mutated `p.asyncPollingEnabled = true` — wait, checking the ordering: actually the negative check is *first* (line 107-109), then the mutation. My apologies; re-reading confirms the order is correct. Leaving this as an observation: the construction in `NewTwelveLabsClient` discards the partial client on any option error, so even if ordering were reversed there would be no observable effect.
+**Fix:** None required.
+
+### IN-04: `pollTask` backoff has no jitter
+
+**File:** `pkg/embeddings/twelvelabs/twelvelabs_async.go:128-134`
+**Issue:** `nextBackoff` is a deterministic exponential with a cap. When many goroutines share a Twelve Labs deployment (e.g., a worker pool processing a video batch), synchronized polling cycles are possible (thundering herd at each interval boundary). CONTEXT D-04 frames the backoff as internal and un-tunable, which is fine for now, but adding +/- 20% jitter is the standard defense and costs nothing.
+**Fix:** Optional future hardening — add jitter:
+```go
+func nextBackoff(cur time.Duration, mul float64, cap time.Duration) time.Duration {
+    next := time.Duration(float64(cur) * mul)
+    if next > cap { next = cap }
+    // Full jitter per AWS architecture blog recommendation:
+    return time.Duration(rand.Int63n(int64(next)))
+}
+```
+Not required for v1 — document as deliberate omission.
+
+---
+
+_Reviewed: 2026-04-14_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/26-twelve-labs-async-embedding/26-REVIEWS.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-REVIEWS.md
@@ -1,0 +1,203 @@
+---
+phase: 26
+reviewers: [gemini, codex]
+reviewed_at: 2026-04-14T07:17:23Z
+plans_reviewed: [26-01-PLAN.md, 26-02-PLAN.md, 26-03-PLAN.md, 26-04-PLAN.md]
+self_cli_skipped: claude
+---
+
+# Cross-AI Plan Review — Phase 26
+
+## Gemini Review
+
+# Phase 26 Implementation Plan Review: Twelve Labs Async Embedding
+
+This review covers plans **26-01** through **26-04** for the Twelve Labs Async Embedding phase of the `chroma-go` SDK.
+
+### 1. Summary
+
+The implementation plans for Phase 26 are of **exceptionally high quality**, demonstrating deep alignment with the project's engineering standards and the specific constraints discovered during research. The strategy follows a clean **Wave-based execution** (Wave 1: Plumbing, Wave 2: Logic/Routing/Options, Wave 3: Validation) that minimizes file conflicts and ensures a robust foundation. The transition from the originally hypothesized three-endpoint model to the researched two-endpoint reality (F-01) is correctly handled. The plans rigorously address "timeout-bug-fix" framing by keeping the public API surface minimal while hardening internal polling with capped exponential backoff and independent `maxWait` bounds.
+
+### 2. Strengths
+
+- **Research Integration:** The plans faithfully execute on the findings in `26-RESEARCH.md`, specifically the `_id` JSON alias (Pitfall 1), the two-endpoint polling collapse (F-01), and the distinct request body shapes for async (F-02).
+- **Engineering Standards:** Strict adherence to "no panics," `pkg/errors` for wrapping, `chttp` for sanitization, and `time.NewTimer` to avoid leaks.
+- **Defensive Design:** The independent `maxWait` deadline (D-20) is correctly implemented without deriving child contexts, ensuring that callers can distinguish between an SDK-level timeout and their own context expiration.
+- **Lossless Config Round-trip:** The plan for `GetConfig` and `FromConfig` (D-21/22/23) handles type coercion (int/float/int64) and conditional emission, ensuring registry persistence is stable.
+- **Validation Rigor:** The test suite in Plan 04 is comprehensive, covering edge cases like unexpected status codes, context cancellation, and modality-based skip rules.
+
+### 3. Concerns
+
+- **Assumption A5 (The "Fused" Audio Option):**
+  - **Severity: MEDIUM**
+  - **Description:** `RESEARCH.md` Assumption A5 and Flag F-02 note that the async endpoint's `embedding_option` list only supports `audio` and `transcription`, whereas the sync `fused` option is represented via a separate `embedding_type` field in the async API.
+  - **Gap:** Plan 02's `contentToAsyncRequest` simply wraps the existing `AudioEmbeddingOption` string in a list. If a user has `WithAudioEmbeddingOption("fused")` and enables async polling, the resulting request `{"embedding_option": ["fused"]}` may be rejected by the Twelve Labs API.
+- **Async Body Minimalist Risk (A1):**
+  - **Severity: LOW**
+  - **Description:** Plan 01/02 assume a minimal body (omitting `embedding_scope` and `embedding_type` arrays) is accepted. While likely, if the server requires empty arrays instead of null/omitted fields, Plan 01's types will need a quick adjustment to remove `omitempty` or provide defaults.
+- **Dependency Ordering for Parallelism:**
+  - **Severity: LOW**
+  - **Description:** Plan 02 and 03 are both marked as `Wave 2` and `depends_on: [26-01]`. This is correct for concurrency, but since they both modify `twelvelabs.go` (Plan 03 adds Config/FromConfig logic), the executor must be careful with turn-sequencing to avoid git conflicts if running automated tools.
+
+### 4. Suggestions
+
+- **Address the "Fused" Mapping:** In Plan 02, Task 1 (`contentToAsyncRequest`), add a check: if `audioOpt == "fused"`, either return an error stating that `fused` is not yet supported for async polling, or (better) transform it correctly. Given the "radical simplicity" mandate, a simple validation error in `WithAsyncPolling` or `contentToAsyncRequest` when `fused` is active is a safe fallback.
+- **Refined Poll-First Logic:** In Plan 02, Task 1 (`pollTask`), ensure the code explicitly handles the case where `doTaskGet` returns "ready" on the very first call (rare but documented). The current plan pseudocode handles this correctly via the `for { poll; switch status }` structure.
+- **Test Identity Verification:** In Plan 04, Task 2 (`TestTwelveLabsAsyncConfigRoundTrip`), ensure the test also asserts that `APIKeyEnvVar` is correctly restored, as this is a common point of failure in registry round-trips.
+
+### 5. Risk Assessment: LOW
+
+The overall risk is **LOW**. The plans are surgical and highly defensive. The primary risk (API contract mismatch for "fused" or minimal bodies) is mitigated by the comprehensive `httptest`-based suite which will catch type/logic errors, and the fact that the feature is gated behind a new, explicit functional option, preventing regressions for all existing users.
+
+**Recommendation:** Proceed to Execution. *Note to executor: Pay close attention to the "fused" option mapping in Plan 02.*
+
+---
+
+## Codex Review
+
+### Key Findings
+
+- `[HIGH]` `26-02-PLAN.md:191` checks `maxWait` only between polls. A slow or hung `doTaskGet`/`doTaskPost` can run past `maxWait`, so D-09/TLA-02 are not actually guaranteed.
+- `[HIGH]` `26-02-PLAN.md:172` blindly wraps `audioOpt` into `[]string{audioOpt}`. The current provider already accepts `"fused"` in `pkg/embeddings/twelvelabs/option.go:76`, but research says async tasks do not; this needs explicit reject-or-map logic.
+- `[HIGH]` `26-01-PLAN.md:170` and `26-02-PLAN.md:202` throw away raw failed-task payloads, then build the error reason from the parsed struct. That will likely miss the real server failure reason and weakens D-17/TLA-03.
+- `[MEDIUM]` `26-04-PLAN.md:131` uses `embeddings.ContentPart`, but the actual type is `embeddings.Part` in `pkg/embeddings/multimodal.go:54`. The test plan, as written, does not compile. **(Verified: 5 occurrences in 26-04-PLAN.md; `ContentPart` does not exist in the embeddings package.)**
+- `[LOW]` The plans themselves use the corrected 2-endpoint model, but stale 3-endpoint references still remain in `26-CONTEXT.md:14` and `26-CONTEXT.md:37`. That should be cleaned up to avoid executor drift.
+
+### 26-01-PLAN
+
+Summary: Strong wave-1 foundation. It correctly anchors the implementation on two task endpoints, preserves existing transport conventions, and sequences the shared types/helpers before routing and public option work. The main gap is that the proposed response model is too thin for the later error-semantics requirement.
+
+Strengths
+- Correctly adopts the 2-endpoint model and `_id` alias.
+- Reuses `ReadLimitedBody`, `SanitizeErrorBody`, existing headers, and existing `doPost` structure.
+- Good dependency split: types/helpers first, behavior later.
+- Keeps public API unchanged in wave 1.
+
+Concerns
+- `[MEDIUM]` `26-01-PLAN.md:180` `TaskResponse` only keeps `ID`, `Status`, and `Data`. That makes D-17 hard to satisfy because failed-task reason fields are discarded before Plan 02 can use them.
+- `[LOW]` Verification is mostly grep/build based; there is no small decode test proving `_id` and `[]string` behavior at runtime in this wave.
+
+Suggestions
+- Add either a raw-response return path for `doTaskGet`, or a `json.RawMessage`/failure-detail field so Plan 02 can emit real failed-task reasons.
+- Add one minimal unit test for `_id` decode and `embedding_option` array shape instead of relying only on grep.
+
+Risk Assessment
+- `MEDIUM`: good structure, but the response-shape choice can block correct TLA-03 behavior later.
+
+### 26-02-PLAN
+
+Summary: This is the critical plan and the one with the most real risk. The routing split, timer-leak avoidance, and status-machine design are good, but the proposed polling implementation does not fully enforce the stated timeout contract and it leaves one known async request-shape incompatibility unresolved.
+
+Strengths
+- Clean isolation into `twelvelabs_async.go` reduces merge conflict risk.
+- Correct poll-first/sleep-second structure.
+- Explicit `processing`/`ready`/`failed`/unknown status handling.
+- Correctly avoids `time.After` in the loop.
+- Keeps text/image on sync path and gates async by flag + modality.
+
+Concerns
+- `[HIGH]` `26-02-PLAN.md:191` `maxWait` is enforced only after `doTaskGet` returns. A blocked HTTP request can outlive `maxWait`, which violates D-09's "minimum of ctx deadline and maxWait."
+- `[HIGH]` `26-02-PLAN.md:172` wrapping `audioOpt` into a list will send `["fused"]` for existing valid sync configs, but research already flagged that as invalid for async.
+- `[HIGH]` `26-02-PLAN.md:203` marshaling `TaskResponse` back to JSON on failure loses any undeclared server reason fields; the resulting error message may contain no useful reason at all.
+- `[MEDIUM]` `26-02-PLAN.md:223` wraps both cancellation and deadline with `"async polling canceled"`, which is inaccurate when the parent context deadline expires.
+
+Suggestions
+- Bound each HTTP call with a derived per-call deadline of `min(parent ctx deadline, maxWait deadline)`, then translate expiry back to a distinct maxWait error when the SDK bound fired first.
+- Explicitly reject `WithAudioEmbeddingOption("fused")` on the async path unless you also implement the correct async `embedding_type` mapping.
+- Preserve raw task-response bytes for failed-task errors, or parse/store the failure detail field explicitly.
+- Change the ctx wrap message to neutral wording like `"async polling stopped"`.
+
+Risk Assessment
+- `HIGH`: this plan carries the core correctness and currently leaves TLA-02 and TLA-03 partially unmet.
+
+### 26-03-PLAN
+
+Summary: Good minimal public surface. The option shape is consistent with the phase boundary and the config round-trip design matches existing provider patterns. The main issue is a small but real mismatch between the stated behavior and the sample implementation for malformed config values.
+
+Strengths
+- Keeps async enablement to one option, which matches the "timeout-bug-fix, not async-DX" framing.
+- Correct defaulting and omission behavior.
+- Round-trip persistence is explicitly planned.
+- Parallel-safe after 26-01.
+
+Concerns
+- `[MEDIUM]` `26-03-PLAN.md:166` says malformed types should be skipped, but the sample code at `26-03-PLAN.md:189` still appends `WithAsyncPolling(maxWait)` with zero on unknown numeric types, which silently enables async with the 30-minute default.
+- `[LOW]` It reimplements numeric parsing instead of using the existing helper in `pkg/embeddings/embedding.go:672`.
+
+Suggestions
+- Use `embeddings.ConfigInt(cfg, "async_max_wait_ms")` for consistency.
+- Distinguish "missing key" from "present but malformed"; only default on missing, not on bad types.
+- Consider tagging this plan as supporting TLA-01/TLA-02 too, since it is the sole public trigger for the feature.
+
+Risk Assessment
+- `MEDIUM-LOW`: solid overall, with one config-edge-case ambiguity that should be tightened before execution.
+
+### 26-04-PLAN
+
+Summary: Coverage breadth is good and the right behaviors are being exercised, but the test plan has one compile-time mistake and still misses the highest-risk edge cases from Plan 02. As written, it proves the happy/expected polling loop, not the hardest failure modes.
+
+Strengths
+- Good test matrix across create, ready, failed, unexpected status, ctx cancel, maxWait, sync-path skip, and config round-trip.
+- Uses ms-scale polling overrides, which fits repo test conventions.
+- Explicitly guards the `_id` alias issue.
+- Adds dedicated tests for "text/image must stay sync."
+
+Concerns
+- `[HIGH]` `26-04-PLAN.md:131` and `26-04-PLAN.md:358` use nonexistent `embeddings.ContentPart`; the actual type is `embeddings.Part`.
+- `[MEDIUM]` No test asserts that failed-task reasons are preserved and sanitized; that leaves D-17 effectively unratcheted.
+- `[MEDIUM]` No test covers an in-flight blocked HTTP request, so the maxWait/ctx bug in Plan 02 would still pass this suite.
+- `[LOW]` The validation-file update step is stale; `26-VALIDATION.md` is already populated and approved.
+
+Suggestions
+- Replace every `embeddings.ContentPart` reference with `embeddings.Part`.
+- Add a failed-task fixture with a long reason payload and assert truncation/sanitization.
+- Add a blocking-handler test that proves ctx deadline or SDK maxWait can interrupt an in-flight GET, not just the sleep between polls.
+- Add a test for `WithAudioEmbeddingOption("fused")` plus `WithAsyncPolling(...)` on audio content, expecting a deterministic validation error unless mapping is implemented.
+
+Risk Assessment
+- `MEDIUM`: broad coverage, but not yet covering the two most failure-prone behaviors.
+
+### Overall Risk
+`MEDIUM-HIGH`. The plan set is well structured and uses the corrected 2-endpoint model, but Plan 02 still has two substantive correctness gaps: maxWait does not currently bound in-flight HTTP work, and async audio request shaping does not account for the existing `"fused"` option. Fix those, preserve raw failure payloads, and tighten Plan 04 around those cases; then the phase is in good shape to satisfy TLA-01..04.
+
+---
+
+## Consensus Summary
+
+Two independent reviewers (gemini, codex) reached notably different risk assessments: **gemini rated LOW**, **codex rated MEDIUM-HIGH**. The divergence is driven by codex reading actual source files (`multimodal.go`, `option.go`, `embedding.go`) and catching concrete integration bugs that gemini's plan-level read missed.
+
+### Agreed Strengths
+
+- 2-endpoint model correctly adopted (F-01 reconciled)
+- `_id` JSON alias enforced as a grep-verifiable acceptance criterion
+- Clean wave structure, minimal merge-conflict risk between parallel Wave 2 plans
+- `time.NewTimer` used instead of `time.After` (timer-leak-safe)
+- Test suite covers the six D-26 flows plus D-07 routing-skip
+
+### Agreed Concerns (raised by both reviewers)
+
+1. **`fused` audio option mismatch** — gemini MEDIUM, codex HIGH. The existing `WithAudioEmbeddingOption("fused")` is valid on the sync path but `fused` is not a valid async `embedding_option` value. Plan 02's blind list-wrap will send an invalid request. Must be rejected or mapped explicitly.
+
+### Divergent Views (codex-only findings — the codex-exclusive cluster is the value-add of this review)
+
+1. **[HIGH] `maxWait` does not bound in-flight HTTP work** — Plan 02 checks `maxWait` only between polls. A blocked `doTaskGet` can exceed `maxWait`, violating D-09. Fix: derive a per-HTTP-call deadline of `min(parent ctx deadline, SDK maxWait deadline)`, and translate expiry back to a distinct maxWait error when the SDK bound fired first. **This is a real correctness gap, not a style nit.**
+
+2. **[HIGH] Failed-task reason is extracted from parsed struct, not raw body** — Plan 01's `TaskResponse` keeps only `{ID, Status, Data}`, so when Plan 02 builds the failure error it has no access to server-provided reason fields. D-17's "sanitized reason" requirement may yield empty strings. Fix: add a `json.RawMessage FailureDetail` field on `TaskResponse`, or preserve raw body bytes on non-ready statuses.
+
+3. **[HIGH/compile-blocker] `embeddings.ContentPart` does not exist** — Plan 04 references `embeddings.ContentPart` in 5 places; the actual type is `embeddings.Part`. Verified against `pkg/embeddings/multimodal.go:61`. Tests will not compile.
+
+4. **[MEDIUM] Plan 02 ctx-cancel vs deadline error message** — both paths wrap as `"async polling canceled"`, which mislabels deadline expiry. Use neutral wording.
+
+5. **[MEDIUM] Plan 03 malformed-config silently defaults** — stated behavior says "skip malformed values," but the sample code still appends `WithAsyncPolling(0)` which enables async with a 30-minute default. Distinguish "missing key" from "present but malformed."
+
+6. **[LOW] Reimplements numeric-config parsing** — use the existing `embeddings.ConfigInt` helper at `pkg/embeddings/embedding.go:672` for consistency.
+
+### Recommended Next Step
+
+The codex findings are concrete, source-verified, and surface two correctness gaps the plan-checker missed (maxWait-in-flight and failed-reason-preservation) plus a compile blocker (`ContentPart`). Before `/gsd-execute-phase 26`:
+
+```
+/gsd-plan-phase 26 --reviews
+```
+
+This will re-plan incorporating the REVIEWS.md feedback. At minimum the replan should address: (a) compile blocker in Plan 04, (b) `fused` option rejection or mapping in Plan 02, (c) per-HTTP-call deadline in Plan 02, (d) raw failure payload preservation in Plan 01, (e) malformed-config disambiguation in Plan 03.

--- a/.planning/phases/26-twelve-labs-async-embedding/26-SECURITY.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-SECURITY.md
@@ -1,0 +1,86 @@
+---
+phase: 26
+slug: twelve-labs-async-embedding
+status: verified
+threats_open: 0
+asvs_level: 1
+created: 2026-04-14
+---
+
+# Phase 26 — Security
+
+> Per-phase security contract: threat register, accepted risks, and audit trail for the Twelve Labs async embedding feature.
+
+---
+
+## Trust Boundaries
+
+| Boundary | Description | Data Crossing |
+|----------|-------------|---------------|
+| caller → TwelveLabsClient | Public SDK surface; caller-supplied media URLs already validated upstream. | `WithAsyncPolling(maxWait time.Duration)` opts into async path. |
+| Twelve Labs API → client | Server response bodies (JSON tasks API) are untrusted text flowing into error messages and logs. | `_id`, `status`, raw JSON bytes preserved in `TaskResponse.FailureDetail`. |
+| caller's ctx → polling loop | Caller-controlled deadline / cancellation bounds the loop. | `context.Context`. |
+| `maxWait` config → polling loop | Caller-tunable SDK-side bound, independent of ctx. | `time.Duration`. |
+| saved config map → FromConfig | Persistent config can round-trip numerics through JSON (int64 → float64). | `async_polling: bool`, `async_max_wait_ms: int64`. |
+
+---
+
+## Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation | Status |
+|-----------|----------|-----------|-------------|------------|--------|
+| T-26-01 | I (Info Disclosure) | `doTaskPost` / `doTaskGet` error paths | mitigate | `chttp.SanitizeErrorBody` on every raw-body error path — `pkg/embeddings/twelvelabs/twelvelabs.go:293,295,336,338` | closed |
+| T-26-02 | T (Tampering) | response body bloat | mitigate | `chttp.ReadLimitedBody` (200MB cap at `pkg/commons/http/utils.go:12,28`) — `twelvelabs.go:286,329` | closed |
+| T-26-03 | D (Denial of Service) | unbounded response size | mitigate | Same `ReadLimitedBody` cap at `twelvelabs.go:286,329` | closed |
+| T-26-04 | S (Spoofing) | task ID path injection | mitigate | `url.PathEscape(taskID)` at `twelvelabs.go:314` + empty-ID guard at `:311-313` | closed |
+| T-26-05 | I (Info Disclosure) | API key in logs | accept | API key only set via `x-api-key` header at `twelvelabs.go:275,319`; never appears in error wrappers. See Accepted Risks AR-26-01. | closed |
+| T-26-06 | I (Info Disclosure) | `pollTask` failed-status reason | mitigate | `chttp.SanitizeErrorBody(resp.FailureDetail)` at `twelvelabs_async.go:96`; raw body preserved at `twelvelabs.go:348` | closed |
+| T-26-07 | D (Denial of Service) | unbounded polling loop | mitigate | Three independent bounds — `ctx.Done` at `twelvelabs_async.go:113`, `sdkMaxWaitDeadline` at `:62`/`:103-106`, `asyncPollCap=60s` at `twelvelabs.go:73` | closed |
+| T-26-08 | D (Denial of Service) | timer leak | mitigate | `time.NewTimer` at `twelvelabs_async.go:111` + `timer.Stop()` on ctx branch at `:114`; no `time.After` in file | closed |
+| T-26-09 | T (Tampering) | malformed status field | mitigate | D-16 default branch rejecting unknown status with `"unexpected status %q"` at `twelvelabs_async.go:99-101` | closed |
+| T-26-10 | R (Repudiation) | indistinguishable timeout errors | mitigate | D-20 distinct messages — `"async polling maxWait %s exceeded"` at `:79,105`, `"async polling deadline exceeded"` at `:82,118`, `"async polling canceled"` at `:85,120`; `errors.Wrap` preserves `errors.Is` | closed |
+| T-26-11 | T (Tampering) | negative maxWait | mitigate | `WithAsyncPolling` rejects `maxWait < 0` at `option.go:112-114` | closed |
+| T-26-12 | D (Denial of Service) | missing maxWait | mitigate | `WithAsyncPolling(0)` → `30 * time.Minute` default at `option.go:116-118` | closed |
+| T-26-13 | T (Tampering) | config type mismatch on reload | mitigate | `embeddings.ConfigInt` coerces int/int64/float64 at `twelvelabs.go:473`; broken-value path leaves async OFF (`:467-476`) | closed |
+| T-26-14 | I (Info Disclosure) | config leakage | accept | `GetConfig` emits only `async_polling` (bool) + `async_max_wait_ms` (int64 ms) at `twelvelabs.go:438-441`; no secrets, no PII. See AR-26-02. | closed |
+| T-26-15 | T (Tampering) | fixture drift `id` vs `_id` | mitigate | Test fixtures emit `_id` at `twelvelabs_test.go:365-374`; regression surfaces as loud 404 against `/tasks/` | closed |
+| T-26-16 | D (Denial of Service) | slow tests | mitigate | `asyncPollInitial=1ms`, `asyncPollCap=10ms`, `asyncMaxWait=5s` in `newTestAsyncEF` at `twelvelabs_test.go:344,346` | closed |
+| T-26-17 | R (Repudiation) | indistinguishable timeout errors in tests | mitigate | `TestTwelveLabsAsyncMaxWait` asserts `stderrors.Is(err, context.DeadlineExceeded) == false` at `twelvelabs_test.go:523`; `TestTwelveLabsAsyncBlockedHTTPMaxWait` mirrors at `:642` | closed |
+
+*Status: open · closed*
+*Disposition: mitigate (implementation required) · accept (documented risk) · transfer (third-party)*
+
+---
+
+## Accepted Risks Log
+
+| Risk ID | Threat Ref | Rationale | Accepted By | Date |
+|---------|------------|-----------|-------------|------|
+| AR-26-01 | T-26-05 | API key never appears in `errors.Errorf` / `errors.Wrap` messages on any of the four HTTP helpers (`doPost`, `doTaskPost`, `doTaskGet`, plus existing sync paths). The key only flows through the `x-api-key` request header. The convention is enforced by code review — adding a new helper that prints the key would be visible in PR diff. Mitigation cost (e.g., redacting the entire transport layer) outweighs the residual risk for a SDK that already requires the caller to handle their own credential storage. | gsd-security-auditor + author | 2026-04-14 |
+| AR-26-02 | T-26-14 | The two emitted config keys are a boolean flag and an integer millisecond duration. Neither contains secrets, PII, URLs, model identifiers, or any other sensitive material. They are safe to persist in registries that round-trip through JSON. The accept disposition is the appropriate outcome — there is no information to disclose. | gsd-security-auditor + author | 2026-04-14 |
+
+*Accepted risks do not resurface in future audit runs.*
+
+---
+
+## Security Audit Trail
+
+| Audit Date | Threats Total | Closed | Open | Run By |
+|------------|---------------|--------|------|--------|
+| 2026-04-14 | 17 | 17 | 0 | gsd-security-auditor (sonnet) |
+
+### Audit notes (2026-04-14)
+
+- Bonus tests beyond the original register strengthen coverage: `TestTwelveLabsAsyncFailedReasonSanitized` (T-26-06), `TestTwelveLabsAsyncBlockedHTTPMaxWait` (T-26-07/T-26-17), `TestTwelveLabsAsyncTaskCreateError*` regression set (T-26-01), `TestTwelveLabsAsyncFusedRejected` (validation gate before any HTTP fires).
+- T-26-13 was hardened during the WR-01/WR-02 review cycle: a malformed `async_max_wait_ms` value with `async_polling=true` now leaves async OFF rather than silently falling back to `WithAsyncPolling(0)` — registry corruption no longer triggers a hidden 30-minute default. Encoded at `twelvelabs.go:467-476`.
+
+---
+
+## Sign-Off
+
+- [x] All threats have a disposition (mitigate / accept / transfer)
+- [x] Accepted risks documented in Accepted Risks Log
+- [x] `threats_open: 0` confirmed
+- [x] `status: verified` set in frontmatter
+
+**Approval:** verified 2026-04-14

--- a/.planning/phases/26-twelve-labs-async-embedding/26-UAT.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-UAT.md
@@ -1,0 +1,58 @@
+---
+status: complete
+phase: 26-twelve-labs-async-embedding
+source: [26-01-SUMMARY.md, 26-02-SUMMARY.md, 26-03-SUMMARY.md, 26-04-SUMMARY.md]
+started: 2026-04-14T00:00:00.000Z
+updated: 2026-04-14T00:00:00.000Z
+---
+
+## Current Test
+
+[testing complete]
+
+## Tests
+
+### 1. Package builds and vets cleanly with ef tag
+expected: Run `go build -tags=ef ./pkg/embeddings/twelvelabs/... && go vet -tags=ef ./pkg/embeddings/twelvelabs/...` — both exit 0, confirming the async request/response types, polling fields, and HTTP helpers compile cleanly alongside the existing sync surface.
+result: pass
+
+### 2. Async task-create and poll-to-ready happy path
+expected: Run `go test -tags=ef -count=1 -run 'TestTwelveLabsAsyncTaskCreate|TestTwelveLabsAsyncPollToReady' ./pkg/embeddings/twelvelabs/...` — both tests pass, proving POST /tasks sends `embedding_option:["audio"]` (F-02 list shape), GET /tasks/{id} is hit with the `_id`-aliased task ID, and the final embedding materializes after status transitions processing→ready.
+result: pass
+
+### 3. Failed and unknown-status terminals surface distinguishable errors
+expected: Run `go test -tags=ef -count=1 -run 'TestTwelveLabsAsyncPollToFailed|TestTwelveLabsAsyncUnexpectedStatus' ./pkg/embeddings/twelvelabs/...` — both tests pass. `failed` paths include "terminal status=failed" and the task ID; unknown status values are rejected with "unexpected status" rather than silently polled forever (D-16).
+result: pass
+
+### 4. Three timeout sources stay distinguishable (ctx-cancel, ctx-deadline, SDK maxWait) even when HTTP is blocked
+expected: Run `go test -tags=ef -count=1 -run 'TestTwelveLabsAsyncCtxCancel|TestTwelveLabsAsyncMaxWait|TestTwelveLabsAsyncBlockedHTTPMaxWait' ./pkg/embeddings/twelvelabs/...` — all three pass. Errors contain "async polling canceled" vs "async polling maxWait %s exceeded", and SDK maxWait error does NOT satisfy `errors.Is(err, context.DeadlineExceeded)` (D-20). Blocked HTTP call is interrupted by maxWait via per-call `context.WithDeadline`, not left hanging (D-09 hard bound).
+result: pass
+
+### 5. Modality routing: text/image skip async even when the flag is on
+expected: Run `go test -tags=ef -count=1 -run TestTwelveLabsAsyncSkipsTextImage ./pkg/embeddings/twelvelabs/...` — passes. Test fatals if any /tasks endpoint is hit; proves text and image modalities keep using the existing sync `doPost` flow regardless of `asyncPollingEnabled` (D-07).
+result: pass
+
+### 6. Config round-trip preserves async settings + APIKeyEnvVar; keys omitted when disabled
+expected: Run `go test -tags=ef -count=1 -run 'TestTwelveLabsAsyncConfigRoundTrip|TestTwelveLabsAsyncConfigOmitWhenDisabled' ./pkg/embeddings/twelvelabs/...` — both pass. Round-trip: EF built with `WithAsyncPolling(7*time.Minute)` → `GetConfig()` → `NewTwelveLabsEmbeddingFunctionFromConfig()` preserves `asyncPollingEnabled`, `asyncMaxWait=7m`, and the `APIKeyEnvVar`. Omit-when-disabled: default EF's config map contains neither `async_polling` nor `async_max_wait_ms` (D-22).
+result: pass
+
+### 7. Failure-reason sanitization and fused+async rejection
+expected: Run `go test -tags=ef -count=1 -run 'TestTwelveLabsAsyncFailedReasonSanitized|TestTwelveLabsAsyncFusedRejected' ./pkg/embeddings/twelvelabs/...` — both pass. Failed-reason test: a ~1.5KB server-provided reason field (not in the TaskResponse struct) survives via raw-body `FailureDetail` → `chttp.SanitizeErrorBody`, and final error stays under the 4096-byte cap (D-17). Fused test: building async content with `AudioEmbeddingOption="fused"` returns an error mentioning both "fused" and "async" BEFORE any HTTP call fires (F-02 / A5).
+result: pass
+
+### 8. Full twelvelabs suite + lint stay green
+expected: Run `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/... && make lint` — suite exits 0 (including all 12 `TestTwelveLabsAsync*` tests plus the pre-existing `TestTwelveLabs*` set) and `make lint` reports `0 issues.` across the full tree.
+result: pass
+
+## Summary
+
+total: 8
+passed: 8
+issues: 0
+pending: 0
+skipped: 0
+blocked: 0
+
+## Gaps
+
+[none]

--- a/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
@@ -2,8 +2,8 @@
 phase: 26
 slug: twelve-labs-async-embedding
 status: draft
-nyquist_compliant: false
-wave_0_complete: false
+nyquist_compliant: true
+wave_0_complete: true
 created: 2026-04-14
 ---
 
@@ -40,17 +40,24 @@ created: 2026-04-14
 
 | Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
-| 26-01-01 | 01 | 1 | TLA-01..04 | — | N/A | — | (Wave 0 fixtures) | ❌ W0 | ⬜ pending |
+| 26-01-01 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | `_id` alias + list-shape `embedding_option` + polling defaults | unit (build + grep) | `go build -tags=ef ./pkg/embeddings/twelvelabs/...` plus grep asserts `_id`, `[]string`, `asyncPollInitial` | EXISTS | pending |
+| 26-01-02 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | body sanitization on non-2xx, URL escaping, empty-id guard | unit (build + grep) | grep asserts `doTaskPost`, `doTaskGet`, `url.PathEscape`, `SanitizeErrorBody` count >= 4 | EXISTS | pending |
+| 26-02-01 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | status discriminator, ctx-cancel, maxWait distinct, no `time.After`, no `WithTimeout` on maxWait | unit (build + grep) | grep asserts `time.NewTimer`, `case <-ctx.Done`, `async polling maxWait`, `terminal status=failed`, absence of `time.After(` and `context.WithTimeout(ctx, maxWait)` | EXISTS | pending |
+| 26-02-02 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | modality-gated routing; sync path unchanged for non-opt-in | unit (existing tests regression) | `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
+| 26-03-01 | 03 | 2 | TLA-03 | T-26-11, T-26-12 | reject negative maxWait, 30m default on zero | unit (build + grep) | grep asserts `maxWait cannot be negative`, `30 * time.Minute`, exact signature `func WithAsyncPolling(maxWait time.Duration) Option` | EXISTS | pending |
+| 26-03-02 | 03 | 2 | TLA-03 | T-26-13, T-26-14 | config keys round-trip; omit when disabled | unit (build + grep + regression) | grep asserts emit/read of `async_polling` + `async_max_wait_ms` + `asyncMaxWait.Milliseconds()`; existing tests still pass | EXISTS | pending |
+| 26-04-01 | 04 | 3 | TLA-04 | T-26-15, T-26-16 | task-create, poll-to-ready, poll-to-failed, unexpected-status | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncTaskCreate\|TestTwelveLabsAsyncPollToReady\|TestTwelveLabsAsyncPollToFailed\|TestTwelveLabsAsyncUnexpectedStatus ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
+| 26-04-02 | 04 | 3 | TLA-04 | T-26-17 | ctx-cancel, maxWait distinct from DeadlineExceeded, text/image skip async, config round-trip | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncCtxCancel\|TestTwelveLabsAsyncMaxWait\|TestTwelveLabsAsyncSkipsTextImage\|TestTwelveLabsAsyncConfigRoundTrip\|TestTwelveLabsAsyncConfigOmitWhenDisabled ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
 
-*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+*Status: pending · green · red · flaky*
 
 ---
 
 ## Wave 0 Requirements
 
-- [ ] `pkg/embeddings/twelvelabs/twelvelabs_test.go` — extend `newTestEF` to expose ms-scale polling fields (`pollInitial`, `pollMultiplier`, `pollCap`) for tests
-- [ ] Shared task-mock helpers for `httptest.Server` covering: `POST /v1.3/embed-v2/tasks`, `GET /v1.3/embed-v2/tasks/{id}` (status discriminator via `status` field)
-- [ ] Per D-26, fixtures for 6 flows: task-create, poll-to-ready, poll-to-failed, ctx-cancel mid-poll, maxWait expiry, config round-trip
+- [x] `pkg/embeddings/twelvelabs/twelvelabs_test.go` — sibling helper `newTestAsyncEF` wraps `newTestEF` and sets ms-scale `asyncPollInitial=1ms`, `asyncPollMultiplier=1.5`, `asyncPollCap=10ms`, `asyncMaxWait=5s` (Plan 04 Task 1)
+- [x] Fixture helpers `taskCreateJSON(id, status)` and `taskGetJSON(id, status, data)` emit the Mongo-style `_id` alias (Pitfall 1 guard) — Plan 04 Task 1
+- [x] Seven tests cover all 6 D-26 flows plus the D-07 text/image-skip rule and D-22 config-omit-when-disabled — Plan 04 Task 2
 
 *No framework install needed — stdlib `net/http/httptest` + existing testify.*
 
@@ -66,11 +73,11 @@ created: 2026-04-14
 
 ## Validation Sign-Off
 
-- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
-- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
-- [ ] Wave 0 covers all MISSING references
-- [ ] No watch-mode flags
-- [ ] Feedback latency < 5s
-- [ ] `nyquist_compliant: true` set in frontmatter
+- [x] All tasks have `<automated>` verify or Wave 0 dependencies
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all MISSING references (helpers + fixtures land in Plan 04 Task 1, consumed by Task 2)
+- [x] No watch-mode flags
+- [x] Feedback latency < 5s (ms-scale polling keeps async test suite ~2s)
+- [x] `nyquist_compliant: true` set in frontmatter
 
-**Approval:** pending
+**Approval:** approved by planner 2026-04-14

--- a/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
@@ -1,10 +1,11 @@
 ---
 phase: 26
 slug: twelve-labs-async-embedding
-status: draft
+status: validated
 nyquist_compliant: true
 wave_0_complete: true
 created: 2026-04-14
+validated: 2026-04-14
 ---
 
 # Phase 26 — Validation Strategy
@@ -40,14 +41,14 @@ created: 2026-04-14
 
 | Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
-| 26-01-01 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | `_id` alias + list-shape `embedding_option` + polling defaults | unit (build + grep) | `go build -tags=ef ./pkg/embeddings/twelvelabs/...` plus grep asserts `_id`, `[]string`, `asyncPollInitial` | EXISTS | pending |
-| 26-01-02 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | body sanitization on non-2xx, URL escaping, empty-id guard | unit (build + grep) | grep asserts `doTaskPost`, `doTaskGet`, `url.PathEscape`, `SanitizeErrorBody` count >= 4 | EXISTS | pending |
-| 26-02-01 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | status discriminator, ctx-cancel, maxWait distinct, no `time.After`, no `WithTimeout` on maxWait | unit (build + grep) | grep asserts `time.NewTimer`, `case <-ctx.Done`, `async polling maxWait`, `terminal status=failed`, absence of `time.After(` and `context.WithTimeout(ctx, maxWait)` | EXISTS | pending |
-| 26-02-02 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | modality-gated routing; sync path unchanged for non-opt-in | unit (existing tests regression) | `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
-| 26-03-01 | 03 | 2 | TLA-03 | T-26-11, T-26-12 | reject negative maxWait, 30m default on zero | unit (build + grep) | grep asserts `maxWait cannot be negative`, `30 * time.Minute`, exact signature `func WithAsyncPolling(maxWait time.Duration) Option` | EXISTS | pending |
-| 26-03-02 | 03 | 2 | TLA-03 | T-26-13, T-26-14 | config keys round-trip; omit when disabled | unit (build + grep + regression) | grep asserts emit/read of `async_polling` + `async_max_wait_ms` + `asyncMaxWait.Milliseconds()`; existing tests still pass | EXISTS | pending |
-| 26-04-01 | 04 | 3 | TLA-04 | T-26-15, T-26-16 | task-create, poll-to-ready, poll-to-failed, unexpected-status | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncTaskCreate\|TestTwelveLabsAsyncPollToReady\|TestTwelveLabsAsyncPollToFailed\|TestTwelveLabsAsyncUnexpectedStatus ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
-| 26-04-02 | 04 | 3 | TLA-04 | T-26-17 | ctx-cancel, maxWait distinct from DeadlineExceeded, text/image skip async, config round-trip | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncCtxCancel\|TestTwelveLabsAsyncMaxWait\|TestTwelveLabsAsyncSkipsTextImage\|TestTwelveLabsAsyncConfigRoundTrip\|TestTwelveLabsAsyncConfigOmitWhenDisabled ./pkg/embeddings/twelvelabs/...` | EXISTS | pending |
+| 26-01-01 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | `_id` alias + list-shape `embedding_option` + polling defaults | unit (build + grep) | `go build -tags=ef ./pkg/embeddings/twelvelabs/...` plus grep asserts `_id`, `[]string`, `asyncPollInitial` | EXISTS | green |
+| 26-01-02 | 01 | 1 | TLA-01, TLA-02, TLA-03 | T-26-01..05 | body sanitization on non-2xx, URL escaping, empty-id guard | unit (build + grep) | grep asserts `doTaskPost`, `doTaskGet`, `url.PathEscape`, `SanitizeErrorBody` count >= 4 | EXISTS | green |
+| 26-02-01 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | status discriminator, ctx-cancel, maxWait distinct, no `time.After`, no `WithTimeout` on maxWait | unit (build + grep) | grep asserts `time.NewTimer`, `case <-ctx.Done`, `async polling maxWait`, `terminal status=failed`, absence of `time.After(` and `context.WithTimeout(ctx, maxWait)` | EXISTS | green |
+| 26-02-02 | 02 | 2 | TLA-01, TLA-02, TLA-03 | T-26-06..10 | modality-gated routing; sync path unchanged for non-opt-in | unit (existing tests regression) | `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` | EXISTS | green |
+| 26-03-01 | 03 | 2 | TLA-03 | T-26-11, T-26-12 | reject negative maxWait, 30m default on zero | unit (build + grep) | grep asserts `maxWait cannot be negative`, `30 * time.Minute`, exact signature `func WithAsyncPolling(maxWait time.Duration) Option` | EXISTS | green |
+| 26-03-02 | 03 | 2 | TLA-03 | T-26-13, T-26-14 | config keys round-trip; omit when disabled | unit (build + grep + regression) | grep asserts emit/read of `async_polling` + `async_max_wait_ms` + `asyncMaxWait.Milliseconds()`; existing tests still pass | EXISTS | green |
+| 26-04-01 | 04 | 3 | TLA-04 | T-26-15, T-26-16 | task-create, poll-to-ready, poll-to-failed, unexpected-status | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncTaskCreate\|TestTwelveLabsAsyncPollToReady\|TestTwelveLabsAsyncPollToFailed\|TestTwelveLabsAsyncUnexpectedStatus ./pkg/embeddings/twelvelabs/...` | EXISTS | green |
+| 26-04-02 | 04 | 3 | TLA-04 | T-26-17 | ctx-cancel, maxWait distinct from DeadlineExceeded, text/image skip async, config round-trip | unit (httptest) | `go test -tags=ef -count=1 -run TestTwelveLabsAsyncCtxCancel\|TestTwelveLabsAsyncMaxWait\|TestTwelveLabsAsyncSkipsTextImage\|TestTwelveLabsAsyncConfigRoundTrip\|TestTwelveLabsAsyncConfigOmitWhenDisabled ./pkg/embeddings/twelvelabs/...` | EXISTS | green |
 
 *Status: pending · green · red · flaky*
 
@@ -81,3 +82,24 @@ created: 2026-04-14
 - [x] `nyquist_compliant: true` set in frontmatter
 
 **Approval:** approved by planner 2026-04-14
+
+---
+
+## Validation Audit 2026-04-14
+
+| Metric | Count |
+|--------|-------|
+| Tasks audited | 8 |
+| Gaps found | 0 |
+| Resolved | 0 |
+| Escalated | 0 |
+
+**Evidence:**
+
+- `go test -tags=ef -count=1 -run TestTwelveLabs ./pkg/embeddings/twelvelabs/...` → PASS (0.537s)
+- All 9 async httptest cases (`TestTwelveLabsAsync{TaskCreate,PollToReady,PollToFailed,UnexpectedStatus,CtxCancel,MaxWait,SkipsTextImage,ConfigRoundTrip,ConfigOmitWhenDisabled}`) green; 3 extra error-sanitization regressions (WR-02) also green
+- Grep assertions verified for 26-01-01, 26-01-02, 26-02-01, 26-03-01, 26-03-02 (positive matches present, negative matches absent — no `time.After(` and no `context.WithTimeout(ctx, maxWait)` in `twelvelabs_async.go`)
+- Manual-only entry (live long-media) retained — requires paid API key, not CI-runnable
+
+Phase 26 remains `nyquist_compliant: true`. No new test files generated.
+

--- a/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-VALIDATION.md
@@ -1,0 +1,76 @@
+---
+phase: 26
+slug: twelve-labs-async-embedding
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-04-14
+---
+
+# Phase 26 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | go test (stdlib) + `httptest.Server` + `testify` |
+| **Config file** | none — uses existing `ef` build tag (`Makefile`: `make test-ef`) |
+| **Quick run command** | `go test -tags=ef -run TestTwelveLabs -count=1 ./pkg/embeddings/twelvelabs/...` |
+| **Full suite command** | `make test-ef` |
+| **Estimated runtime** | ~2 seconds (ms-scale poll intervals in tests) |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `go test -tags=ef -run TestTwelveLabs -count=1 ./pkg/embeddings/twelvelabs/...`
+- **After every plan wave:** Run `make test-ef`
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** 5 seconds
+
+---
+
+## Per-Task Verification Map
+
+> Populated by planner. Each task from PLAN.md must map to a test command (or be covered by Wave 0 fixture/helper setup). Execution auditor fills Status column during `/gsd-execute-phase`.
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 26-01-01 | 01 | 1 | TLA-01..04 | — | N/A | — | (Wave 0 fixtures) | ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `pkg/embeddings/twelvelabs/twelvelabs_test.go` — extend `newTestEF` to expose ms-scale polling fields (`pollInitial`, `pollMultiplier`, `pollCap`) for tests
+- [ ] Shared task-mock helpers for `httptest.Server` covering: `POST /v1.3/embed-v2/tasks`, `GET /v1.3/embed-v2/tasks/{id}` (status discriminator via `status` field)
+- [ ] Per D-26, fixtures for 6 flows: task-create, poll-to-ready, poll-to-failed, ctx-cancel mid-poll, maxWait expiry, config round-trip
+
+*No framework install needed — stdlib `net/http/httptest` + existing testify.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Live long-media (>5 min video) completes end-to-end via `WithAsyncPolling` | TLA-01..04 | Requires paid Twelve Labs API key and a real media URL; not runnable in CI without credentials | Set `TWELVE_LABS_API_KEY`, call `EmbedContent` with a 10-minute video URL and `WithAsyncPolling(30*time.Minute)`, confirm a non-empty embedding returns |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 5s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/26-twelve-labs-async-embedding/26-VERIFICATION.md
+++ b/.planning/phases/26-twelve-labs-async-embedding/26-VERIFICATION.md
@@ -1,0 +1,122 @@
+---
+phase: 26-twelve-labs-async-embedding
+verified: 2026-04-14T14:00:00Z
+status: passed
+score: 4/4 must-haves verified
+overrides_applied: 0
+re_verification: false
+---
+
+# Phase 26: Twelve Labs Async Embedding Verification Report
+
+**Phase Goal:** Twelve Labs provider handles async task responses for long-running audio and video embeddings
+**Verified:** 2026-04-14T14:00:00Z
+**Status:** PASSED
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (from ROADMAP Success Criteria)
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | When the tasks endpoint is called (async opt-in), provider detects task response and enters polling loop | ✓ VERIFIED | `pollTask` in `twelvelabs_async.go` loops over `doTaskGet`, dispatched from `createTaskAndPoll`. D-01 documents that the ROADMAP phrasing "sync endpoint returns async response" was a premise drift — the correct model uses dedicated `POST /tasks` + `GET /tasks/{id}` endpoints. `TestTwelveLabsAsyncPollToReady` exercises 3 GETs before ready. |
+| 2 | Polling respects caller context for cancellation and timeout | ✓ VERIFIED | `pollTask` has `select { case <-ctx.Done(): ... }` with distinct error messages for `context.Canceled` vs `context.DeadlineExceeded`. Per-HTTP-call deadline = `min(parentCtx, sdkMaxWaitDeadline)` via `context.WithDeadline`. `TestTwelveLabsAsyncCtxCancel` asserts `stderrors.Is(err, context.Canceled)`. `TestTwelveLabsAsyncBlockedHTTPMaxWait` proves in-flight HTTP unblocked within 2s. |
+| 3 | Terminal states (ready, failed) are handled with appropriate result delivery or error messages | ✓ VERIFIED | `pollTask` 4-state discriminator: `"ready"` → extract embedding; `"failed"` → `errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(resp.FailureDetail))`; `"processing"` → loop; default → `errors.Errorf("unexpected status %q")`. `TestTwelveLabsAsyncPollToFailed` and `TestTwelveLabsAsyncFailedReasonSanitized` cover both failure paths. |
+| 4 | Tests cover async task creation, polling to completion, polling to failure, and context cancellation | ✓ VERIFIED | 12 `TestTwelveLabsAsync*` functions confirmed present in `twelvelabs_test.go`: TaskCreate, PollToReady, PollToFailed, UnexpectedStatus, CtxCancel, MaxWait, SkipsTextImage, ConfigRoundTrip, ConfigOmitWhenDisabled, FailedReasonSanitized, BlockedHTTPMaxWait, FusedRejected. Full `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` exits 0 in 4.69s. |
+
+**Score:** 4/4 truths verified
+
+### Requirements Coverage
+
+| Requirement | Plans | Description | Status | Evidence |
+|-------------|-------|-------------|--------|----------|
+| TLA-01 | 26-01, 26-02 | Provider detects async task responses and enters polling loop | ✓ SATISFIED | `AsyncEmbedV2Request` + `TaskCreateResponse`/`TaskResponse` with `_id` alias; `doTaskPost`/`doTaskGet` helpers; `pollTask` polling loop; `embedContent` dispatch on `asyncPollingEnabled`. |
+| TLA-02 | 26-02 | Async polling respects caller context for cancellation and timeout | ✓ SATISFIED | `context.WithDeadline(ctx, callDeadline)` per-HTTP-call; `case <-ctx.Done()` in timer select; three distinct error messages (canceled / deadline exceeded / maxWait exceeded); `TestTwelveLabsAsyncCtxCancel` + `TestTwelveLabsAsyncMaxWait` assert D-20 distinction. |
+| TLA-03 | 26-01, 26-02, 26-03 | Terminal states handled with appropriate error messages | ✓ SATISFIED | `status=ready` returns embedding; `status=failed` returns error with raw `FailureDetail` body via `chttp.SanitizeErrorBody` (D-17); unknown status returns `unexpected status` error (D-16); `WithAsyncPolling` negative-maxWait rejected; fused+async rejected before any HTTP call. |
+| TLA-04 | 26-04 | Tests cover create, polling, completion, failure, ctx cancellation | ✓ SATISFIED | 12 `TestTwelveLabsAsync*` tests cover every D-26 flow including review-fix guards (D-17 FailureDetail, blocked-HTTP per-call deadline, fused rejection). All pass in <5s per D-24. |
+
+### Required Artifacts
+
+| Artifact | Provides | Status | Details |
+|----------|----------|--------|---------|
+| `pkg/embeddings/twelvelabs/twelvelabs.go` | Async request/response types, polling fields + defaults, doTaskPost/doTaskGet, GetConfig/FromConfig async keys | ✓ VERIFIED | Contains `AsyncEmbedV2Request`, `AsyncAudioInput` (EmbeddingOption `[]string`), `TaskCreateResponse`/`TaskResponse` (both with `json:"_id"`), `FailureDetail json.RawMessage`, polling fields with backoff defaults, 7x `SanitizeErrorBody`, 3x `ReadLimitedBody`, `url.PathEscape`, empty-ID guard, async config emit/read. |
+| `pkg/embeddings/twelvelabs/twelvelabs_async.go` | pollTask, contentToAsyncRequest, createTaskAndPoll, buildEmbeddingFromData | ✓ VERIFIED | All four functions present and substantive. `time.NewTimer` (not `time.After`). `context.WithDeadline` per-call. Three distinct timeout error messages. `resp.FailureDetail` used in failed branch. Fused rejection before HTTP call. |
+| `pkg/embeddings/twelvelabs/content.go` | embedContent modality routing | ✓ VERIFIED | `asyncPollingEnabled` check gates `createTaskAndPoll` dispatch for `ModalityAudio`/`ModalityVideo`. Sync path unchanged for text/image and when flag off. |
+| `pkg/embeddings/twelvelabs/option.go` | WithAsyncPolling functional option | ✓ VERIFIED | `func WithAsyncPolling(maxWait time.Duration) Option` present. Negative → error. Zero → 30min default. Positive → verbatim. Sets `asyncPollingEnabled = true`. |
+| `pkg/embeddings/twelvelabs/twelvelabs_test.go` | 12 TestTwelveLabsAsync* tests | ✓ VERIFIED | All 12 functions confirmed. `atomic.Int32` attempt counters. `_id` in all fixtures. ms-scale polling fields. `stderrors.Is` assertions for D-20 distinction. All pass. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `doTaskPost` | `chttp.SanitizeErrorBody` | error body sanitization | ✓ WIRED | `chttp.SanitizeErrorBody` called on both structured-message and raw-body error paths in `doTaskPost`. |
+| `doTaskGet` | `chttp.ReadLimitedBody` + `chttp.SanitizeErrorBody` | Phase 25 pattern | ✓ WIRED | `ReadLimitedBody` reads response; `SanitizeErrorBody` on error paths; raw body copied to `FailureDetail`. |
+| `applyDefaults` | `asyncPollInitial`/`asyncPollMultiplier`/`asyncPollCap` | default assignment | ✓ WIRED | Three `if c.asyncPoll* == 0` guards set 2s / 1.5 / 60s defaults. |
+| `embedContent` | `createTaskAndPoll` | modality + asyncPollingEnabled dispatch | ✓ WIRED | `if e.apiClient.asyncPollingEnabled && len(content.Parts) == 1 { switch Modality { case Audio, Video: return e.createTaskAndPoll } }` |
+| `pollTask` | `doTaskGet` | status discriminator polling | ✓ WIRED | `e.doTaskGet(callCtx, taskID)` called inside the loop. |
+| `pollTask` | `ctx.Done()` | select-case cancellation | ✓ WIRED | `select { case <-ctx.Done(): timer.Stop(); ... }` |
+| `pollTask` | `time.NewTimer` | leak-safe sleep | ✓ WIRED | `timer := time.NewTimer(wait)` — no `time.After` present. |
+| `WithAsyncPolling` | `asyncPollingEnabled` / `asyncMaxWait` | option assignment | ✓ WIRED | `p.asyncPollingEnabled = true; p.asyncMaxWait = ...` |
+| `GetConfig` | `async_polling` / `async_max_wait_ms` | conditional emit | ✓ WIRED | `if e.apiClient.asyncPollingEnabled { cfg["async_polling"] = true; cfg["async_max_wait_ms"] = ...Milliseconds() }` |
+| `NewTwelveLabsEmbeddingFunctionFromConfig` | `WithAsyncPolling` | missing-keys = opt-in-off | ✓ WIRED | `if enabled, ok := cfg["async_polling"].(bool); ok && enabled { if ms, ok := embeddings.ConfigInt(...); ok && ms >= 0 { ... WithAsyncPolling(...) } }` |
+
+### Data-Flow Trace (Level 4)
+
+The package is a client library producing embeddings, not a rendering component. Data flows: user content → HTTP task → poll → embedding. Key data-flow nodes verified:
+
+| Artifact | Data Path | Produces Real Data | Status |
+|----------|-----------|-------------------|--------|
+| `doTaskGet` | `ReadLimitedBody` → `json.Unmarshal` → `TaskResponse` + `FailureDetail` copy | Yes — real HTTP bytes | ✓ FLOWING |
+| `pollTask` | `doTaskGet` result → status switch → `resp.FailureDetail` on failed | Yes — uses raw body | ✓ FLOWING |
+| `createTaskAndPoll` | `contentToAsyncRequest` → `doTaskPost` → `pollTask` → `buildEmbeddingFromData` | Yes — end-to-end | ✓ FLOWING |
+| `buildEmbeddingFromData` | `data[0].Embedding` (float64 slice) → `float64sToFloat32s` → `NewEmbeddingFromFloat32` | Yes — not static | ✓ FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| All async tests pass | `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...` | `ok` in 4.69s | ✓ PASS |
+| Lint clean | `make lint` | `0 issues.` | ✓ PASS |
+| Package builds | `go build -tags=ef ./pkg/embeddings/twelvelabs/...` | exit 0 (implied by test pass) | ✓ PASS |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `twelvelabs.go` | 46-47, 264, 309 | Stale `//nolint:unused` annotations on `asyncPollingEnabled`, `asyncMaxWait`, `doTaskPost`, `doTaskGet` — these symbols are now consumed by `twelvelabs_async.go` and `content.go` | ℹ️ Info | Zero impact — lint passes with or without them; annotations are conservative dead code. Can be removed in a follow-up cleanup. |
+
+No blockers or warnings found.
+
+### Human Verification Required
+
+None. All observable behaviors are verifiable programmatically:
+- Polling loop, cancellation, and timeout behavior are covered by httptest.Server-based tests.
+- Config round-trip is asserted deterministically.
+- Visual or UX review is not applicable to a library embedding function.
+
+### Review Findings Status
+
+The REVIEW.md identified two warnings:
+
+- **WR-01 (createTaskAndPoll POST not bounded by maxWait):** This is a known gap — the initial `doTaskPost` call uses the parent ctx only, not a derived deadline from `sdkMaxWaitDeadline`. There is no test for a blocked POST and the D-09 "hard bound" claim does not fully hold for the task-create phase. This is a real limitation but was acknowledged in the review and is not tested by the current suite. It is a warning-level finding: the feature still works correctly in all tested scenarios, and blocking creates are extremely rare in practice (the TL API is fast to accept tasks). No test exercises this path.
+- **WR-02 (no regression test for doTaskPost non-2xx error path):** The `doTaskPost` error path is untested. A bug there would go undetected until a real 4xx from Twelve Labs.
+
+Both WR-01 and WR-02 are known, documented, warning-level gaps from the code review. They do not prevent the phase goal from being achieved — all four TLA-01..TLA-04 requirements have functional, tested implementations. However, they are legitimate improvement items.
+
+Given the project's "no surprises" DX principle (feedback_dx_no_surprises.md) and the existing review documentation, these are recorded as info-level items rather than blocking gaps, consistent with their classification in REVIEW.md (warnings, not criticals).
+
+## Gaps Summary
+
+No blocking gaps. The phase goal is achieved: Twelve Labs provider handles async task responses for long-running audio and video embeddings via `WithAsyncPolling`, with correct polling semantics, three distinguishable timeout sources, terminal state handling, and 12 passing tests.
+
+Two warning-level items from REVIEW.md remain open:
+1. `createTaskAndPoll`'s initial `doTaskPost` call is not bounded by `asyncMaxWait` — a hung server could make the create call outlive `maxWait`.
+2. No test covers the `doTaskPost` non-2xx error path.
+
+These are improvement items for a follow-up, not blockers for this phase.
+
+---
+
+_Verified: 2026-04-14T14:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/pkg/embeddings/twelvelabs/content.go
+++ b/pkg/embeddings/twelvelabs/content.go
@@ -127,7 +127,16 @@ func buildMediaSource(source *embeddings.BinarySource) (MediaSource, error) {
 }
 
 // embedContent sends a single Content item to the API and returns the embedding.
+// When asyncPollingEnabled is true and the modality is audio or video, the
+// content routes through the tasks endpoint + polling loop (CONTEXT.md D-07).
+// All other cases use the sync /embed-v2 path (D-08 — zero change for non-opt-in).
 func (e *TwelveLabsEmbeddingFunction) embedContent(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+	if e.apiClient.asyncPollingEnabled && len(content.Parts) == 1 {
+		switch content.Parts[0].Modality {
+		case embeddings.ModalityAudio, embeddings.ModalityVideo:
+			return e.createTaskAndPoll(ctx, content)
+		}
+	}
 	req, err := contentToRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
 	if err != nil {
 		return nil, err

--- a/pkg/embeddings/twelvelabs/content.go
+++ b/pkg/embeddings/twelvelabs/content.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -127,6 +128,11 @@ func buildMediaSource(source *embeddings.BinarySource) (MediaSource, error) {
 		}
 		if parsed.Scheme == "" || parsed.Host == "" {
 			return MediaSource{}, errors.New("URL source must be an absolute URL with scheme and host")
+		}
+		switch strings.ToLower(parsed.Scheme) {
+		case "http", "https":
+		default:
+			return MediaSource{}, errors.Errorf("URL source scheme %q not supported; use http or https", parsed.Scheme)
 		}
 		return MediaSource{URL: source.URL}, nil
 	}

--- a/pkg/embeddings/twelvelabs/content.go
+++ b/pkg/embeddings/twelvelabs/content.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
+	"net/url"
 	"os"
 
 	"github.com/pkg/errors"
@@ -117,6 +118,16 @@ func buildMediaSource(source *embeddings.BinarySource) (MediaSource, error) {
 		return MediaSource{}, errors.New("binary source is required for non-text parts")
 	}
 	if source.Kind == embeddings.SourceKindURL {
+		if source.URL == "" {
+			return MediaSource{}, errors.New("URL source must include non-empty URL")
+		}
+		parsed, err := url.Parse(source.URL)
+		if err != nil {
+			return MediaSource{}, errors.Wrap(err, "invalid URL source")
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return MediaSource{}, errors.New("URL source must be an absolute URL with scheme and host")
+		}
 		return MediaSource{URL: source.URL}, nil
 	}
 	data, err := resolveBytes(source)

--- a/pkg/embeddings/twelvelabs/content.go
+++ b/pkg/embeddings/twelvelabs/content.go
@@ -43,7 +43,12 @@ func resolveBytes(source *embeddings.BinarySource) ([]byte, error) {
 		if source.Base64 == "" {
 			return nil, errors.New("base64 source must include non-empty data")
 		}
-		if int64(len(source.Base64))*3/4 > maxMediaSourceSize {
+		// Cheap guard against decoding an oversized payload. Compare encoded
+		// lengths rather than estimating the decoded size: a *3/4 estimate folds
+		// "=" padding into the payload and rejects a string encoding exactly
+		// maxMediaSourceSize. A pre-check must only ever over-admit — the
+		// post-decode check below is authoritative.
+		if len(source.Base64) > base64.StdEncoding.EncodedLen(int(maxMediaSourceSize)) {
 			return nil, errors.Errorf("base64 payload too large: estimated decoded size exceeds maximum of %d bytes", maxMediaSourceSize)
 		}
 		data, err := base64.StdEncoding.DecodeString(source.Base64)

--- a/pkg/embeddings/twelvelabs/option.go
+++ b/pkg/embeddings/twelvelabs/option.go
@@ -102,6 +102,11 @@ func WithAudioEmbeddingOption(opt string) Option {
 // audio and video content. Passing maxWait=0 selects the 30-minute default
 // (CONTEXT.md D-03). This is the sole public trigger for async — polling
 // interval, backoff multiplier, and cap are internal (D-04).
+//
+// maxWait is a hard upper bound on the whole async operation (task create
+// + polling), not just the polling loop. A blocked POST /tasks call will
+// be interrupted at maxWait and surface as a distinct SDK timeout error
+// (not raw context.DeadlineExceeded — see D-20).
 func WithAsyncPolling(maxWait time.Duration) Option {
 	return func(p *TwelveLabsClient) error {
 		if maxWait < 0 {

--- a/pkg/embeddings/twelvelabs/option.go
+++ b/pkg/embeddings/twelvelabs/option.go
@@ -3,6 +3,7 @@ package twelvelabs
 import (
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -94,5 +95,24 @@ func WithAudioEmbeddingOption(opt string) Option {
 		default:
 			return errors.Errorf("invalid audio embedding option %q: must be one of audio, transcription, fused", opt)
 		}
+	}
+}
+
+// WithAsyncPolling enables the Twelve Labs tasks-endpoint code path for
+// audio and video content. Passing maxWait=0 selects the 30-minute default
+// (CONTEXT.md D-03). This is the sole public trigger for async — polling
+// interval, backoff multiplier, and cap are internal (D-04).
+func WithAsyncPolling(maxWait time.Duration) Option {
+	return func(p *TwelveLabsClient) error {
+		if maxWait < 0 {
+			return errors.New("maxWait cannot be negative")
+		}
+		p.asyncPollingEnabled = true
+		if maxWait == 0 {
+			p.asyncMaxWait = 30 * time.Minute
+		} else {
+			p.asyncMaxWait = maxWait
+		}
+		return nil
 	}
 }

--- a/pkg/embeddings/twelvelabs/option.go
+++ b/pkg/embeddings/twelvelabs/option.go
@@ -99,7 +99,7 @@ func WithAudioEmbeddingOption(opt string) Option {
 }
 
 // WithAsyncPolling enables the Twelve Labs tasks-endpoint code path for
-// audio and video content. Passing maxWait=0 selects the 30-minute default
+// audio and video content. Passing maxWait=0 selects the default timeout
 // (CONTEXT.md D-03). This is the sole public trigger for async — polling
 // interval, backoff multiplier, and cap are internal (D-04).
 //
@@ -114,7 +114,7 @@ func WithAsyncPolling(maxWait time.Duration) Option {
 		}
 		p.asyncPollingEnabled = true
 		if maxWait == 0 {
-			p.asyncMaxWait = 30 * time.Minute
+			p.asyncMaxWait = defaultAsyncMaxWait
 		} else {
 			p.asyncMaxWait = maxWait
 		}

--- a/pkg/embeddings/twelvelabs/option.go
+++ b/pkg/embeddings/twelvelabs/option.go
@@ -107,10 +107,19 @@ func WithAudioEmbeddingOption(opt string) Option {
 // + polling), not just the polling loop. A blocked POST /tasks call will
 // be interrupted at maxWait and surface as a distinct SDK timeout error
 // (not raw context.DeadlineExceeded — see D-20).
+//
+// maxWait must be >= defaultAsyncPollInitial (one poll interval) so the
+// loop can complete at least one GET before timing out. Sub-floor values
+// are rejected rather than silently clamped so misconfiguration surfaces
+// at option-application time, mirroring the "poll cap >= poll initial"
+// validation in validate().
 func WithAsyncPolling(maxWait time.Duration) Option {
 	return func(p *TwelveLabsClient) error {
 		if maxWait < 0 {
 			return errors.New("maxWait cannot be negative")
+		}
+		if maxWait > 0 && maxWait < defaultAsyncPollInitial {
+			return errors.Errorf("maxWait %s is below minimum %s (one poll interval)", maxWait, defaultAsyncPollInitial)
 		}
 		p.asyncPollingEnabled = true
 		if maxWait == 0 {

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -20,6 +20,7 @@ const (
 	defaultModel                = "marengo3.0"
 	defaultAudioEmbeddingOption = "audio"
 	defaultAsyncMaxWait         = 30 * time.Minute
+	defaultAsyncPollInitial     = 2 * time.Second
 	APIKeyEnvVar                = "TWELVE_LABS_API_KEY"
 	taskStatusProcessing        = "processing"
 	taskStatusReady             = "ready"
@@ -68,7 +69,7 @@ func applyDefaults(c *TwelveLabsClient) {
 		c.AudioEmbeddingOption = defaultAudioEmbeddingOption
 	}
 	if c.asyncPollInitial == 0 {
-		c.asyncPollInitial = 2 * time.Second
+		c.asyncPollInitial = defaultAsyncPollInitial
 	}
 	if c.asyncPollMultiplier == 0 {
 		c.asyncPollMultiplier = 1.5
@@ -371,7 +372,16 @@ func sanitizeTaskFailureDetail(body json.RawMessage) string {
 	if detail := extractTaskFailureDetail(body); detail != "" {
 		return chttp.SanitizeErrorBody([]byte(detail))
 	}
-	return chttp.SanitizeErrorBody(body)
+	// No structured reason. If the body parses as a JSON object, dumping it
+	// just leaks housekeeping fields (_id, status) without diagnostic value.
+	// Non-JSON bodies may carry free-text errors worth preserving.
+	var probe map[string]any
+	if len(body) > 0 && json.Unmarshal(body, &probe) != nil {
+		if sanitized := chttp.SanitizeErrorBody(body); sanitized != "" {
+			return sanitized
+		}
+	}
+	return "(no failure detail provided)"
 }
 
 func extractTaskFailureDetail(body json.RawMessage) string {

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -41,8 +41,10 @@ type TwelveLabsClient struct {
 	Insecure             bool
 	AudioEmbeddingOption string
 
-	asyncPollingEnabled bool
-	asyncMaxWait        time.Duration
+	// Async polling state — wired up by WithAsyncPolling (Plan 26-03)
+	// and consumed by the polling loop (Plan 26-02).
+	asyncPollingEnabled bool          //nolint:unused // consumed by Plans 26-02/03
+	asyncMaxWait        time.Duration //nolint:unused // consumed by Plans 26-02/03
 	asyncPollInitial    time.Duration
 	asyncPollMultiplier float64
 	asyncPollCap        time.Duration
@@ -253,6 +255,98 @@ func (e *TwelveLabsEmbeddingFunction) doPost(ctx context.Context, req EmbedV2Req
 		return nil, errors.Wrap(err, "failed to unmarshal response body")
 	}
 	return &embedResp, nil
+}
+
+// doTaskPost creates an async embedding task via POST {BaseAPI}/tasks.
+// Used when WithAsyncPolling is enabled and the content modality is
+// audio or video. See CONTEXT.md D-01, D-07.
+//
+//nolint:unused // consumed by Plans 26-02/03
+func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncEmbedV2Request) (*TaskCreateResponse, error) {
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal async task request")
+	}
+	endpoint := strings.TrimRight(e.apiClient.BaseAPI, "/") + "/tasks"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create HTTP request")
+	}
+	httpReq.Header.Set("x-api-key", e.apiClient.APIKey.Value())
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+
+	resp, err := e.apiClient.Client.Do(httpReq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to send task request to %s", endpoint)
+	}
+	defer resp.Body.Close()
+
+	respData, err := chttp.ReadLimitedBody(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response body")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiErr EmbedV2ErrorResponse
+		if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
+			return nil, errors.Errorf("Twelve Labs task create error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+		}
+		return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
+	}
+
+	var out TaskCreateResponse
+	if err := json.Unmarshal(respData, &out); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal task create response")
+	}
+	return &out, nil
+}
+
+// doTaskGet retrieves an async embedding task via GET {BaseAPI}/tasks/{id}.
+// Per RESEARCH F-01 this single endpoint serves BOTH status polling and
+// final result retrieval — the response carries status + data.
+//
+//nolint:unused // consumed by Plans 26-02/03
+func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID string) (*TaskResponse, error) {
+	if taskID == "" {
+		return nil, errors.New("task ID cannot be empty (check _id JSON tag on create response)")
+	}
+	endpoint := strings.TrimRight(e.apiClient.BaseAPI, "/") + "/tasks/" + url.PathEscape(taskID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create HTTP request")
+	}
+	httpReq.Header.Set("x-api-key", e.apiClient.APIKey.Value())
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("User-Agent", chttp.ChromaGoClientUserAgent)
+
+	resp, err := e.apiClient.Client.Do(httpReq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to send task retrieve request to %s", endpoint)
+	}
+	defer resp.Body.Close()
+
+	respData, err := chttp.ReadLimitedBody(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read response body")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var apiErr EmbedV2ErrorResponse
+		if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
+			return nil, errors.Errorf("Twelve Labs task retrieve error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+		}
+		return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
+	}
+
+	var out TaskResponse
+	if err := json.Unmarshal(respData, &out); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal task retrieve response")
+	}
+	// Preserve raw body so pollTask can sanitize the authentic server reason
+	// on status=failed (D-17). Copy respData — the underlying buffer may be
+	// reused; json.RawMessage needs stable bytes.
+	out.FailureDetail = append(json.RawMessage(nil), respData...)
+	return &out, nil
 }
 
 func (e *TwelveLabsEmbeddingFunction) Name() string {

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -39,6 +40,12 @@ type TwelveLabsClient struct {
 	Client               *http.Client
 	Insecure             bool
 	AudioEmbeddingOption string
+
+	asyncPollingEnabled bool
+	asyncMaxWait        time.Duration
+	asyncPollInitial    time.Duration
+	asyncPollMultiplier float64
+	asyncPollCap        time.Duration
 }
 
 func applyDefaults(c *TwelveLabsClient) {
@@ -53,6 +60,15 @@ func applyDefaults(c *TwelveLabsClient) {
 	}
 	if c.AudioEmbeddingOption == "" {
 		c.AudioEmbeddingOption = defaultAudioEmbeddingOption
+	}
+	if c.asyncPollInitial == 0 {
+		c.asyncPollInitial = 2 * time.Second
+	}
+	if c.asyncPollMultiplier == 0 {
+		c.asyncPollMultiplier = 1.5
+	}
+	if c.asyncPollCap == 0 {
+		c.asyncPollCap = 60 * time.Second
 	}
 }
 
@@ -117,6 +133,49 @@ type AudioInput struct {
 
 type VideoInput struct {
 	MediaSource MediaSource `json:"media_source"`
+}
+
+// AsyncEmbedV2Request is the JSON body for POST /v1.3/embed-v2/tasks.
+// The async endpoint uses a distinct shape from the sync endpoint
+// (embedding_option is a list, not a single string). See RESEARCH F-02.
+type AsyncEmbedV2Request struct {
+	InputType string           `json:"input_type"`
+	ModelName string           `json:"model_name"`
+	Audio     *AsyncAudioInput `json:"audio,omitempty"`
+	Video     *AsyncVideoInput `json:"video,omitempty"`
+}
+
+type AsyncAudioInput struct {
+	MediaSource     MediaSource `json:"media_source"`
+	EmbeddingOption []string    `json:"embedding_option,omitempty"`
+}
+
+type AsyncVideoInput struct {
+	MediaSource MediaSource `json:"media_source"`
+}
+
+// TaskCreateResponse is returned from POST /v1.3/embed-v2/tasks.
+// NOTE: task ID uses `_id` alias (Mongo-style) — RESEARCH Pitfall 1.
+type TaskCreateResponse struct {
+	ID     string            `json:"_id"`
+	Status string            `json:"status"`
+	Data   []EmbedV2DataItem `json:"data,omitempty"`
+}
+
+// TaskResponse is returned from GET /v1.3/embed-v2/tasks/{id}.
+// Serves BOTH polling and retrieval (RESEARCH F-01 — only two
+// endpoints exist; there is no separate /status sub-path).
+//
+// FailureDetail holds the raw HTTP response body so that on status=failed
+// Plan 02 can sanitize the actual server-provided failure reason rather
+// than re-marshaling this struct's subset of fields (D-17 compliance).
+// The `json:"-"` tag excludes it from unmarshaling; doTaskGet populates
+// it directly from the body bytes.
+type TaskResponse struct {
+	ID            string            `json:"_id"`
+	Status        string            `json:"status"` // "processing" | "ready" | "failed"
+	Data          []EmbedV2DataItem `json:"data,omitempty"`
+	FailureDetail json.RawMessage   `json:"-"`
 }
 
 // EmbedV2Response is the response body from the embed-v2 endpoint.

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -435,6 +435,10 @@ func (e *TwelveLabsEmbeddingFunction) GetConfig() embeddings.EmbeddingFunctionCo
 	if e.apiClient.Insecure {
 		cfg["insecure"] = true
 	}
+	if e.apiClient.asyncPollingEnabled {
+		cfg["async_polling"] = true
+		cfg["async_max_wait_ms"] = e.apiClient.asyncMaxWait.Milliseconds() // int64
+	}
 	return cfg
 }
 
@@ -459,6 +463,16 @@ func NewTwelveLabsEmbeddingFunctionFromConfig(cfg embeddings.EmbeddingFunctionCo
 	}
 	if audioOpt, ok := cfg["audio_embedding_option"].(string); ok && audioOpt != "" {
 		opts = append(opts, WithAudioEmbeddingOption(audioOpt))
+	}
+	// Only enable async when BOTH keys are present and parseable. A missing or
+	// malformed async_max_wait_ms with async_polling=true is treated as a broken
+	// round-trip — we deliberately do NOT fall back to WithAsyncPolling(0) (the
+	// 30-minute default) because that would silently enable a 30-minute blocking
+	// bound on config the caller didn't specify. Missing key → not enabled.
+	if enabled, ok := cfg["async_polling"].(bool); ok && enabled {
+		if ms, ok := embeddings.ConfigInt(cfg, "async_max_wait_ms"); ok && ms >= 0 {
+			opts = append(opts, WithAsyncPolling(time.Duration(ms)*time.Millisecond))
+		}
 	}
 	return NewTwelveLabsEmbeddingFunction(opts...)
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -47,8 +47,8 @@ type TwelveLabsClient struct {
 
 	// Async polling state — wired up by WithAsyncPolling (Plan 26-03)
 	// and consumed by the polling loop (Plan 26-02).
-	asyncPollingEnabled bool          //nolint:unused // consumed by Plans 26-02/03
-	asyncMaxWait        time.Duration //nolint:unused // consumed by Plans 26-02/03
+	asyncPollingEnabled bool
+	asyncMaxWait        time.Duration
 	asyncPollInitial    time.Duration
 	asyncPollMultiplier float64
 	asyncPollCap        time.Duration
@@ -267,8 +267,6 @@ func (e *TwelveLabsEmbeddingFunction) doPost(ctx context.Context, req EmbedV2Req
 // doTaskPost creates an async embedding task via POST {BaseAPI}/tasks.
 // Used when WithAsyncPolling is enabled and the content modality is
 // audio or video. See CONTEXT.md D-01, D-07.
-//
-//nolint:unused // consumed by Plans 26-02/03
 func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncEmbedV2Request) (*TaskCreateResponse, error) {
 	reqJSON, err := json.Marshal(req)
 	if err != nil {
@@ -312,8 +310,6 @@ func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncE
 // doTaskGet retrieves an async embedding task via GET {BaseAPI}/tasks/{id}.
 // Per RESEARCH F-01 this single endpoint serves BOTH status polling and
 // final result retrieval — the response carries status + data.
-//
-//nolint:unused // consumed by Plans 26-02/03
 func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID string) (*TaskResponse, error) {
 	if taskID == "" {
 		return nil, errors.New("task ID cannot be empty (check _id JSON tag on create response)")
@@ -351,8 +347,12 @@ func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID stri
 	}
 	// Preserve raw body so pollTask can sanitize the authentic server reason
 	// on status=failed (D-17). Copy respData — the underlying buffer may be
-	// reused; json.RawMessage needs stable bytes.
-	out.FailureDetail = append(json.RawMessage(nil), respData...)
+	// reused; json.RawMessage needs stable bytes. Only populated on terminal
+	// failure: ready responses carry the full embedding payload and copying
+	// that would double memory for data we never read.
+	if out.Status == taskStatusFailed {
+		out.FailureDetail = append(json.RawMessage(nil), respData...)
+	}
 	return &out, nil
 }
 

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -19,7 +19,11 @@ const (
 	defaultBaseAPI              = "https://api.twelvelabs.io/v1.3/embed-v2"
 	defaultModel                = "marengo3.0"
 	defaultAudioEmbeddingOption = "audio"
+	defaultAsyncMaxWait         = 30 * time.Minute
 	APIKeyEnvVar                = "TWELVE_LABS_API_KEY"
+	taskStatusProcessing        = "processing"
+	taskStatusReady             = "ready"
+	taskStatusFailed            = "failed"
 )
 
 type contextKey struct{ name string }
@@ -84,6 +88,12 @@ func validate(c *TwelveLabsClient) error {
 	}
 	if !c.Insecure && !strings.EqualFold(parsed.Scheme, "https") {
 		return errors.New("base URL must use HTTPS scheme for secure API key transmission; use WithInsecure() to override")
+	}
+	if c.asyncPollMultiplier < 1 {
+		return errors.Errorf("async poll multiplier %.3f must be >= 1.0", c.asyncPollMultiplier)
+	}
+	if c.asyncPollCap < c.asyncPollInitial {
+		return errors.Errorf("async poll cap %s must be >= async poll initial %s", c.asyncPollCap, c.asyncPollInitial)
 	}
 	return nil
 }
@@ -168,9 +178,9 @@ type TaskCreateResponse struct {
 // Serves BOTH polling and retrieval (RESEARCH F-01 — only two
 // endpoints exist; there is no separate /status sub-path).
 //
-// FailureDetail holds the raw HTTP response body so that on status=failed
-// Plan 02 can sanitize the actual server-provided failure reason rather
-// than re-marshaling this struct's subset of fields (D-17 compliance).
+// FailureDetail holds the raw HTTP response body so terminal task failures can
+// surface the provider's authentic reason rather than a re-marshaled subset of
+// known fields.
 // The `json:"-"` tag excludes it from unmarshaling; doTaskGet populates
 // it directly from the body bytes.
 type TaskResponse struct {
@@ -242,10 +252,7 @@ func (e *TwelveLabsEmbeddingFunction) doPost(ctx context.Context, req EmbedV2Req
 	if resp.StatusCode != http.StatusOK {
 		var apiErr EmbedV2ErrorResponse
 		if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
-			if apiErr.Code != "" {
-				return nil, errors.Errorf("Twelve Labs API error [%s] (%s): %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Code)), chttp.SanitizeErrorBody([]byte(apiErr.Message)))
-			}
-			return nil, errors.Errorf("Twelve Labs API error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+			return nil, formatStructuredAPIError("Twelve Labs API error", resp.Status, apiErr)
 		}
 		return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, e.apiClient.BaseAPI, chttp.SanitizeErrorBody(respData))
 	}
@@ -290,7 +297,7 @@ func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncE
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var apiErr EmbedV2ErrorResponse
 		if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
-			return nil, errors.Errorf("Twelve Labs task create error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+			return nil, formatStructuredAPIError("Twelve Labs task create error", resp.Status, apiErr)
 		}
 		return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
 	}
@@ -333,7 +340,7 @@ func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID stri
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var apiErr EmbedV2ErrorResponse
 		if jsonErr := json.Unmarshal(respData, &apiErr); jsonErr == nil && apiErr.Message != "" {
-			return nil, errors.Errorf("Twelve Labs task retrieve error [%s]: %s", resp.Status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+			return nil, formatStructuredAPIError("Twelve Labs task retrieve error", resp.Status, apiErr)
 		}
 		return nil, errors.Errorf("unexpected status [%s] from %s: %s", resp.Status, endpoint, chttp.SanitizeErrorBody(respData))
 	}
@@ -351,6 +358,72 @@ func (e *TwelveLabsEmbeddingFunction) doTaskGet(ctx context.Context, taskID stri
 
 func (e *TwelveLabsEmbeddingFunction) Name() string {
 	return "twelvelabs"
+}
+
+func formatStructuredAPIError(prefix, status string, apiErr EmbedV2ErrorResponse) error {
+	if apiErr.Code != "" {
+		return errors.Errorf("%s [%s] (%s): %s", prefix, status, chttp.SanitizeErrorBody([]byte(apiErr.Code)), chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+	}
+	return errors.Errorf("%s [%s]: %s", prefix, status, chttp.SanitizeErrorBody([]byte(apiErr.Message)))
+}
+
+func sanitizeTaskFailureDetail(body json.RawMessage) string {
+	if detail := extractTaskFailureDetail(body); detail != "" {
+		return chttp.SanitizeErrorBody([]byte(detail))
+	}
+	return chttp.SanitizeErrorBody(body)
+}
+
+func extractTaskFailureDetail(body json.RawMessage) string {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+
+	if detail := extractTaskFailureValue(payload["error"]); detail != "" {
+		return detail
+	}
+	if detail := firstStringField(payload, "message", "failure_reason", "reason", "detail"); detail != "" {
+		return detail
+	}
+	return ""
+}
+
+func extractTaskFailureValue(v any) string {
+	switch value := v.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case map[string]any:
+		detail := firstStringField(value, "message", "failure_reason", "reason", "detail")
+		code := firstStringField(value, "code")
+		if detail != "" && code != "" {
+			return code + ": " + detail
+		}
+		if detail != "" {
+			return detail
+		}
+		return code
+	default:
+		return ""
+	}
+}
+
+func firstStringField(payload map[string]any, keys ...string) string {
+	for _, key := range keys {
+		raw, ok := payload[key]
+		if !ok {
+			continue
+		}
+		value, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (e *TwelveLabsEmbeddingFunction) resolveModel(ctx context.Context) string {

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -96,6 +96,12 @@ func validate(c *TwelveLabsClient) error {
 	if c.asyncPollCap < c.asyncPollInitial {
 		return errors.Errorf("async poll cap %s must be >= async poll initial %s", c.asyncPollCap, c.asyncPollInitial)
 	}
+	// Fail fast on option combinations that would only surface at EmbedContent
+	// time. The async /tasks endpoint rejects "fused" (RESEARCH F-02) — surface
+	// this at construction rather than minutes into a pipeline.
+	if c.asyncPollingEnabled && c.AudioEmbeddingOption == "fused" {
+		return errors.New(`WithAudioEmbeddingOption("fused") is not supported with WithAsyncPolling; the async tasks endpoint accepts only "audio" and "transcription" (RESEARCH F-02)`)
+	}
 	return nil
 }
 
@@ -173,6 +179,11 @@ type TaskCreateResponse struct {
 	ID     string            `json:"_id"`
 	Status string            `json:"status"`
 	Data   []EmbedV2DataItem `json:"data,omitempty"`
+	// FailureDetail carries the raw server response body when Status=failed so
+	// callers surface the authentic server reason rather than just the task ID.
+	// Mirrors TaskResponse.FailureDetail; populated only on terminal-failure
+	// creates (rare — usually surface as non-2xx).
+	FailureDetail json.RawMessage `json:"-"`
 }
 
 // TaskResponse is returned from GET /v1.3/embed-v2/tasks/{id}.
@@ -304,6 +315,11 @@ func (e *TwelveLabsEmbeddingFunction) doTaskPost(ctx context.Context, req AsyncE
 	var out TaskCreateResponse
 	if err := json.Unmarshal(respData, &out); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal task create response")
+	}
+	// Preserve raw body on terminal failure so callers can sanitize the
+	// authentic server reason — mirrors doTaskGet (D-17).
+	if out.Status == taskStatusFailed {
+		out.FailureDetail = append(json.RawMessage(nil), respData...)
 	}
 	return &out, nil
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs.go
@@ -27,6 +27,10 @@ const (
 	taskStatusFailed            = "failed"
 )
 
+// taskHousekeepingFields carry no diagnostic value on a failed task, so a
+// body containing only these is reported as "no detail" rather than dumped.
+var taskHousekeepingFields = []string{"_id", "status"}
+
 type contextKey struct{ name string }
 
 var modelContextKey = contextKey{"model"}
@@ -388,14 +392,24 @@ func sanitizeTaskFailureDetail(body json.RawMessage) string {
 	if detail := extractTaskFailureDetail(body); detail != "" {
 		return chttp.SanitizeErrorBody([]byte(detail))
 	}
-	// No structured reason. If the body parses as a JSON object, dumping it
-	// just leaks housekeeping fields (_id, status) without diagnostic value.
-	// Non-JSON bodies may carry free-text errors worth preserving.
+	if len(body) == 0 {
+		return "(no failure detail provided)"
+	}
+	// No known field matched. The failure schema is undocumented (26-RESEARCH
+	// A3), so an allowlist can't be exhaustive — unrecognized keys are the only
+	// diagnostic signal left and must survive. Suppress only the case where
+	// nothing but housekeeping remains, which would be pure noise.
 	var probe map[string]any
-	if len(body) > 0 && json.Unmarshal(body, &probe) != nil {
-		if sanitized := chttp.SanitizeErrorBody(body); sanitized != "" {
-			return sanitized
+	if json.Unmarshal(body, &probe) == nil {
+		for _, k := range taskHousekeepingFields {
+			delete(probe, k)
 		}
+		if len(probe) == 0 {
+			return "(no failure detail provided)"
+		}
+	}
+	if sanitized := chttp.SanitizeErrorBody(body); sanitized != "" {
+		return sanitized
 	}
 	return "(no failure detail provided)"
 }
@@ -563,15 +577,17 @@ func NewTwelveLabsEmbeddingFunctionFromConfig(cfg embeddings.EmbeddingFunctionCo
 	if audioOpt, ok := cfg["audio_embedding_option"].(string); ok && audioOpt != "" {
 		opts = append(opts, WithAudioEmbeddingOption(audioOpt))
 	}
-	// Only enable async when BOTH keys are present and parseable. A missing or
-	// malformed async_max_wait_ms with async_polling=true is treated as a broken
-	// round-trip — we deliberately do NOT fall back to WithAsyncPolling(0) (the
-	// 30-minute default) because that would silently enable a 30-minute blocking
-	// bound on config the caller didn't specify. Missing key → not enabled.
+	// async_polling=true requires a usable async_max_wait_ms. Falling back to
+	// WithAsyncPolling(0) would silently impose the 30-minute default bound the
+	// caller never specified; silently skipping it would just as silently
+	// downgrade audio/video to the sync path. Both are surprises, so a broken
+	// round-trip fails loudly here instead.
 	if enabled, ok := cfg["async_polling"].(bool); ok && enabled {
-		if ms, ok := embeddings.ConfigInt(cfg, "async_max_wait_ms"); ok && ms >= 0 {
-			opts = append(opts, WithAsyncPolling(time.Duration(ms)*time.Millisecond))
+		ms, ok := embeddings.ConfigInt(cfg, "async_max_wait_ms")
+		if !ok || ms <= 0 {
+			return nil, errors.Errorf("async_polling is enabled but async_max_wait_ms is missing or invalid: %v", cfg["async_max_wait_ms"])
 		}
+		opts = append(opts, WithAsyncPolling(time.Duration(ms)*time.Millisecond))
 	}
 	return NewTwelveLabsEmbeddingFunction(opts...)
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -13,8 +13,6 @@ import (
 // contentToAsyncRequest builds the tasks-endpoint body for audio/video content.
 // See RESEARCH F-02 — the async endpoint uses embedding_option as []string
 // and does NOT accept "fused" (only "audio" and "transcription").
-//
-//nolint:unused // wired in Task 2 (content.go routing)
 func contentToAsyncRequest(content embeddings.Content, model string, audioOpt string) (*AsyncEmbedV2Request, error) {
 	if len(content.Parts) != 1 {
 		return nil, errors.Errorf("Twelve Labs requires exactly one part per Content item, got %d", len(content.Parts))
@@ -60,8 +58,6 @@ func contentToAsyncRequest(content embeddings.Content, model string, audioOpt st
 // a blocked HTTP request cannot outlive maxWait (D-09 hard bound). When the
 // derived deadline fires, we inspect which source expired first and translate
 // back into the appropriate distinct error message (D-20).
-//
-//nolint:unused // wired in Task 2 (content.go routing) via createTaskAndPoll
 func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID string, maxWait time.Duration) (*TaskResponse, error) {
 	sdkMaxWaitDeadline := time.Now().Add(maxWait)
 	interval := e.apiClient.asyncPollInitial
@@ -129,7 +125,6 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 	}
 }
 
-//nolint:unused // wired in Task 2 (content.go routing) via pollTask
 func nextBackoff(cur time.Duration, mul float64, backoffCap time.Duration) time.Duration {
 	next := time.Duration(float64(cur) * mul)
 	if next > backoffCap {
@@ -139,8 +134,6 @@ func nextBackoff(cur time.Duration, mul float64, backoffCap time.Duration) time.
 }
 
 // createTaskAndPoll builds the async request, creates the task, and polls to completion.
-//
-//nolint:unused // wired in Task 2 (content.go routing)
 func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
 	req, err := contentToAsyncRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
 	if err != nil {
@@ -165,8 +158,6 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 }
 
 // buildEmbeddingFromData mirrors embeddingFromResponse but operates on a raw data slice.
-//
-//nolint:unused // wired in Task 2 (content.go routing) via createTaskAndPoll
 func buildEmbeddingFromData(data []EmbedV2DataItem) (embeddings.Embedding, error) {
 	if len(data) == 0 {
 		return nil, errors.New("no embedding returned from Twelve Labs task")

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -181,7 +181,15 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	if created.Status == taskStatusReady && len(created.Data) > 0 {
 		return buildEmbeddingFromData(created.Data)
 	}
-	final, err := e.pollTask(ctx, created.ID, e.apiClient.asyncMaxWait)
+	// Pass the *remaining* maxWait budget to pollTask so total operation time
+	// (create + poll) stays within a single asyncMaxWait window — honoring the
+	// documented hard upper bound (D-09). Without this, a slow create would
+	// grant polling a fresh full budget, yielding up to 2× maxWait total.
+	remaining := time.Until(sdkMaxWaitDeadline)
+	if remaining <= 0 {
+		return nil, errors.Errorf("Twelve Labs async maxWait %s exceeded after task create", e.apiClient.asyncMaxWait)
+	}
+	final, err := e.pollTask(ctx, created.ID, remaining)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -85,7 +85,7 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 				return nil, errors.Wrap(err, "Twelve Labs async polling request timed out")
 			}
 			if errors.Is(err, context.Canceled) {
-				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+				return nil, errors.Wrap(err, "Twelve Labs async polling canceled")
 			}
 			return nil, err
 		}
@@ -170,7 +170,7 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 			return nil, errors.Wrap(err, "Twelve Labs async task create request timed out")
 		}
 		if errors.Is(err, context.Canceled) {
-			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async task create canceled")
+			return nil, errors.Wrap(err, "Twelve Labs async task create canceled")
 		}
 		return nil, errors.Wrap(err, "failed to create Twelve Labs async task")
 	}

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -1,0 +1,181 @@
+package twelvelabs
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
+	"github.com/amikos-tech/chroma-go/pkg/embeddings"
+)
+
+// contentToAsyncRequest builds the tasks-endpoint body for audio/video content.
+// See RESEARCH F-02 — the async endpoint uses embedding_option as []string
+// and does NOT accept "fused" (only "audio" and "transcription").
+//
+//nolint:unused // wired in Task 2 (content.go routing)
+func contentToAsyncRequest(content embeddings.Content, model string, audioOpt string) (*AsyncEmbedV2Request, error) {
+	if len(content.Parts) != 1 {
+		return nil, errors.Errorf("Twelve Labs requires exactly one part per Content item, got %d", len(content.Parts))
+	}
+	part := content.Parts[0]
+	req := &AsyncEmbedV2Request{ModelName: model}
+	switch part.Modality {
+	case embeddings.ModalityAudio:
+		// RESEARCH F-02 / A5: "fused" is valid on the sync embedding_option
+		// string but is NOT a valid async embedding_option list value. Reject
+		// deterministically rather than silently dropping or mapping.
+		if audioOpt == "fused" {
+			return nil, errors.New("Twelve Labs async path does not support audio embedding option \"fused\"; async endpoint only accepts \"audio\" and \"transcription\" (see RESEARCH F-02). Disable WithAsyncPolling for fused-audio calls.")
+		}
+		ms, err := buildMediaSource(part.Source)
+		if err != nil {
+			return nil, errors.Wrap(err, "audio source")
+		}
+		req.InputType = "audio"
+		audio := &AsyncAudioInput{MediaSource: ms}
+		if audioOpt != "" {
+			audio.EmbeddingOption = []string{audioOpt} // wrap single-string sync option into list per F-02
+		}
+		req.Audio = audio
+	case embeddings.ModalityVideo:
+		ms, err := buildMediaSource(part.Source)
+		if err != nil {
+			return nil, errors.Wrap(err, "video source")
+		}
+		req.InputType = "video"
+		req.Video = &AsyncVideoInput{MediaSource: ms}
+	default:
+		return nil, errors.Errorf("async path only handles audio/video; got modality %q", part.Modality)
+	}
+	return req, nil
+}
+
+// pollTask loops GET /tasks/{id} until ready, failed, ctx-cancel, or maxWait-expiry.
+// D-09/D-10/D-11/D-14/D-16/D-17/D-20 all land here.
+//
+// Per-HTTP-call deadline: every doTaskGet is wrapped in a derived context
+// bounded by min(parent ctx deadline, SDK maxWait deadline). This ensures
+// a blocked HTTP request cannot outlive maxWait (D-09 hard bound). When the
+// derived deadline fires, we inspect which source expired first and translate
+// back into the appropriate distinct error message (D-20).
+//
+//nolint:unused // wired in Task 2 (content.go routing) via createTaskAndPoll
+func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID string, maxWait time.Duration) (*TaskResponse, error) {
+	sdkMaxWaitDeadline := time.Now().Add(maxWait)
+	interval := e.apiClient.asyncPollInitial
+	for {
+		// Derive per-call deadline = min(parent ctx deadline, sdkMaxWaitDeadline).
+		callDeadline := sdkMaxWaitDeadline
+		if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(callDeadline) {
+			callDeadline = parentDL
+		}
+		callCtx, cancel := context.WithDeadline(ctx, callDeadline)
+		resp, err := e.doTaskGet(callCtx, taskID)
+		cancel()
+		if err != nil {
+			// If the call was terminated because our derived deadline fired,
+			// figure out which source was responsible and return the distinct
+			// error (D-20). errors.Is works through pkg/errors wrapping.
+			if errors.Is(err, context.DeadlineExceeded) {
+				if time.Now().After(sdkMaxWaitDeadline) {
+					return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+				}
+				// Parent ctx deadline fired first.
+				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")
+			}
+			if errors.Is(err, context.Canceled) {
+				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+			}
+			return nil, err
+		}
+		switch resp.Status {
+		case "ready":
+			return resp, nil
+		case "failed":
+			// Use the raw server body captured by doTaskGet (Plan 01 FailureDetail)
+			// so the sanitized reason reflects the authentic server payload,
+			// not a re-marshaled subset of known fields.
+			return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(resp.FailureDetail))
+		case "processing":
+			// fall through to sleep
+		default:
+			return nil, errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, resp.Status)
+		}
+
+		remaining := time.Until(sdkMaxWaitDeadline)
+		if remaining <= 0 {
+			return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+		}
+		wait := interval
+		if wait > remaining {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			// Distinct wording for cancel vs deadline (D-20). errors.Is still
+			// unwraps to the stdlib sentinel for caller introspection.
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")
+			}
+			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
+		case <-timer.C:
+		}
+
+		interval = nextBackoff(interval, e.apiClient.asyncPollMultiplier, e.apiClient.asyncPollCap)
+	}
+}
+
+//nolint:unused // wired in Task 2 (content.go routing) via pollTask
+func nextBackoff(cur time.Duration, mul float64, backoffCap time.Duration) time.Duration {
+	next := time.Duration(float64(cur) * mul)
+	if next > backoffCap {
+		next = backoffCap
+	}
+	return next
+}
+
+// createTaskAndPoll builds the async request, creates the task, and polls to completion.
+//
+//nolint:unused // wired in Task 2 (content.go routing)
+func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, content embeddings.Content) (embeddings.Embedding, error) {
+	req, err := contentToAsyncRequest(content, e.resolveModel(ctx), e.apiClient.AudioEmbeddingOption)
+	if err != nil {
+		return nil, err
+	}
+	created, err := e.doTaskPost(ctx, *req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Twelve Labs async task")
+	}
+	if created.ID == "" {
+		return nil, errors.New("Twelve Labs async task create returned empty _id")
+	}
+	// Rare early-ready path (server finished before response round-trip returned).
+	if created.Status == "ready" && len(created.Data) > 0 {
+		return buildEmbeddingFromData(created.Data)
+	}
+	final, err := e.pollTask(ctx, created.ID, e.apiClient.asyncMaxWait)
+	if err != nil {
+		return nil, err
+	}
+	return buildEmbeddingFromData(final.Data)
+}
+
+// buildEmbeddingFromData mirrors embeddingFromResponse but operates on a raw data slice.
+//
+//nolint:unused // wired in Task 2 (content.go routing) via createTaskAndPoll
+func buildEmbeddingFromData(data []EmbedV2DataItem) (embeddings.Embedding, error) {
+	if len(data) == 0 {
+		return nil, errors.New("no embedding returned from Twelve Labs task")
+	}
+	if len(data) > 1 {
+		return nil, errors.Errorf("expected 1 embedding from Twelve Labs task, got %d", len(data))
+	}
+	if len(data[0].Embedding) == 0 {
+		return nil, errors.New("empty embedding vector returned from Twelve Labs task")
+	}
+	return embeddings.NewEmbeddingFromFloat32(float64sToFloat32s(data[0].Embedding)), nil
+}

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -139,8 +139,31 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	if err != nil {
 		return nil, err
 	}
-	created, err := e.doTaskPost(ctx, *req)
+	// Bound the create call by the same min(parent ctx deadline, sdk maxWait
+	// deadline) used in pollTask so the whole operation honors maxWait as a
+	// hard upper bound (D-09). Without this, a blocked POST /tasks would hang
+	// until the underlying http.Client transport timed out (default: forever).
+	sdkMaxWaitDeadline := time.Now().Add(e.apiClient.asyncMaxWait)
+	createDeadline := sdkMaxWaitDeadline
+	if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(createDeadline) {
+		createDeadline = parentDL
+	}
+	createCtx, cancel := context.WithDeadline(ctx, createDeadline)
+	created, err := e.doTaskPost(createCtx, *req)
+	cancel()
 	if err != nil {
+		// Translate deadline errors the same way pollTask does so a maxWait
+		// timeout on the create call surfaces as the distinct SDK error rather
+		// than raw context.DeadlineExceeded (D-20).
+		if errors.Is(err, context.DeadlineExceeded) {
+			if time.Now().After(sdkMaxWaitDeadline) {
+				return nil, errors.Errorf("Twelve Labs async task create maxWait %s exceeded", e.apiClient.asyncMaxWait)
+			}
+			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async task create deadline exceeded")
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async task create canceled")
+		}
 		return nil, errors.Wrap(err, "failed to create Twelve Labs async task")
 	}
 	if created.ID == "" {

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	chttp "github.com/amikos-tech/chroma-go/pkg/commons/http"
 	"github.com/amikos-tech/chroma-go/pkg/embeddings"
 )
 
@@ -21,11 +20,10 @@ func contentToAsyncRequest(content embeddings.Content, model string, audioOpt st
 	req := &AsyncEmbedV2Request{ModelName: model}
 	switch part.Modality {
 	case embeddings.ModalityAudio:
-		// RESEARCH F-02 / A5: "fused" is valid on the sync embedding_option
-		// string but is NOT a valid async embedding_option list value. Reject
-		// deterministically rather than silently dropping or mapping.
-		if audioOpt == "fused" {
-			return nil, errors.New("Twelve Labs async path does not support audio embedding option \"fused\"; async endpoint only accepts \"audio\" and \"transcription\" (see RESEARCH F-02). Disable WithAsyncPolling for fused-audio calls.")
+		switch audioOpt {
+		case "", "audio", "transcription":
+		default:
+			return nil, errors.Errorf("Twelve Labs async path does not support audio embedding option %q; async endpoint only accepts \"audio\" and \"transcription\" (see RESEARCH F-02). Disable WithAsyncPolling for unsupported async-audio calls.", audioOpt)
 		}
 		ms, err := buildMediaSource(part.Source)
 		if err != nil {
@@ -64,8 +62,10 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 	for {
 		// Derive per-call deadline = min(parent ctx deadline, sdkMaxWaitDeadline).
 		callDeadline := sdkMaxWaitDeadline
+		parentDeadlineSelected := false
 		if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(callDeadline) {
 			callDeadline = parentDL
+			parentDeadlineSelected = true
 		}
 		callCtx, cancel := context.WithDeadline(ctx, callDeadline)
 		resp, err := e.doTaskGet(callCtx, taskID)
@@ -76,11 +76,11 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 			// error (D-20). errors.Is works through pkg/errors wrapping.
 			if errors.Is(err, context.DeadlineExceeded) {
 				if !time.Now().Before(sdkMaxWaitDeadline) {
-					return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+					return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded: %v", taskID, maxWait, err)
 				}
-				if ctxErr := ctx.Err(); ctxErr != nil {
+				if parentDeadlineSelected || ctx.Err() != nil {
 					// Parent ctx deadline fired first.
-					return nil, errors.Wrap(ctxErr, "Twelve Labs async polling deadline exceeded")
+					return nil, errors.Wrapf(err, "Twelve Labs async polling deadline exceeded")
 				}
 				return nil, errors.Wrap(err, "Twelve Labs async polling request timed out")
 			}
@@ -90,14 +90,14 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 			return nil, err
 		}
 		switch resp.Status {
-		case "ready":
+		case taskStatusReady:
 			return resp, nil
-		case "failed":
+		case taskStatusFailed:
 			// Use the raw server body captured by doTaskGet (Plan 01 FailureDetail)
 			// so the sanitized reason reflects the authentic server payload,
 			// not a re-marshaled subset of known fields.
-			return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, chttp.SanitizeErrorBody(resp.FailureDetail))
-		case "processing":
+			return nil, errors.Errorf("Twelve Labs task [%s] terminal status=failed: %s", taskID, sanitizeTaskFailureDetail(resp.FailureDetail))
+		case taskStatusProcessing:
 			// fall through to sleep
 		default:
 			return nil, errors.Errorf("Twelve Labs task [%s] unexpected status %q", taskID, resp.Status)
@@ -148,8 +148,10 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	// until the underlying http.Client transport timed out (default: forever).
 	sdkMaxWaitDeadline := time.Now().Add(e.apiClient.asyncMaxWait)
 	createDeadline := sdkMaxWaitDeadline
+	parentDeadlineSelected := false
 	if parentDL, ok := ctx.Deadline(); ok && parentDL.Before(createDeadline) {
 		createDeadline = parentDL
+		parentDeadlineSelected = true
 	}
 	createCtx, cancel := context.WithDeadline(ctx, createDeadline)
 	created, err := e.doTaskPost(createCtx, *req)
@@ -160,10 +162,10 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 		// than raw context.DeadlineExceeded (D-20).
 		if errors.Is(err, context.DeadlineExceeded) {
 			if !time.Now().Before(sdkMaxWaitDeadline) {
-				return nil, errors.Errorf("Twelve Labs async task create maxWait %s exceeded", e.apiClient.asyncMaxWait)
+				return nil, errors.Errorf("Twelve Labs async task create maxWait %s exceeded: %v", e.apiClient.asyncMaxWait, err)
 			}
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return nil, errors.Wrap(ctxErr, "Twelve Labs async task create deadline exceeded")
+			if parentDeadlineSelected || ctx.Err() != nil {
+				return nil, errors.Wrapf(err, "Twelve Labs async task create deadline exceeded")
 			}
 			return nil, errors.Wrap(err, "Twelve Labs async task create request timed out")
 		}
@@ -176,7 +178,7 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 		return nil, errors.New("Twelve Labs async task create returned empty _id")
 	}
 	// Rare early-ready path (server finished before response round-trip returned).
-	if created.Status == "ready" && len(created.Data) > 0 {
+	if created.Status == taskStatusReady && len(created.Data) > 0 {
 		return buildEmbeddingFromData(created.Data)
 	}
 	final, err := e.pollTask(ctx, created.ID, e.apiClient.asyncMaxWait)

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -2,12 +2,20 @@ package twelvelabs
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/amikos-tech/chroma-go/pkg/embeddings"
 )
+
+// ErrAsyncMaxWaitExceeded is returned when the total async budget
+// (task create + polling) is exhausted. Detect programmatically with
+// errors.Is. This is intentionally NOT chained to context.DeadlineExceeded
+// so callers can distinguish SDK-enforced maxWait timeouts from parent
+// context deadlines (D-20).
+var ErrAsyncMaxWaitExceeded = errors.New("Twelve Labs async maxWait exceeded")
 
 // contentToAsyncRequest builds the tasks-endpoint body for audio/video content.
 // See RESEARCH F-02 — the async endpoint uses embedding_option as []string
@@ -76,7 +84,7 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 			// error (D-20). errors.Is works through pkg/errors wrapping.
 			if errors.Is(err, context.DeadlineExceeded) {
 				if !time.Now().Before(sdkMaxWaitDeadline) {
-					return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded: %v", taskID, maxWait, err)
+					return nil, fmt.Errorf("task [%s] async polling maxWait %s: %w", taskID, maxWait, ErrAsyncMaxWaitExceeded)
 				}
 				if parentDeadlineSelected || ctx.Err() != nil {
 					// Parent ctx deadline fired first.
@@ -105,7 +113,7 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 
 		remaining := time.Until(sdkMaxWaitDeadline)
 		if remaining <= 0 {
-			return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
+			return nil, fmt.Errorf("task [%s] async polling maxWait %s: %w", taskID, maxWait, ErrAsyncMaxWaitExceeded)
 		}
 		wait := interval
 		if wait > remaining {
@@ -162,7 +170,7 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 		// than raw context.DeadlineExceeded (D-20).
 		if errors.Is(err, context.DeadlineExceeded) {
 			if !time.Now().Before(sdkMaxWaitDeadline) {
-				return nil, errors.Errorf("Twelve Labs async task create maxWait %s exceeded: %v", e.apiClient.asyncMaxWait, err)
+				return nil, fmt.Errorf("async task create maxWait %s: %w", e.apiClient.asyncMaxWait, ErrAsyncMaxWaitExceeded)
 			}
 			if parentDeadlineSelected || ctx.Err() != nil {
 				return nil, errors.Wrapf(err, "Twelve Labs async task create deadline exceeded")
@@ -195,7 +203,7 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	// grant polling a fresh full budget, yielding up to 2× maxWait total.
 	remaining := time.Until(sdkMaxWaitDeadline)
 	if remaining <= 0 {
-		return nil, errors.Errorf("Twelve Labs async maxWait %s exceeded after task create", e.apiClient.asyncMaxWait)
+		return nil, fmt.Errorf("async maxWait %s after task create: %w", e.apiClient.asyncMaxWait, ErrAsyncMaxWaitExceeded)
 	}
 	final, err := e.pollTask(ctx, created.ID, remaining)
 	if err != nil {

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -177,8 +177,16 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	if created.ID == "" {
 		return nil, errors.New("Twelve Labs async task create returned empty _id")
 	}
-	// Rare early-ready path (server finished before response round-trip returned).
-	if created.Status == taskStatusReady && len(created.Data) > 0 {
+	// Terminal states short-circuit the poll loop. A status=failed on the
+	// create response is rare (usually surfaces as a non-2xx, handled by
+	// doTaskPost) but the async contract allows it — error immediately rather
+	// than waste a GET round-trip. Likewise status=ready is always terminal;
+	// if data is absent that's a server-side malformation and
+	// buildEmbeddingFromData will surface it.
+	switch created.Status {
+	case taskStatusFailed:
+		return nil, errors.Errorf("Twelve Labs async task [%s] terminal status=failed at creation", created.ID)
+	case taskStatusReady:
 		return buildEmbeddingFromData(created.Data)
 	}
 	// Pass the *remaining* maxWait budget to pollTask so total operation time

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -193,7 +193,7 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 	// buildEmbeddingFromData will surface it.
 	switch created.Status {
 	case taskStatusFailed:
-		return nil, errors.Errorf("Twelve Labs async task [%s] terminal status=failed at creation", created.ID)
+		return nil, errors.Errorf("Twelve Labs async task [%s] terminal status=failed at creation: %s", created.ID, sanitizeTaskFailureDetail(created.FailureDetail))
 	case taskStatusReady:
 		return buildEmbeddingFromData(created.Data)
 	}

--- a/pkg/embeddings/twelvelabs/twelvelabs_async.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_async.go
@@ -75,11 +75,14 @@ func (e *TwelveLabsEmbeddingFunction) pollTask(ctx context.Context, taskID strin
 			// figure out which source was responsible and return the distinct
 			// error (D-20). errors.Is works through pkg/errors wrapping.
 			if errors.Is(err, context.DeadlineExceeded) {
-				if time.Now().After(sdkMaxWaitDeadline) {
+				if !time.Now().Before(sdkMaxWaitDeadline) {
 					return nil, errors.Errorf("Twelve Labs task [%s] async polling maxWait %s exceeded", taskID, maxWait)
 				}
-				// Parent ctx deadline fired first.
-				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling deadline exceeded")
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					// Parent ctx deadline fired first.
+					return nil, errors.Wrap(ctxErr, "Twelve Labs async polling deadline exceeded")
+				}
+				return nil, errors.Wrap(err, "Twelve Labs async polling request timed out")
 			}
 			if errors.Is(err, context.Canceled) {
 				return nil, errors.Wrap(ctx.Err(), "Twelve Labs async polling canceled")
@@ -156,10 +159,13 @@ func (e *TwelveLabsEmbeddingFunction) createTaskAndPoll(ctx context.Context, con
 		// timeout on the create call surfaces as the distinct SDK error rather
 		// than raw context.DeadlineExceeded (D-20).
 		if errors.Is(err, context.DeadlineExceeded) {
-			if time.Now().After(sdkMaxWaitDeadline) {
+			if !time.Now().Before(sdkMaxWaitDeadline) {
 				return nil, errors.Errorf("Twelve Labs async task create maxWait %s exceeded", e.apiClient.asyncMaxWait)
 			}
-			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async task create deadline exceeded")
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, errors.Wrap(ctxErr, "Twelve Labs async task create deadline exceeded")
+			}
+			return nil, errors.Wrap(err, "Twelve Labs async task create request timed out")
 		}
 		if errors.Is(err, context.Canceled) {
 			return nil, errors.Wrap(ctx.Err(), "Twelve Labs async task create canceled")

--- a/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
@@ -197,6 +197,26 @@ func TestResolveBytes(t *testing.T) {
 	})
 }
 
+func TestBuildMediaSourceURLValidation(t *testing.T) {
+	t.Run("rejects empty URL", func(t *testing.T) {
+		_, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-empty URL")
+	})
+
+	t.Run("rejects malformed URL", func(t *testing.T) {
+		_, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "example.com/audio.mp3"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute URL")
+	})
+
+	t.Run("accepts absolute URL", func(t *testing.T) {
+		got, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/audio.mp3"})
+		require.NoError(t, err)
+		assert.Equal(t, MediaSource{URL: "https://example.com/audio.mp3"}, got)
+	})
+}
+
 func TestTwelveLabsEmbedContentValidationIncludesProviderContext(t *testing.T) {
 	ef := newTestEF("http://localhost")
 	_, err := ef.EmbedContent(context.Background(), embeddings.NewTextContent(""))

--- a/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
@@ -215,6 +215,31 @@ func TestBuildMediaSourceURLValidation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, MediaSource{URL: "https://example.com/audio.mp3"}, got)
 	})
+
+	t.Run("accepts plain http URL", func(t *testing.T) {
+		got, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "http://example.com/audio.mp3"})
+		require.NoError(t, err)
+		assert.Equal(t, MediaSource{URL: "http://example.com/audio.mp3"}, got)
+	})
+
+	t.Run("rejects non-http(s) schemes", func(t *testing.T) {
+		for _, url := range []string{
+			"ftp://example.com/clip.mp3",
+			"gopher://example.com/clip.mp3",
+			"file://localhost/etc/passwd",
+		} {
+			_, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url})
+			require.Error(t, err, "scheme in %q must be rejected", url)
+			assert.Contains(t, err.Error(), "not supported", "url=%s", url)
+		}
+	})
+
+	t.Run("rejects opaque URLs with unsupported schemes", func(t *testing.T) {
+		// javascript: and data: URLs parse with empty host; the earlier
+		// absolute-URL check handles them, but this pins the behavior.
+		_, err := buildMediaSource(&embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "javascript:alert(1)"})
+		require.Error(t, err)
+	})
 }
 
 func TestTwelveLabsEmbedContentValidationIncludesProviderContext(t *testing.T) {

--- a/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_content_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -268,4 +269,26 @@ func TestTwelveLabsEmbedContentEmptyEmbeddingVector(t *testing.T) {
 	_, err := ef.EmbedContent(context.Background(), embeddings.NewTextContent("hello"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty embedding vector")
+}
+
+// TestResolveBytesBase64AtSizeBoundary proves the cheap pre-check admits a
+// payload decoding to exactly maxMediaSourceSize. The former len*3/4 estimate
+// folded "=" padding into the payload and overshot by 2 bytes, rejecting the
+// one size the authoritative post-decode check is required to accept.
+func TestResolveBytesBase64AtSizeBoundary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocates ~240MB to hit the 100MB boundary exactly")
+	}
+	// 104857600 = 3*34952533 + 1, so the final group carries one byte and
+	// encodes as two chars plus "==".
+	atLimit := embeddings.NewBinarySourceFromBase64(strings.Repeat("A", 139810132) + "AA==")
+	data, err := resolveBytes(&atLimit)
+	require.NoError(t, err, "a payload decoding to exactly the limit must be accepted")
+	assert.Equal(t, maxMediaSourceSize, int64(len(data)))
+
+	// One group beyond the limit must still be rejected.
+	overLimit := embeddings.NewBinarySourceFromBase64(atLimit.Base64 + strings.Repeat("A", 4))
+	_, err = resolveBytes(&overLimit)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum")
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,6 +26,21 @@ const (
 	testTwelveLabsErrorBodyLimit  = 512
 	testTwelveLabsTruncatedSuffix = "[truncated]"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
 
 func newTestEF(serverURL string) *TwelveLabsEmbeddingFunction {
 	return &TwelveLabsEmbeddingFunction{
@@ -195,6 +211,29 @@ func TestNewTwelveLabsClientValidation(t *testing.T) {
 		_, err := NewTwelveLabsClient(WithAPIKey("test-key"), WithAudioEmbeddingOption("invalid"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid audio embedding option")
+	})
+}
+
+func TestValidateAsyncPollingBackoffConfig(t *testing.T) {
+	t.Run("rejects multiplier below one", func(t *testing.T) {
+		client, err := NewTwelveLabsClient(WithAPIKey("test-key"))
+		require.NoError(t, err)
+		client.asyncPollMultiplier = 0.5
+
+		err = validate(client)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "async poll multiplier")
+	})
+
+	t.Run("rejects cap below initial", func(t *testing.T) {
+		client, err := NewTwelveLabsClient(WithAPIKey("test-key"))
+		require.NoError(t, err)
+		client.asyncPollInitial = 3 * time.Second
+		client.asyncPollCap = 2 * time.Second
+
+		err = validate(client)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "async poll cap")
 	})
 }
 
@@ -524,6 +563,54 @@ func TestTwelveLabsAsyncMaxWait(t *testing.T) {
 	assert.False(t, stderrors.Is(err, context.Canceled))
 }
 
+func TestTwelveLabsAsyncPollParentDeadlinePreservesTransportError(t *testing.T) {
+	ef := newTestAsyncEF("https://example.test/embed-v2")
+	ef.apiClient.Client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodPost {
+			return newJSONResponse(http.StatusOK, taskCreateJSON("task_parent_deadline", "processing")), nil
+		}
+		<-req.Context().Done()
+		return nil, fmt.Errorf("simulated retrieve transport failure: %w", req.Context().Err())
+	})}
+	ef.apiClient.asyncMaxWait = time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := ef.EmbedContent(ctx, audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "async polling deadline exceeded")
+	assert.Contains(t, err.Error(), "failed to send task retrieve request")
+	assert.True(t, stderrors.Is(err, context.DeadlineExceeded))
+}
+
+func TestTwelveLabsAsyncPollParentDeadlineDuringSleep(t *testing.T) {
+	var gets atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_sleep_deadline", "processing"))
+			return
+		}
+		gets.Add(1)
+		fmt.Fprint(w, taskGetJSON("task_sleep_deadline", "processing", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.asyncPollInitial = 200 * time.Millisecond
+	ef.apiClient.asyncPollCap = 200 * time.Millisecond
+	ef.apiClient.asyncMaxWait = time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := ef.EmbedContent(ctx, audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "async polling deadline exceeded")
+	assert.True(t, stderrors.Is(err, context.DeadlineExceeded))
+	assert.Equal(t, int32(1), gets.Load(), "deadline during sleep should happen after the first processing poll")
+}
+
 func TestTwelveLabsAsyncSkipsTextImage(t *testing.T) {
 	vec := make512DimVector()
 	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -610,6 +697,30 @@ func TestTwelveLabsAsyncFailedReasonSanitized(t *testing.T) {
 	assert.Less(t, len(err.Error()), 4096, "sanitized error body must be truncated to a safe display length")
 }
 
+func TestTwelveLabsAsyncFailedReasonPrefersStructuredMessageOverLargeBody(t *testing.T) {
+	var dataBuilder strings.Builder
+	for i := 0; i < 400; i++ {
+		if i > 0 {
+			dataBuilder.WriteByte(',')
+		}
+		dataBuilder.WriteString(fmt.Sprintf("%d", i))
+	}
+
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_failmsg", "processing"))
+			return
+		}
+		fmt.Fprintf(w, `{"_id":"task_failmsg","status":"failed","data":[{"embedding":[%s]}],"message":"upstream media fetch failed"}`, dataBuilder.String())
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upstream media fetch failed")
+}
+
 // TestTwelveLabsAsyncBlockedHTTPMaxWait proves the per-HTTP-call deadline
 // added in Plan 02 actually unblocks an in-flight GET /tasks/{id} when
 // maxWait fires. Without the per-call deadline, a blocked HTTP call would
@@ -667,6 +778,27 @@ func TestTwelveLabsAsyncTaskCreateClientTimeoutReturnsError(t *testing.T) {
 	assert.True(t, stderrors.Is(err, context.DeadlineExceeded), "client timeout should preserve the underlying deadline error")
 }
 
+func TestTwelveLabsAsyncTaskCreateParentDeadlinePreservesTransportError(t *testing.T) {
+	ef := newTestAsyncEF("https://example.test/embed-v2")
+	ef.apiClient.Client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.Path)
+		}
+		<-req.Context().Done()
+		return nil, fmt.Errorf("simulated create transport failure: %w", req.Context().Err())
+	})}
+	ef.apiClient.asyncMaxWait = time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := ef.EmbedContent(ctx, audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "async task create deadline exceeded")
+	assert.Contains(t, err.Error(), "failed to send task request")
+	assert.True(t, stderrors.Is(err, context.DeadlineExceeded))
+}
+
 func TestTwelveLabsAsyncPollClientTimeoutReturnsErrorWithoutPanic(t *testing.T) {
 	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -711,6 +843,7 @@ func TestTwelveLabsAsyncTaskCreateError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "task create error")
 	assert.Contains(t, err.Error(), "invalid media source")
+	assert.Contains(t, err.Error(), "E_BAD_SRC")
 }
 
 func TestTwelveLabsAsyncTaskCreateErrorSanitizesStructuredMessage(t *testing.T) {
@@ -743,6 +876,55 @@ func TestTwelveLabsAsyncTaskCreateErrorRawFallback(t *testing.T) {
 	assert.NotContains(t, err.Error(), longBody)
 }
 
+func TestTwelveLabsAsyncTaskRetrieveErrorIncludesStructuredCode(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_retrieve_err", "processing"))
+			return
+		}
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, `{"message":"task fetch failed","code":"E_TASK_FETCH"}`)
+	})
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task retrieve error")
+	assert.Contains(t, err.Error(), "task fetch failed")
+	assert.Contains(t, err.Error(), "E_TASK_FETCH")
+}
+
+func TestTwelveLabsAsyncTaskCreateEmptyIDRejected(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"processing"}`)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty _id")
+}
+
+func TestTwelveLabsAsyncTaskCreateReadyReturnsWithoutPolling(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("ready-on-create must not poll; got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"_id":"task_ready_create","status":"ready","data":[{"embedding":[1,2,3]}]}`)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.NoError(t, err)
+	require.NotNil(t, emb)
+	assert.Equal(t, 3, emb.Len())
+}
+
 // TestTwelveLabsAsyncFusedRejected proves the async path rejects
 // WithAudioEmbeddingOption("fused") deterministically (RESEARCH F-02 / A5
 // review fix). The rejection must happen before any POST /tasks call.
@@ -762,4 +944,28 @@ func TestTwelveLabsAsyncFusedRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fused")
 	assert.Contains(t, err.Error(), "async")
+}
+
+func TestTwelveLabsAsyncRejectsUnknownAudioOption(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no HTTP call expected for unsupported async audio option; got %s %s", r.Method, r.URL.Path)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.AudioEmbeddingOption = "sync-only-future-opt"
+
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audio embedding option")
+	assert.Contains(t, err.Error(), "async")
+}
+
+func TestNextBackoff(t *testing.T) {
+	t.Run("multiplies until cap", func(t *testing.T) {
+		assert.Equal(t, 1500*time.Millisecond, nextBackoff(time.Second, 1.5, 10*time.Second))
+	})
+
+	t.Run("clamps at cap", func(t *testing.T) {
+		assert.Equal(t, 2*time.Second, nextBackoff(1500*time.Millisecond, 2, 2*time.Second))
+	})
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -754,6 +754,30 @@ func TestTwelveLabsAsyncConfigRoundTrip(t *testing.T) {
 	assert.Equal(t, 7*time.Minute, rebuiltFromJSON.apiClient.asyncMaxWait)
 }
 
+// TestTwelveLabsAsyncRejectsFusedAudioAtConstruction proves the fused+async
+// combination fails at NewTwelveLabsEmbeddingFunction rather than deferring
+// the error to the first EmbedContent call (RESEARCH F-02 — async endpoint
+// only accepts "audio" and "transcription").
+func TestTwelveLabsAsyncRejectsFusedAudioAtConstruction(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "fused-key")
+	_, err := NewTwelveLabsEmbeddingFunction(
+		WithEnvAPIKey(),
+		WithAudioEmbeddingOption("fused"),
+		WithAsyncPolling(5*time.Minute),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fused")
+	assert.Contains(t, err.Error(), "async")
+
+	// "fused" alone (no async) must still work.
+	_, err = NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAudioEmbeddingOption("fused"))
+	require.NoError(t, err)
+
+	// "audio" + async must still work.
+	_, err = NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAudioEmbeddingOption("audio"), WithAsyncPolling(5*time.Minute))
+	require.NoError(t, err)
+}
+
 // TestTwelveLabsAsyncPollingRejectsSubFloorMaxWait asserts that sub-second
 // values that can't complete a single poll cycle are rejected at option
 // application time rather than deterministically timing out on first poll.
@@ -792,6 +816,27 @@ func TestTwelveLabsAsyncFailedReasonFallbackOnEmptyBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "terminal status=failed")
 	assert.Contains(t, err.Error(), "(no failure detail provided)")
 	assert.NotContains(t, err.Error(), "_id", "housekeeping fields must not leak into the error message")
+}
+
+// TestTwelveLabsAsyncTaskCreateStatusFailedSurfacesReason proves the rare
+// create-time terminal-failure path preserves the server's failure reason
+// instead of returning only the task ID — mirrors the GET /tasks polling
+// behavior (D-17 symmetry).
+func TestTwelveLabsAsyncTaskCreateStatusFailedSurfacesReason(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected %s %s: create-status=failed must short-circuit before polling", r.Method, r.URL.Path)
+		}
+		fmt.Fprint(w, `{"_id":"task_failatcreate","status":"failed","message":"unsupported media format"}`)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task_failatcreate")
+	assert.Contains(t, err.Error(), "terminal status=failed at creation")
+	assert.Contains(t, err.Error(), "unsupported media format", "server failure reason must reach the caller")
 }
 
 func TestTwelveLabsAsyncConfigOmitWhenDisabled(t *testing.T) {

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -645,6 +645,54 @@ func TestTwelveLabsAsyncBlockedHTTPMaxWait(t *testing.T) {
 	assert.Less(t, elapsed, 2*time.Second, "maxWait must interrupt the blocked HTTP call; took %s", elapsed)
 }
 
+// TestTwelveLabsAsyncTaskCreateError proves the doTaskPost non-2xx error
+// path mirrors the structured-error-then-raw-fallback logic in doPost
+// (twelvelabs.go). Without this test, a regression that breaks the create
+// error branch (forgotten sanitize, wrong wrap) would go undetected until
+// a real Twelve Labs 4xx arrived in production.
+func TestTwelveLabsAsyncTaskCreateError(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"message":"invalid media source","code":"E_BAD_SRC"}`)
+	})
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task create error")
+	assert.Contains(t, err.Error(), "invalid media source")
+}
+
+func TestTwelveLabsAsyncTaskCreateErrorSanitizesStructuredMessage(t *testing.T) {
+	longMessage := strings.Repeat("create-err-", 80)
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, `{"message":%q,"code":"bad_request"}`, longMessage)
+	})
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task create error")
+	assert.Contains(t, err.Error(), testTwelveLabsTruncatedSuffix)
+	assert.NotContains(t, err.Error(), longMessage)
+}
+
+func TestTwelveLabsAsyncTaskCreateErrorRawFallback(t *testing.T) {
+	longBody := strings.Repeat("raw-create-", 80)
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, longBody)
+	})
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status")
+	assert.Contains(t, err.Error(), testTwelveLabsTruncatedSuffix)
+	assert.NotContains(t, err.Error(), longBody)
+}
+
 // TestTwelveLabsAsyncFusedRejected proves the async path rejects
 // WithAudioEmbeddingOption("fused") deterministically (RESEARCH F-02 / A5
 // review fix). The rejection must happen before any POST /tasks call.

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -563,6 +563,43 @@ func TestTwelveLabsAsyncMaxWait(t *testing.T) {
 	assert.False(t, stderrors.Is(err, context.Canceled))
 }
 
+// TestTwelveLabsAsyncMaxWaitHardBound asserts the documented D-09 guarantee:
+// total operation time (create + poll) stays within a single asyncMaxWait
+// window, not create_time + asyncMaxWait. A slow task-create POST must eat
+// into the polling budget, not reset it.
+func TestTwelveLabsAsyncMaxWaitHardBound(t *testing.T) {
+	const maxWait = 200 * time.Millisecond
+	const createDelay = 120 * time.Millisecond // spends >half the budget
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			time.Sleep(createDelay)
+			fmt.Fprint(w, taskCreateJSON("task_hard_bound", "processing"))
+			return
+		}
+		fmt.Fprint(w, taskGetJSON("task_hard_bound", "processing", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.asyncMaxWait = maxWait
+
+	start := time.Now()
+	_, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// Either the create call or the poll loop may trip the bound depending on
+	// scheduling; both surface the distinct maxWait SDK error, not raw ctx errs.
+	assert.Contains(t, err.Error(), "maxWait")
+	assert.False(t, stderrors.Is(err, context.DeadlineExceeded))
+	assert.False(t, stderrors.Is(err, context.Canceled))
+	// Total elapsed must stay within ~maxWait. Allow 50% slack for CI jitter
+	// (backoff sleeps, goroutine scheduling). Without the fix this would be
+	// ~createDelay + maxWait ≈ 320ms, which is well over the threshold.
+	assert.Less(t, elapsed, maxWait+maxWait/2,
+		"total elapsed %s must stay within ~asyncMaxWait %s (D-09 hard bound)", elapsed, maxWait)
+}
+
 func TestTwelveLabsAsyncPollParentDeadlinePreservesTransportError(t *testing.T) {
 	ef := newTestAsyncEF("https://example.test/embed-v2")
 	ef.apiClient.Client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -645,6 +645,56 @@ func TestTwelveLabsAsyncBlockedHTTPMaxWait(t *testing.T) {
 	assert.Less(t, elapsed, 2*time.Second, "maxWait must interrupt the blocked HTTP call; took %s", elapsed)
 }
 
+func TestTwelveLabsAsyncTaskCreateClientTimeoutReturnsError(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.Client = &http.Client{Timeout: 50 * time.Millisecond}
+	ef.apiClient.asyncMaxWait = time.Second
+
+	emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Nil(t, emb)
+	assert.Contains(t, err.Error(), "async task create request timed out")
+	assert.True(t, stderrors.Is(err, context.DeadlineExceeded), "client timeout should preserve the underlying deadline error")
+}
+
+func TestTwelveLabsAsyncPollClientTimeoutReturnsErrorWithoutPanic(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_client_timeout", "processing"))
+			return
+		}
+		select {
+		case <-r.Context().Done():
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.Client = &http.Client{Timeout: 50 * time.Millisecond}
+	ef.apiClient.asyncMaxWait = time.Second
+
+	var emb embeddings.Embedding
+	var err error
+	assert.NotPanics(t, func() {
+		emb, err = ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	})
+	require.Error(t, err)
+	assert.Nil(t, emb)
+	assert.Contains(t, err.Error(), "async polling request timed out")
+	assert.True(t, stderrors.Is(err, context.DeadlineExceeded), "client timeout should preserve the underlying deadline error")
+}
+
 // TestTwelveLabsAsyncTaskCreateError proves the doTaskPost non-2xx error
 // path mirrors the structured-error-then-raw-fallback logic in doPost
 // (twelvelabs.go). Without this test, a regression that breaks the create

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -5,11 +5,14 @@ package twelvelabs
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
@@ -330,4 +333,143 @@ func TestTwelveLabsContextModel(t *testing.T) {
 	ctx := ContextWithModel(context.Background(), "custom-model")
 	_, err := ef.EmbedQuery(ctx, "test")
 	require.NoError(t, err)
+}
+
+// --- Async polling test helpers ---
+
+func newTestAsyncEF(serverURL string) *TwelveLabsEmbeddingFunction {
+	ef := newTestEF(serverURL)
+	ef.apiClient.asyncPollingEnabled = true
+	ef.apiClient.asyncMaxWait = 5 * time.Second
+	ef.apiClient.asyncPollInitial = 1 * time.Millisecond
+	ef.apiClient.asyncPollMultiplier = 1.5
+	ef.apiClient.asyncPollCap = 10 * time.Millisecond
+	return ef
+}
+
+func audioContent(url string) embeddings.Content {
+	return embeddings.Content{Parts: []embeddings.Part{{
+		Modality: embeddings.ModalityAudio,
+		Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
+	}}}
+}
+
+func videoContent(url string) embeddings.Content {
+	return embeddings.Content{Parts: []embeddings.Part{{
+		Modality: embeddings.ModalityVideo,
+		Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: url},
+	}}}
+}
+
+// taskCreateJSON and taskGetJSON produce fixtures with the _id alias (Pitfall 1).
+func taskCreateJSON(id, status string) string {
+	return fmt.Sprintf(`{"_id":%q,"status":%q}`, id, status)
+}
+
+func taskGetJSON(id, status string, data []float64) string {
+	if data == nil {
+		return fmt.Sprintf(`{"_id":%q,"status":%q}`, id, status)
+	}
+	b, _ := json.Marshal(data)
+	return fmt.Sprintf(`{"_id":%q,"status":%q,"data":[{"embedding":%s}]}`, id, status, b)
+}
+
+// --- Async polling tests ---
+
+func TestTwelveLabsAsyncTaskCreate(t *testing.T) {
+	vec := make512DimVector()
+	var attempts atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tasks"):
+			var req AsyncEmbedV2Request
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			assert.Equal(t, "audio", req.InputType)
+			require.NotNil(t, req.Audio)
+			assert.Equal(t, []string{"audio"}, req.Audio.EmbeddingOption, "async endpoint requires embedding_option as []string (F-02)")
+			fmt.Fprint(w, taskCreateJSON("task_abc", "processing"))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/tasks/task_abc"):
+			fmt.Fprint(w, taskGetJSON("task_abc", "ready", vec))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.NoError(t, err)
+	require.NotNil(t, emb)
+	assert.Equal(t, 512, emb.Len())
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "expected at least 1 POST + 1 GET")
+}
+
+func TestTwelveLabsAsyncPollToReady(t *testing.T) {
+	vec := make512DimVector()
+	var gets atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_ready", "processing"))
+			return
+		}
+		n := gets.Add(1)
+		if n < 3 {
+			fmt.Fprint(w, taskGetJSON("task_ready", "processing", nil))
+			return
+		}
+		fmt.Fprint(w, taskGetJSON("task_ready", "ready", vec))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	emb, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+	require.NoError(t, err)
+	require.NotNil(t, emb)
+	assert.Equal(t, 512, emb.Len())
+	assert.Equal(t, int32(3), gets.Load(), "expected 3 GETs before ready")
+}
+
+func TestTwelveLabsAsyncPollToFailed(t *testing.T) {
+	var gets atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_fail", "processing"))
+			return
+		}
+		n := gets.Add(1)
+		if n < 2 {
+			fmt.Fprint(w, taskGetJSON("task_fail", "processing", nil))
+			return
+		}
+		fmt.Fprint(w, taskGetJSON("task_fail", "failed", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	emb, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Nil(t, emb)
+	assert.Contains(t, err.Error(), "task_fail")
+	assert.Contains(t, err.Error(), "terminal status=failed")
+	assert.False(t, stderrors.Is(err, context.Canceled))
+	assert.False(t, stderrors.Is(err, context.DeadlineExceeded))
+}
+
+func TestTwelveLabsAsyncUnexpectedStatus(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_weird", "processing"))
+			return
+		}
+		fmt.Fprint(w, taskGetJSON("task_weird", "weird", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status")
+	assert.Contains(t, err.Error(), "weird")
+	assert.Contains(t, err.Error(), "task_weird")
 }

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -495,6 +495,51 @@ func TestTwelveLabsAsyncPollToFailed(t *testing.T) {
 	assert.False(t, stderrors.Is(err, context.DeadlineExceeded))
 }
 
+// TestTwelveLabsAsyncCreateReturnsFailed covers the rare case where the server
+// returns status=failed on the POST /tasks response. The SDK must short-circuit
+// rather than fire a wasteful GET on the same terminal state.
+func TestTwelveLabsAsyncCreateReturnsFailed(t *testing.T) {
+	var gets atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_create_failed", "failed"))
+			return
+		}
+		gets.Add(1)
+		fmt.Fprint(w, taskGetJSON("task_create_failed", "failed", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task_create_failed")
+	assert.Contains(t, err.Error(), "terminal status=failed at creation")
+	assert.Equal(t, int32(0), gets.Load(), "failed create response must not trigger a poll GET")
+}
+
+// TestTwelveLabsAsyncCreateReturnsReadyEmptyData covers the malformed server
+// case where status=ready arrives with no data. Since ready is terminal per F-01,
+// we surface the malformation immediately instead of polling for the same state.
+func TestTwelveLabsAsyncCreateReturnsReadyEmptyData(t *testing.T) {
+	var gets atomic.Int32
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_empty_ready", "ready"))
+			return
+		}
+		gets.Add(1)
+		fmt.Fprint(w, taskGetJSON("task_empty_ready", "ready", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no embedding returned")
+	assert.Equal(t, int32(0), gets.Load(), "terminal ready must not trigger a poll GET even when data is empty")
+}
+
 func TestTwelveLabsAsyncUnexpectedStatus(t *testing.T) {
 	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -473,3 +473,195 @@ func TestTwelveLabsAsyncUnexpectedStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "weird")
 	assert.Contains(t, err.Error(), "task_weird")
 }
+
+func TestTwelveLabsAsyncCtxCancel(t *testing.T) {
+	var gets atomic.Int32
+	cancelCh := make(chan struct{})
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_cancel", "processing"))
+			return
+		}
+		n := gets.Add(1)
+		if n == 1 {
+			close(cancelCh) // signal the test to cancel after the first poll response
+		}
+		fmt.Fprint(w, taskGetJSON("task_cancel", "processing", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.asyncPollInitial = 50 * time.Millisecond // slow enough that cancel wins
+	ef.apiClient.asyncPollCap = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-cancelCh
+		cancel()
+	}()
+	_, err := ef.EmbedContent(ctx, audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.True(t, stderrors.Is(err, context.Canceled), "expected ctx.Canceled wrapping, got %v", err)
+}
+
+func TestTwelveLabsAsyncMaxWait(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_maxwait", "processing"))
+			return
+		}
+		fmt.Fprint(w, taskGetJSON("task_maxwait", "processing", nil))
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.asyncMaxWait = 50 * time.Millisecond
+
+	_, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "async polling maxWait")
+	assert.False(t, stderrors.Is(err, context.DeadlineExceeded), "maxWait must surface distinct from ctx.DeadlineExceeded (D-20)")
+	assert.False(t, stderrors.Is(err, context.Canceled))
+}
+
+func TestTwelveLabsAsyncSkipsTextImage(t *testing.T) {
+	vec := make512DimVector()
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/tasks") {
+			t.Fatalf("text/image must not hit async endpoint; got %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, embedV2Response(vec))
+	})
+
+	ef := newTestAsyncEF(srv.URL) // asyncPollingEnabled=true — but text/image skip async per D-07
+
+	// text
+	textContent := embeddings.Content{Parts: []embeddings.Part{{Modality: embeddings.ModalityText, Text: "hello"}}}
+	emb, err := ef.EmbedContent(context.Background(), textContent)
+	require.NoError(t, err)
+	require.NotNil(t, emb)
+
+	// image (URL source)
+	imageContent := embeddings.Content{Parts: []embeddings.Part{{
+		Modality: embeddings.ModalityImage,
+		Source:   &embeddings.BinarySource{Kind: embeddings.SourceKindURL, URL: "https://example.com/i.png"},
+	}}}
+	emb2, err := ef.EmbedContent(context.Background(), imageContent)
+	require.NoError(t, err)
+	require.NotNil(t, emb2)
+}
+
+func TestTwelveLabsAsyncConfigRoundTrip(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "round-trip-key")
+	ef, err := NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAsyncPolling(7*time.Minute))
+	require.NoError(t, err)
+
+	cfg := ef.GetConfig()
+	assert.Equal(t, true, cfg["async_polling"])
+	assert.Equal(t, int64(420000), cfg["async_max_wait_ms"], "7 min = 420000 ms as int64")
+
+	rebuilt, err := NewTwelveLabsEmbeddingFunctionFromConfig(cfg)
+	require.NoError(t, err)
+	assert.True(t, rebuilt.apiClient.asyncPollingEnabled)
+	assert.Equal(t, 7*time.Minute, rebuilt.apiClient.asyncMaxWait)
+	// APIKeyEnvVar must survive the round-trip so env-var-sourced EFs
+	// rebuilt from a registry still resolve the same way.
+	assert.Equal(t, APIKeyEnvVar, rebuilt.apiClient.APIKeyEnvVar)
+}
+
+func TestTwelveLabsAsyncConfigOmitWhenDisabled(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "some-key")
+	ef, err := NewTwelveLabsEmbeddingFunction(WithEnvAPIKey())
+	require.NoError(t, err)
+
+	cfg := ef.GetConfig()
+	_, hasPolling := cfg["async_polling"]
+	_, hasWait := cfg["async_max_wait_ms"]
+	assert.False(t, hasPolling, "async_polling must be omitted when WithAsyncPolling is absent (D-22)")
+	assert.False(t, hasWait, "async_max_wait_ms must be omitted when WithAsyncPolling is absent (D-22)")
+}
+
+// TestTwelveLabsAsyncFailedReasonSanitized proves the authentic server
+// failure reason (from the raw response body, preserved in
+// TaskResponse.FailureDetail by Plan 01) reaches the error — not a
+// re-marshaled subset of known fields (D-17 review fix).
+func TestTwelveLabsAsyncFailedReasonSanitized(t *testing.T) {
+	longReason := strings.Repeat("detailed server-side failure reason — ", 40) // ~1.5KB
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_failreason", "processing"))
+			return
+		}
+		// Respond with an extra server-only reason field NOT in TaskResponse.
+		// If the plan re-marshaled the parsed struct the reason would be lost.
+		fmt.Fprintf(w, `{"_id":"task_failreason","status":"failed","reason":%q,"error":{"code":"E_BAD_MEDIA","detail":%q}}`, longReason, longReason)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task_failreason")
+	assert.Contains(t, err.Error(), "terminal status=failed")
+	// Authentic server reason substring must survive sanitization.
+	assert.Contains(t, err.Error(), "detailed server-side failure reason", "error must carry the server-provided reason from the raw body, not just the parsed TaskResponse fields")
+	// Sanitization must still cap the error size.
+	assert.Less(t, len(err.Error()), 4096, "sanitized error body must be truncated to a safe display length")
+}
+
+// TestTwelveLabsAsyncBlockedHTTPMaxWait proves the per-HTTP-call deadline
+// added in Plan 02 actually unblocks an in-flight GET /tasks/{id} when
+// maxWait fires. Without the per-call deadline, a blocked HTTP call would
+// hang indefinitely regardless of maxWait (Plan 02 review fix).
+func TestTwelveLabsAsyncBlockedHTTPMaxWait(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_block", "processing"))
+			return
+		}
+		// Block until the request's context is canceled by the per-call
+		// deadline. If the plan fails to bound the HTTP call, this select
+		// would block until the server closed and the test would hang until
+		// `go test` timeout — a loud failure.
+		<-r.Context().Done()
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	ef.apiClient.asyncMaxWait = 100 * time.Millisecond
+
+	start := time.Now()
+	_, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The distinct SDK-timeout message must fire, not ctx.DeadlineExceeded —
+	// parent ctx has no deadline, so maxWait is the only bound.
+	assert.Contains(t, err.Error(), "async polling maxWait")
+	assert.False(t, stderrors.Is(err, context.DeadlineExceeded), "SDK maxWait must not collapse into context.DeadlineExceeded (D-20)")
+	// Sanity-check the upper bound so a regression where maxWait is not
+	// enforced on in-flight HTTP work fails loudly.
+	assert.Less(t, elapsed, 2*time.Second, "maxWait must interrupt the blocked HTTP call; took %s", elapsed)
+}
+
+// TestTwelveLabsAsyncFusedRejected proves the async path rejects
+// WithAudioEmbeddingOption("fused") deterministically (RESEARCH F-02 / A5
+// review fix). The rejection must happen before any POST /tasks call.
+func TestTwelveLabsAsyncFusedRejected(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no HTTP call expected for fused+async; got %s %s", r.Method, r.URL.Path)
+	})
+	_ = srv
+
+	ef := newTestAsyncEF(srv.URL)
+	// Apply the fused audio option by setting the field directly (the
+	// public option setter would also work; direct assignment keeps the
+	// test independent of option ordering).
+	ef.apiClient.AudioEmbeddingOption = "fused"
+
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fused")
+	assert.Contains(t, err.Error(), "async")
+}

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -604,6 +604,7 @@ func TestTwelveLabsAsyncMaxWait(t *testing.T) {
 	_, err := ef.EmbedContent(context.Background(), videoContent("https://example.com/v.mp4"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "async polling maxWait")
+	assert.True(t, stderrors.Is(err, ErrAsyncMaxWaitExceeded), "maxWait must wrap ErrAsyncMaxWaitExceeded sentinel")
 	assert.False(t, stderrors.Is(err, context.DeadlineExceeded), "maxWait must surface distinct from ctx.DeadlineExceeded (D-20)")
 	assert.False(t, stderrors.Is(err, context.Canceled))
 }
@@ -737,6 +738,60 @@ func TestTwelveLabsAsyncConfigRoundTrip(t *testing.T) {
 	// APIKeyEnvVar must survive the round-trip so env-var-sourced EFs
 	// rebuilt from a registry still resolve the same way.
 	assert.Equal(t, APIKeyEnvVar, rebuilt.apiClient.APIKeyEnvVar)
+
+	// JSON round-trip: registries persist configs as JSON, which decodes
+	// integers as float64. ConfigInt must coerce back to int64 so the
+	// rebuilt EF honors the original asyncMaxWait.
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	var decoded embeddings.EmbeddingFunctionConfig
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	_, isFloat := decoded["async_max_wait_ms"].(float64)
+	assert.True(t, isFloat, "sanity check: JSON decoding must produce float64, not int64")
+	rebuiltFromJSON, err := NewTwelveLabsEmbeddingFunctionFromConfig(decoded)
+	require.NoError(t, err)
+	assert.True(t, rebuiltFromJSON.apiClient.asyncPollingEnabled)
+	assert.Equal(t, 7*time.Minute, rebuiltFromJSON.apiClient.asyncMaxWait)
+}
+
+// TestTwelveLabsAsyncPollingRejectsSubFloorMaxWait asserts that sub-second
+// values that can't complete a single poll cycle are rejected at option
+// application time rather than deterministically timing out on first poll.
+func TestTwelveLabsAsyncPollingRejectsSubFloorMaxWait(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "floor-key")
+	_, err := NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAsyncPolling(100*time.Millisecond))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "below minimum")
+
+	// 0 means "use default" and must still be accepted.
+	_, err = NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAsyncPolling(0))
+	require.NoError(t, err)
+
+	// Exactly the floor value is accepted.
+	_, err = NewTwelveLabsEmbeddingFunction(WithEnvAPIKey(), WithAsyncPolling(defaultAsyncPollInitial))
+	require.NoError(t, err)
+}
+
+// TestTwelveLabsAsyncFailedReasonFallbackOnEmptyBody proves the failure
+// message uses the generic fallback when the server returns a JSON body with
+// no diagnostic fields (only housekeeping), rather than dumping the raw JSON.
+func TestTwelveLabsAsyncFailedReasonFallbackOnEmptyBody(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_nodetail", "processing"))
+			return
+		}
+		fmt.Fprint(w, `{"_id":"task_nodetail","status":"failed"}`)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task_nodetail")
+	assert.Contains(t, err.Error(), "terminal status=failed")
+	assert.Contains(t, err.Error(), "(no failure detail provided)")
+	assert.NotContains(t, err.Error(), "_id", "housekeeping fields must not leak into the error message")
 }
 
 func TestTwelveLabsAsyncConfigOmitWhenDisabled(t *testing.T) {
@@ -832,6 +887,7 @@ func TestTwelveLabsAsyncBlockedHTTPMaxWait(t *testing.T) {
 	// The distinct SDK-timeout message must fire, not ctx.DeadlineExceeded —
 	// parent ctx has no deadline, so maxWait is the only bound.
 	assert.Contains(t, err.Error(), "async polling maxWait")
+	assert.True(t, stderrors.Is(err, ErrAsyncMaxWaitExceeded), "SDK maxWait must wrap ErrAsyncMaxWaitExceeded sentinel")
 	assert.False(t, stderrors.Is(err, context.DeadlineExceeded), "SDK maxWait must not collapse into context.DeadlineExceeded (D-20)")
 	// Sanity-check the upper bound so a regression where maxWait is not
 	// enforced on in-flight HTTP work fails loudly.

--- a/pkg/embeddings/twelvelabs/twelvelabs_test.go
+++ b/pkg/embeddings/twelvelabs/twelvelabs_test.go
@@ -754,6 +754,49 @@ func TestTwelveLabsAsyncConfigRoundTrip(t *testing.T) {
 	assert.Equal(t, 7*time.Minute, rebuiltFromJSON.apiClient.asyncMaxWait)
 }
 
+// TestTwelveLabsAsyncConfigRejectsBrokenMaxWait proves a config claiming
+// async_polling=true with an unusable async_max_wait_ms fails loudly rather
+// than silently applying the 30-minute default or silently downgrading to the
+// sync path — both are behavior the caller never asked for.
+func TestTwelveLabsAsyncConfigRejectsBrokenMaxWait(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "broken-cfg-key")
+
+	for name, maxWait := range map[string]any{
+		"zero":        0,
+		"negative":    -1,
+		"non-numeric": "5m",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewTwelveLabsEmbeddingFunctionFromConfig(embeddings.EmbeddingFunctionConfig{
+				"api_key_env_var":   APIKeyEnvVar,
+				"async_polling":     true,
+				"async_max_wait_ms": maxWait,
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "async_max_wait_ms")
+		})
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		_, err := NewTwelveLabsEmbeddingFunctionFromConfig(embeddings.EmbeddingFunctionConfig{
+			"api_key_env_var": APIKeyEnvVar,
+			"async_polling":   true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "async_max_wait_ms")
+	})
+
+	// async_polling absent stays a valid sync config — this rejection must not
+	// leak into the far more common non-async round-trip.
+	t.Run("absent async_polling", func(t *testing.T) {
+		ef, err := NewTwelveLabsEmbeddingFunctionFromConfig(embeddings.EmbeddingFunctionConfig{
+			"api_key_env_var": APIKeyEnvVar,
+		})
+		require.NoError(t, err)
+		assert.False(t, ef.apiClient.asyncPollingEnabled)
+	})
+}
+
 // TestTwelveLabsAsyncRejectsFusedAudioAtConstruction proves the fused+async
 // combination fails at NewTwelveLabsEmbeddingFunction rather than deferring
 // the error to the first EmbedContent call (RESEARCH F-02 — async endpoint
@@ -816,6 +859,29 @@ func TestTwelveLabsAsyncFailedReasonFallbackOnEmptyBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "terminal status=failed")
 	assert.Contains(t, err.Error(), "(no failure detail provided)")
 	assert.NotContains(t, err.Error(), "_id", "housekeeping fields must not leak into the error message")
+}
+
+// TestTwelveLabsAsyncFailedReasonUnknownFields proves diagnostics survive when
+// the server names its failure fields something outside the known set. The
+// failure schema is undocumented (26-RESEARCH A3), so an allowlist miss must
+// fall back to the raw body rather than swallow the reason.
+func TestTwelveLabsAsyncFailedReasonUnknownFields(t *testing.T) {
+	srv := newMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, taskCreateJSON("task_unknownfields", "processing"))
+			return
+		}
+		fmt.Fprint(w, `{"_id":"task_unknownfields","status":"failed","error_code":"QUOTA_EXCEEDED","description":"you have exceeded your quota"}`)
+	})
+
+	ef := newTestAsyncEF(srv.URL)
+	_, err := ef.EmbedContent(context.Background(), audioContent("https://example.com/a.mp3"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal status=failed")
+	assert.NotContains(t, err.Error(), "(no failure detail provided)")
+	assert.Contains(t, err.Error(), "QUOTA_EXCEEDED")
+	assert.Contains(t, err.Error(), "you have exceeded your quota")
 }
 
 // TestTwelveLabsAsyncTaskCreateStatusFailedSurfacesReason proves the rare


### PR DESCRIPTION
## Summary

**Phase 26: Twelve Labs Async Embedding**  
**Goal:** Twelve Labs provider handles async task responses for long-running audio and video embeddings  
**Status:** Verified on 2026-04-14 (`26-VERIFICATION.md` status: `passed`)

This phase adds an explicit async path for Twelve Labs long-running media embeddings. Audio and video callers can now opt in with `WithAsyncPolling(maxWait)` to create a task, poll until it reaches a terminal state, and return the final embedding or a sanitized failure. Text/image callers and all non-opt-in traffic remain on the existing synchronous path.

## Changes

### Plan 26-01: Async HTTP foundation
Added dedicated async request/response types for the tasks API, decoded the `_id` alias correctly, preserved raw task failure bodies for later sanitization, and introduced internal polling configuration fields/defaults plus task POST/GET helpers.

**Key files:**
- `pkg/embeddings/twelvelabs/twelvelabs.go`

### Plan 26-02: Polling loop and modality routing
Implemented the async polling loop with capped backoff, distinct cancellation/deadline/maxWait behavior, failure-body sanitization, fused-audio rejection on the async path, and audio/video routing into the tasks flow while leaving text/image unchanged.

**Key files:**
- `pkg/embeddings/twelvelabs/twelvelabs_async.go`
- `pkg/embeddings/twelvelabs/content.go`

### Plan 26-03: Public option and config round-trip
Added the public `WithAsyncPolling(maxWait)` option and made async config persist/rebuild through `async_polling` and `async_max_wait_ms` without changing default behavior for callers who do not opt in.

**Key files:**
- `pkg/embeddings/twelvelabs/option.go`
- `pkg/embeddings/twelvelabs/twelvelabs.go`

### Plan 26-04: Async test coverage
Added 12 async-focused tests covering task creation, ready/failed/unexpected task states, context cancellation, SDK maxWait behavior, sync-path preservation for text/image, config round-trip, raw failure sanitization, blocked HTTP maxWait enforcement, and fused-mode rejection.

**Key files:**
- `pkg/embeddings/twelvelabs/twelvelabs_test.go`

## Requirements Addressed

- `TLA-01`: Twelve Labs provider detects async task responses and enters a polling loop
- `TLA-02`: Async polling respects caller context for cancellation and timeout
- `TLA-03`: Async polling handles terminal states with appropriate result delivery or error messages
- `TLA-04`: Tests cover async task creation, polling, completion, failure, and context cancellation

## Verification

- [x] Automated verification passed (`26-VERIFICATION.md`, 4/4 must-haves verified on 2026-04-14)
- [x] `go test -tags=ef -count=1 ./pkg/embeddings/twelvelabs/...`
- [x] `make lint`
- [x] Human verification not required for this library change

## Key Decisions

- Async stays opt-in through `WithAsyncPolling(maxWait)`; polling internals remain hidden.
- Audio/video route through the tasks API; text/image always stay on sync `/embed-v2`.
- Async audio request payloads use `embedding_option` as `[]string`, and task responses decode Twelve Labs’ `_id` field.
- Failed-task errors sanitize the authentic raw response body instead of a re-marshaled subset.
- `fused` audio is rejected on the async path instead of being silently remapped.

