### PR TITLE
fix(ci): pass GITHUB_TOKEN to cloud test jobs for ONNX bootstrap

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -263,6 +263,10 @@ jobs:
           CHROMA_API_KEY: ${{ secrets.CHROMA_API_KEY }}
           CHROMA_TENANT: ${{ secrets.CHROMA_TENANT }}
           CHROMA_DATABASE: ${{ secrets.CHROMA_DATABASE }}
+          # Authenticates the ONNX Runtime checksum lookup during default-EF bootstrap;
+          # without it the runner IP shares an unauthenticated rate limit and 403s.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: "true"
       - name: Upload Test Results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -290,6 +294,9 @@ jobs:
           CHROMA_API_KEY: ${{ secrets.CHROMA_API_KEY }}
           CHROMA_TENANT: ${{ secrets.CHROMA_TENANT }}
           CHROMA_DATABASE: ${{ secrets.CHROMA_DATABASE }}
+          # Listing collections attempts EF auto-wiring, which hits the same lookup.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ef:
     name: Test EF (${{ matrix.provider }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `cloud` and `cloud-cleanup` jobs were the only test jobs in `go.yml` not passing a GitHub token. The default embedding function resolves its ONNX Runtime checksum from `api.github.com` during bootstrap, so without a token those jobs used the runner IP's shared unauthenticated rate limit.

When that limit is exhausted the lookup returns HTTP 403, three retries burn, and the failure surfaces as `error creating default embedding function` at collection creation — a long way from the real cause.

## Evidence

Observed on [#519](https://github.com/amikos-tech/chroma-go/pull/519), where `Test Chroma Cloud (CRUD)` failed while the same job had passed on the immediately preceding commit and the change under test touched only `pkg/api/v2` nil handling:

```
failed to resolve ONNX Runtime checksum for "onnxruntime-linux-x64-1.23.1.tgz"
  from "https://api.github.com/repos/microsoft/onnxruntime/releases/tags/v1.23.1":
  attempt 1/3: HTTP 403: {"message":"API rate limit exceeded for 68.220.58.144.
  (But here's the good news: Authenticated requests get a higher rate limit...)"}
  attempt 2/3: ... 403 ...
  attempt 3/3: ... 403 ...
```

A plain re-run of the job passed, confirming it was environmental rather than a code regression.

## Change

Adds `GITHUB_TOKEN` and `GH_TOKEN` to the two affected steps. This is an inconsistency fix, not a new capability — `api`, `ef`, `crosslang` and `smoke-cross-platform` already pass both, and `CLAUDE.md` documents them as the supported escape hatch:

> `GITHUB_TOKEN` / `GH_TOKEN` - Optional token to avoid GitHub API rate limits during ONNX bootstrap checksum resolution

`cloud-cleanup` is included because listing collections attempts EF auto-wiring and hits the same lookup — visible as `failed to auto-wire embedding function for collection` warnings in the same failed run. Those warnings are non-fatal today, but they burn the same quota.

## Verification

- `yq` parses the workflow and both `env:` blocks resolve as expected.
- No behavior change when the rate limit is not being hit; the token only authenticates an existing request.

**Note:** this PR's own CI does *not* verify the change — `paths-filter` does not treat a workflow-only edit as a `base` change, so the cloud jobs are skipped here. They were instead exercised via `workflow_dispatch` with `run_cloud=true` against this branch: [run 30535734729](https://github.com/amikos-tech/chroma-go/actions/runs/30535734729). All five cloud matrix jobs and `cloud-cleanup` passed, the checkout confirms branch commit `ba673f1`, and the logs contain zero `HTTP 403` / `rate limit exceeded` occurrences and zero `failed to auto-wire embedding function` warnings — the failing run on #519 had both.

One honest caveat: a clean run cannot by itself distinguish "the token authenticated the request" from "the shared limit happened not to be exhausted". The absence of the auto-wire warnings that accompanied the failure is the stronger signal.

## Scope

`rf` (Test RF) also lacks the token, but reranking providers do not build the ONNX default EF, so it is not affected by this failure mode and is left alone.
