### PR TITLE
fix(rank): reject typed-nil Rank values instead of panicking

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Quick task 260731-ewm completed — typed-nil rank safety"
+status: "Quick task 260731-fvo completed — typed-nil rank builder safety"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-07-31T08:08:02.000Z"
+last_updated: "2026-07-31T08:41:08.000Z"
 last_activity: 2026-07-31
 progress:
   total_phases: 11
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Quick task 260731-ewm completed — typed-nil rank safety
-Last activity: 2026-07-31 - Completed quick task 260731-ewm: Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records
+Status: Quick task 260731-fvo completed — typed-nil rank builder safety
+Last activity: 2026-07-31 - Completed quick task 260731-fvo: Fix typed-nil rank builder panics and close related tests and documentation gaps
 
 Progress: [██████████] 100%
 
@@ -79,6 +79,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260730-u7z | let's address issue 515 | 2026-07-30 | b79ede4 | Verified | [260730-u7z-let-s-address-issue-515](./quick/260730-u7z-let-s-address-issue-515/) |
 | 260731-e0k | Address typed-nil rank arithmetic and review findings | 2026-07-31 | b3ef969 | Verified | [260731-e0k-address-typed-nil-rank-arithmetic-and-re](./quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/) |
 | 260731-ewm | Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records | 2026-07-31 | b0f52ed | Verified | [260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil](./quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/) |
+| 260731-fvo | Fix typed-nil rank builder panics and close related tests and documentation gaps | 2026-07-31 | 872069b | Complete | [260731-fvo-fix-typed-nil-rank-builder-panics-and-cl](./quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Quick task 260731-fvo completed — typed-nil rank builder safety"
+status: "Quick task chain (u7z/e0k/ewm/fvo) shipped — PR #527"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-07-31T08:41:08.000Z"
+last_updated: "2026-07-31T11:15:12.712Z"
 last_activity: 2026-07-31
 progress:
   total_phases: 11
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Quick task 260731-fvo completed — typed-nil rank builder safety
-Last activity: 2026-07-31 - Completed quick task 260731-fvo: Fix typed-nil rank builder panics and close related tests and documentation gaps
+Status: Quick task chain (u7z/e0k/ewm/fvo) shipped — PR #527
+Last activity: 2026-07-31
 
 Progress: [██████████] 100%
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Quick task 260730-p46 (GH #522) shipped — PR #524"
+status: "Quick task 260730-u7z completed — GH #515"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-07-30T16:13:19.165Z"
+last_updated: "2026-07-30T18:45:34.504Z"
 last_activity: 2026-07-30
 progress:
   total_phases: 11
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Quick task 260730-p46 (GH #522) shipped — PR #524
-Last activity: 2026-07-30
+Status: Quick task 260730-u7z completed — GH #515
+Last activity: 2026-07-30 - Completed quick task 260730-u7z: let's address issue 515
 
 Progress: [██████████] 100%
 
@@ -76,6 +76,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260730-cjl | Normalize nil-handling across V2 SearchRequestOption helpers (GH #503) | 2026-07-30 | dc00f59 | Verified | [260730-cjl-normalize-nil-handling-across-v2-searchr](./quick/260730-cjl-normalize-nil-handling-across-v2-searchr/) |
 | 260730-fzu | Fix typed-nil WhereClause panic and doc accuracy in V2 search nil-handling | 2026-07-30 | e695de6 | Verified | [260730-fzu-fix-typed-nil-whereclause-panic-and-doc-](./quick/260730-fzu-fix-typed-nil-whereclause-panic-and-doc-/) |
 | 260730-p46 | Remove legacy github.com/docker/docker via Testcontainers v0.43.0 + Go 1.25 floor (GH #522) | 2026-07-30 | 03bc90d | Local ✓ / CI pending | [260730-p46-remove-legacy-docker-module](./quick/260730-p46-remove-legacy-docker-module/) |
+| 260730-u7z | let's address issue 515 | 2026-07-30 | 3f3a06f |  | [260730-u7z-let-s-address-issue-515](./quick/260730-u7z-let-s-address-issue-515/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Quick task 260731-e0k completed — typed-nil rank arithmetic"
+status: "Quick task 260731-ewm completed — typed-nil rank safety"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-07-31T07:23:43.000Z"
+last_updated: "2026-07-31T08:08:02.000Z"
 last_activity: 2026-07-31
 progress:
   total_phases: 11
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Quick task 260731-e0k completed — typed-nil rank arithmetic
-Last activity: 2026-07-31 - Completed quick task 260731-e0k: Address typed-nil rank arithmetic and review findings
+Status: Quick task 260731-ewm completed — typed-nil rank safety
+Last activity: 2026-07-31 - Completed quick task 260731-ewm: Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records
 
 Progress: [██████████] 100%
 
@@ -78,6 +78,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260730-p46 | Remove legacy github.com/docker/docker via Testcontainers v0.43.0 + Go 1.25 floor (GH #522) | 2026-07-30 | 03bc90d | Local ✓ / CI pending | [260730-p46-remove-legacy-docker-module](./quick/260730-p46-remove-legacy-docker-module/) |
 | 260730-u7z | let's address issue 515 | 2026-07-30 | b79ede4 | Verified | [260730-u7z-let-s-address-issue-515](./quick/260730-u7z-let-s-address-issue-515/) |
 | 260731-e0k | Address typed-nil rank arithmetic and review findings | 2026-07-31 | b3ef969 | Verified | [260731-e0k-address-typed-nil-rank-arithmetic-and-re](./quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/) |
+| 260731-ewm | Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records | 2026-07-31 | b0f52ed | Verified | [260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil](./quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Quick task 260730-u7z completed — GH #515"
+status: "Quick task 260731-e0k completed — typed-nil rank arithmetic"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-07-30T18:45:34.504Z"
-last_activity: 2026-07-30
+last_updated: "2026-07-31T07:23:43.000Z"
+last_activity: 2026-07-31
 progress:
   total_phases: 11
   completed_phases: 7
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Quick task 260730-u7z completed — GH #515
-Last activity: 2026-07-30 - Completed quick task 260730-u7z: let's address issue 515
+Status: Quick task 260731-e0k completed — typed-nil rank arithmetic
+Last activity: 2026-07-31 - Completed quick task 260731-e0k: Address typed-nil rank arithmetic and review findings
 
 Progress: [██████████] 100%
 
@@ -76,7 +76,8 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260730-cjl | Normalize nil-handling across V2 SearchRequestOption helpers (GH #503) | 2026-07-30 | dc00f59 | Verified | [260730-cjl-normalize-nil-handling-across-v2-searchr](./quick/260730-cjl-normalize-nil-handling-across-v2-searchr/) |
 | 260730-fzu | Fix typed-nil WhereClause panic and doc accuracy in V2 search nil-handling | 2026-07-30 | e695de6 | Verified | [260730-fzu-fix-typed-nil-whereclause-panic-and-doc-](./quick/260730-fzu-fix-typed-nil-whereclause-panic-and-doc-/) |
 | 260730-p46 | Remove legacy github.com/docker/docker via Testcontainers v0.43.0 + Go 1.25 floor (GH #522) | 2026-07-30 | 03bc90d | Local ✓ / CI pending | [260730-p46-remove-legacy-docker-module](./quick/260730-p46-remove-legacy-docker-module/) |
-| 260730-u7z | let's address issue 515 | 2026-07-30 | 3f3a06f |  | [260730-u7z-let-s-address-issue-515](./quick/260730-u7z-let-s-address-issue-515/) |
+| 260730-u7z | let's address issue 515 | 2026-07-30 | b79ede4 | Verified | [260730-u7z-let-s-address-issue-515](./quick/260730-u7z-let-s-address-issue-515/) |
+| 260731-e0k | Address typed-nil rank arithmetic and review findings | 2026-07-31 | b3ef969 | Verified | [260731-e0k-address-typed-nil-rank-arithmetic-and-re](./quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
+++ b/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
@@ -23,7 +23,7 @@ must_haves:
   truths:
     - "Add, Multiply, Sub, Div, Max, and Min reject a typed-nil Rank operand during MarshalJSON with an error instead of panicking"
     - "An untyped nil Operand retains the existing fluent-API behavior of converting to Val(0)"
-    - "Collection.Search emits an exact rank-free payload for a typed-nil rank and an exact non-null payload for a typed-nil rank nested in RRF"
+    - "Collection.Search emits an exact rank-free payload for a typed-nil rank and an exact non-null payload for a typed-nil rank nested in RRF (historical contract, superseded by quick task 260731-ewm)"
     - "A SearchQuery batch containing a typed-nil rank request followed by a normal request preserves both requests in order and serializes the normal rank"
     - "A multi-level RrfRank tree is recursively cloned into independent nodes and the clone marshals to JSON equal to the original"
     - "The 260730-u7z STATE.md row names reachable commit b79ede4 and has status Verified"
@@ -65,6 +65,8 @@ Close the supplied review findings around typed-nil rank arithmetic and the earl
 
 Purpose: all public fluent rank operations must turn an invalid typed-nil Rank operand into a predictable marshal error, never a nil-receiver panic; the HTTP and clone tests must prove complete payload and recursive behavior rather than only checking shallow non-null state.
 
+The regression uses a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; the panic occurs later when the composite serializer invokes the operand.
+
 Output: one shared conversion guard, focused regressions for all six binary fluent operations, exact single- and mixed-batch HTTP payload assertions, multi-level RRF clone/marshal coverage, and a corrected quick-task ledger row.
 </objective>
 
@@ -88,7 +90,7 @@ Output: one shared conversion guard, focused regressions for all six binary flue
 - Preserve `operandToRank(nil) -> Val(0)` for an untyped nil; only a typed-nil value satisfying `Rank` becomes a rejected operand.
 - Reuse the existing `isNilRank`/`isNilInterface` behavior; do not add another reflection helper or a dependency.
 - Keep the existing direct typed-nil SearchRequest behavior: its `rank` key is omitted.
-- Keep the existing clone normalization behavior: a typed-nil child in an RRF tree becomes a true nil in the clone and therefore remains marshalable through RRF's documented nil-to-`Val(0)` path.
+- Historical scope decision, superseded by quick task `260731-ewm`: keep the existing clone normalization behavior so a typed-nil child in an RRF tree becomes a true nil and remains marshalable through RRF's nil-to-`Val(0)` path. The later task identifies that substitution as a defect and changes nested typed-nil RRF input to an error.
 - Do not broaden this task into option validation, rank API redesign, changelog work, or unrelated test cleanup.
 - Do not perform the optional PR-branch filtering suggestion. Do not create or switch branches, filter commits, push, open a PR, or merge.
 </context>
@@ -152,6 +154,8 @@ Use that sentinel for typed-nil operands instead of adding a new public error or
     - "Val(1).Min(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
   </behavior>
   <action>
+    The regression uses a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; the panic occurs later when the composite serializer invokes the operand.
+
     First add `TestRankArithmeticTypedNilOperandMarshal` in `pkg/api/v2/rank_test.go` as a table over the six binary fluent operations: Sum through `Add`, Mul through `Multiply`, Sub, Div, Max, and Min. Use one concrete typed-nil Rank (`var operand *KnnRank`) and a per-row builder starting from `Val(1)`. For every row, invoke `MarshalJSON` inside `require.NotPanics`, then require a non-nil error containing `unknown operand type`. Run the focused test once before the production edit and confirm the current implementation fails by panic.
 
     In `pkg/api/v2/rank.go`, keep the leading `operand == nil` branch unchanged so untyped nil remains `Val(0)`. Inside the `case Rank` branch of `operandToRank`, call the existing `isNilRank(v)` helper before returning `v`; return `&UnknownRank{}` when it reports a typed nil. This covers pointer-backed and caller-supplied nillable Rank implementations without duplicating reflection logic. Keep IntOperand, FloatOperand, and unknown non-Rank handling unchanged.
@@ -176,6 +180,8 @@ Use that sentinel for typed-nil operands instead of adding a new public error or
     3. One direct typed-nil request followed by a normal `Val(2)` request: expected payload `{"searches":[{},{"rank":{"$val":2}}]}`. This proves mixed-batch normalization does not drop, merge, or reorder requests and does not disturb the normal request.
 
     Retain the HTTP-boundary `require.NotPanics`, `require.NoError`, and non-nil result assertions for every case.
+
+    This nested-RRF success case records the contract tested by this task at the time; it was later superseded by quick task `260731-ewm`, which treats the `$val:0` substitution as a defect and requires an error instead.
 
     Add a focused subtest under `TestCloneRank` named for multi-level nested RRF cloning. Build at least three RrfRank nodes (outer -> middle -> inner -> concrete KnnRank) using `RankWithWeight` for the RRF children, clone the outer node, and assert every corresponding RrfRank node and the leaf KnnRank are distinct pointers. Marshal both original and clone inside `require.NotPanics`, require no errors, and compare their complete JSON with `require.JSONEq`. Keep this as test-only coverage; the recursive `cloneRank` implementation already handles RrfRank children.
   </action>
@@ -247,8 +253,9 @@ Use that sentinel for typed-nil operands instead of adding a new public error or
 
 <success_criteria>
 - Typed-nil Rank operands cannot cause a nil-receiver panic through Add, Multiply, Sub, Div, Max, or Min marshal paths.
+- The regression uses a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; the panic occurs later when the composite serializer invokes the operand.
 - The invalid operand produces a stable error while untyped nil retains its existing `Val(0)` meaning.
-- HTTP regressions compare complete payloads and prove direct omission, nested RRF expansion, and mixed-batch order/content.
+- HTTP regressions compare complete payloads and prove direct omission, the historical nested RRF expansion, and mixed-batch order/content; the nested substitution contract was later superseded by quick task `260731-ewm`.
 - A three-level nested RRF tree is deeply cloned and preserves marshal output.
 - `.planning/STATE.md` records `b79ede4 | Verified` for 260730-u7z and no longer contains `3f3a06f`.
 - Focused tests, the full basicv2 package suite, lint, and diff checks pass.

--- a/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
+++ b/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
@@ -1,0 +1,260 @@
+---
+phase: quick-260731-e0k
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/rank_test.go
+  - pkg/api/v2/collection_http_test.go
+  - .planning/STATE.md
+autonomous: true
+requirements:
+  - REVIEW-01
+  - REVIEW-02
+  - REVIEW-03
+  - REVIEW-04
+  - REVIEW-05
+  - REVIEW-06
+  - REVIEW-07
+
+must_haves:
+  truths:
+    - "Add, Multiply, Sub, Div, Max, and Min reject a typed-nil Rank operand during MarshalJSON with an error instead of panicking"
+    - "An untyped nil Operand retains the existing fluent-API behavior of converting to Val(0)"
+    - "Collection.Search emits an exact rank-free payload for a typed-nil rank and an exact non-null payload for a typed-nil rank nested in RRF"
+    - "A SearchQuery batch containing a typed-nil rank request followed by a normal request preserves both requests in order and serializes the normal rank"
+    - "A multi-level RrfRank tree is recursively cloned into independent nodes and the clone marshals to JSON equal to the original"
+    - "The 260730-u7z STATE.md row names reachable commit b79ede4 and has status Verified"
+    - "No PR branch creation, filtering, push, PR, or merge operation is performed"
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Typed-nil Rank rejection at the shared operandToRank conversion boundary"
+      contains: "func operandToRank(operand Operand) Rank"
+    - path: "pkg/api/v2/rank_test.go"
+      provides: "MarshalJSON regressions for all six binary fluent rank operations"
+      contains: "TestRankArithmeticTypedNilOperandMarshal"
+    - path: "pkg/api/v2/collection_http_test.go"
+      provides: "Exact HTTP payload, mixed-batch, and recursive RRF clone/marshal regressions"
+      contains: "TestCollectionSearchTypedNilRank"
+    - path: ".planning/STATE.md"
+      provides: "Correct quick-task commit and verification status"
+      contains: "b79ede4"
+  key_links:
+    - from: "pkg/api/v2/rank.go:operandToRank"
+      to: "pkg/api/v2/search.go:isNilRank"
+      via: "reuse the package's nillable-kind-aware Rank guard before returning a Rank operand"
+      pattern: "isNilRank\\(v\\)"
+    - from: "pkg/api/v2/rank_test.go:TestRankArithmeticTypedNilOperandMarshal"
+      to: "pkg/api/v2/rank.go:operandToRank"
+      via: "each fluent expression reaches the shared conversion helper and then MarshalJSON"
+      pattern: "MarshalJSON\\(\\)"
+    - from: "pkg/api/v2/collection_http_test.go:TestCollectionSearchTypedNilRank"
+      to: "pkg/api/v2/collection_http.go:CollectionImpl.Search"
+      via: "capture the serialized SearchQuery at the HTTP boundary and compare the complete payload"
+      pattern: "require\\.JSONEq"
+    - from: "pkg/api/v2/collection_http_test.go:TestCloneRank"
+      to: "pkg/api/v2/collection_http.go:cloneRank"
+      via: "clone nested RrfRank children recursively, then compare original and clone JSON"
+      pattern: "cloneRank"
+---
+
+<objective>
+Close the supplied review findings around typed-nil rank arithmetic and the earlier search-path regressions.
+
+Purpose: all public fluent rank operations must turn an invalid typed-nil Rank operand into a predictable marshal error, never a nil-receiver panic; the HTTP and clone tests must prove complete payload and recursive behavior rather than only checking shallow non-null state.
+
+Output: one shared conversion guard, focused regressions for all six binary fluent operations, exact single- and mixed-batch HTTP payload assertions, multi-level RRF clone/marshal coverage, and a corrected quick-task ledger row.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+@pkg/api/v2/collection_http.go
+@pkg/api/v2/collection_http_test.go
+@pkg/api/v2/search.go
+@pkg/api/v2/search_test.go
+
+**Working directory:** `/Users/tazarov/GolandProjects/chroma-go`
+
+**Scope boundaries:**
+- Preserve `operandToRank(nil) -> Val(0)` for an untyped nil; only a typed-nil value satisfying `Rank` becomes a rejected operand.
+- Reuse the existing `isNilRank`/`isNilInterface` behavior; do not add another reflection helper or a dependency.
+- Keep the existing direct typed-nil SearchRequest behavior: its `rank` key is omitted.
+- Keep the existing clone normalization behavior: a typed-nil child in an RRF tree becomes a true nil in the clone and therefore remains marshalable through RRF's documented nil-to-`Val(0)` path.
+- Do not broaden this task into option validation, rank API redesign, changelog work, or unrelated test cleanup.
+- Do not perform the optional PR-branch filtering suggestion. Do not create or switch branches, filter commits, push, open a PR, or merge.
+</context>
+
+<interfaces>
+<!-- Existing contracts the executor should use directly. -->
+
+From `pkg/api/v2/rank.go`:
+
+```go
+type Operand interface {
+	IsOperand()
+}
+
+type Rank interface {
+	Operand
+	Multiply(operand Operand) Rank
+	Sub(operand Operand) Rank
+	Add(operand Operand) Rank
+	Div(operand Operand) Rank
+	Max(operand Operand) Rank
+	Min(operand Operand) Rank
+	MarshalJSON() ([]byte, error)
+}
+
+func operandToRank(operand Operand) Rank
+```
+
+From `pkg/api/v2/search.go`:
+
+```go
+type SearchQuery struct {
+	Searches  []SearchRequest `json:"searches"`
+	ReadLevel ReadLevel       `json:"read_level,omitempty"`
+}
+
+func isNilRank(rank Rank) bool
+```
+
+From `pkg/api/v2/collection_http.go`:
+
+```go
+func cloneRank(rank Rank) Rank
+```
+
+`UnknownRank.MarshalJSON` already returns a stable error containing `unknown operand type`.
+Use that sentinel for typed-nil operands instead of adding a new public error or changing fluent method signatures.
+</interfaces>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Reject typed-nil fluent rank operands without panicking</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go</files>
+  <behavior>
+    - "Val(1).Add(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+    - "Val(1).Multiply(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+    - "Val(1).Sub(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+    - "Val(1).Div(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+    - "Val(1).Max(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+    - "Val(1).Min(typedNilRank).MarshalJSON() does not panic and returns the UnknownRank marshal error"
+  </behavior>
+  <action>
+    First add `TestRankArithmeticTypedNilOperandMarshal` in `pkg/api/v2/rank_test.go` as a table over the six binary fluent operations: Sum through `Add`, Mul through `Multiply`, Sub, Div, Max, and Min. Use one concrete typed-nil Rank (`var operand *KnnRank`) and a per-row builder starting from `Val(1)`. For every row, invoke `MarshalJSON` inside `require.NotPanics`, then require a non-nil error containing `unknown operand type`. Run the focused test once before the production edit and confirm the current implementation fails by panic.
+
+    In `pkg/api/v2/rank.go`, keep the leading `operand == nil` branch unchanged so untyped nil remains `Val(0)`. Inside the `case Rank` branch of `operandToRank`, call the existing `isNilRank(v)` helper before returning `v`; return `&UnknownRank{}` when it reports a typed nil. This covers pointer-backed and caller-supplied nillable Rank implementations without duplicating reflection logic. Keep IntOperand, FloatOperand, and unknown non-Rank handling unchanged.
+
+    Update the `operandToRank` comment to distinguish the two contracts plainly: untyped nil becomes `Val(0)` for fluent chaining, while a typed-nil Rank becomes `UnknownRank` and fails cleanly during marshal. Do not add per-operation guards; the shared conversion boundary is the smallest complete fix.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankArithmeticTypedNilOperandMarshal$' -count=1</automated>
+  </verify>
+  <done>All six fluent operations build normally, MarshalJSON never panics for their typed-nil operand, every marshal returns the existing UnknownRank error, and the focused regression test passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Pin exact search payloads, mixed batches, and recursive RRF cloning</name>
+  <files>pkg/api/v2/collection_http_test.go</files>
+  <action>
+    Refactor `TestCollectionSearchTypedNilRank` so every table row supplies the SearchRequest values to append and a complete expected HTTP request payload. Compare the captured request body directly with `require.JSONEq`; remove the current shallow unmarshal/`hasRank`/`rankJSON != "null"` assertions.
+
+    Pin these three cases and their order:
+    1. Direct typed-nil `*KnnRank`: expected payload `{"searches":[{}]}`.
+    2. One `RrfRank` whose only weighted child is that typed-nil rank, `K: 60`, `Weight: 1`: expected payload `{"searches":[{"rank":{"$mul":[{"$val":-1},{"$div":{"left":{"$val":1},"right":{"$sum":[{"$val":60},{"$val":0}]}}}]}}]}`. This proves the nested rank is a real expanded expression, not merely non-null.
+    3. One direct typed-nil request followed by a normal `Val(2)` request: expected payload `{"searches":[{},{"rank":{"$val":2}}]}`. This proves mixed-batch normalization does not drop, merge, or reorder requests and does not disturb the normal request.
+
+    Retain the HTTP-boundary `require.NotPanics`, `require.NoError`, and non-nil result assertions for every case.
+
+    Add a focused subtest under `TestCloneRank` named for multi-level nested RRF cloning. Build at least three RrfRank nodes (outer -> middle -> inner -> concrete KnnRank) using `RankWithWeight` for the RRF children, clone the outer node, and assert every corresponding RrfRank node and the leaf KnnRank are distinct pointers. Marshal both original and clone inside `require.NotPanics`, require no errors, and compare their complete JSON with `require.JSONEq`. Keep this as test-only coverage; the recursive `cloneRank` implementation already handles RrfRank children.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCollectionSearchTypedNilRank|TestCloneRank)$' -count=1</automated>
+  </verify>
+  <done>The HTTP test uses full JSON equality for direct, nested-RRF, and mixed-batch cases; the mixed batch retains both requests in order; and a three-level RRF tree clones into independent nodes whose marshal output is JSON-equivalent to the original.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Repair the completed quick-task ledger entry</name>
+  <files>.planning/STATE.md</files>
+  <action>
+    In the `### Quick Tasks Completed` table, change only the `260730-u7z` row: replace unreachable commit `3f3a06f` with reachable implementation commit `b79ede4`, and fill the blank Status cell with `Verified`, matching the completed neighboring quick-task rows. Preserve the description, date, directory link, frontmatter, current-position text, and every other row.
+
+    This is a planning-ledger correction only. Do not run any PR-branch filtering command or perform any branch, push, PR, or merge operation.
+  </action>
+  <verify>
+    <automated>git cat-file -e 'b79ede4^{commit}' &amp;&amp; rg -n '^\| 260730-u7z \|.*\| b79ede4 \| Verified \|' .planning/STATE.md &amp;&amp; ! rg -n '3f3a06f' .planning/STATE.md</automated>
+  </verify>
+  <done>The 260730-u7z row points to b79ede4, reads Verified, contains no stale 3f3a06f reference, and no unrelated STATE.md content or repository branch state changes.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller Rank operand -> fluent expression builder | A caller-supplied interface may contain a typed-nil pointer or another nillable Rank implementation |
+| In-memory SearchQuery -> HTTP JSON body | Rank normalization and cloning must preserve batch shape while preventing nil-receiver panics and malformed/null rank payloads |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-e0k-01 | Denial of Service | `operandToRank` -> arithmetic `MarshalJSON` | mitigate | Detect typed-nil Rank values once at the conversion boundary and route them to the existing erroring UnknownRank sentinel; six operation-level regressions prove no panic |
+| T-e0k-02 | Tampering | `CollectionImpl.Search` SearchQuery serialization | mitigate | Assert the full captured JSON for direct nil, nested RRF, and mixed-batch inputs so request omission, replacement, or reordering is detected |
+| T-e0k-03 | Tampering | `cloneRank` recursive RRF copy | mitigate | Prove all nested nodes are independent pointers and that original/clone marshal to JSON-equivalent expressions |
+| T-e0k-SC | Tampering | Package installation | accept | No dependency or package-manager change is part of this plan |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankArithmeticTypedNilOperandMarshal$' -count=1`
+2. `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCollectionSearchTypedNilRank|TestCloneRank)$' -count=1`
+3. `go test -tags=basicv2 ./pkg/api/v2/... -count=1`
+4. `make lint`
+5. `git diff --check`
+6. Confirm `git status --short` lists only the four planned implementation/state files plus normal GSD summary bookkeeping; there are no branch-filtering or PR artifacts.
+</verification>
+
+<source_coverage_audit>
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | — | Address typed-nil rank arithmetic and all supplied review findings | 01 | COVERED | Tasks 1-3 |
+| REQ | REVIEW-01 | Reject typed-nil Rank operands in operandToRank | 01 | COVERED | Task 1 |
+| REQ | REVIEW-02 | Add MarshalJSON regressions for Sum/Mul/Sub/Div/Max/Min | 01 | COVERED | Task 1 |
+| REQ | REVIEW-03 | Replace the shallow rank-null assertion with expected-payload JSONEq | 01 | COVERED | Task 2 |
+| REQ | REVIEW-04 | Cover a mixed SearchQuery batch with nil and normal rank requests | 01 | COVERED | Task 2 |
+| REQ | REVIEW-05 | Cover multi-level nested RrfRank clone/marshal behavior | 01 | COVERED | Task 2 |
+| REQ | REVIEW-06 | Correct 260730-u7z to b79ede4 and fill its status | 01 | COVERED | Task 3 |
+| REQ | REVIEW-07 | Do not perform optional PR-branch filtering | 01 | COVERED | Global scope fence and Task 3 |
+| RESEARCH | — | No research phase | — | EXCLUDED | Quick mode explicitly requires no research phase; existing local patterns are sufficient |
+| CONTEXT | PROJECT-01 | Prefer the smallest implementation that fully fixes the issue | 01 | COVERED | One shared guard; remaining changes are focused regressions and ledger repair |
+| CONTEXT | PROJECT-02 | Do not expose private repository details in artifacts | 01 | COVERED | Plan and planned outputs contain no such details |
+| CONTEXT | PROJECT-03 | Always use squash merge | — | EXCLUDED | No merge is requested or permitted in this task |
+</source_coverage_audit>
+
+<success_criteria>
+- Typed-nil Rank operands cannot cause a nil-receiver panic through Add, Multiply, Sub, Div, Max, or Min marshal paths.
+- The invalid operand produces a stable error while untyped nil retains its existing `Val(0)` meaning.
+- HTTP regressions compare complete payloads and prove direct omission, nested RRF expansion, and mixed-batch order/content.
+- A three-level nested RRF tree is deeply cloned and preserves marshal output.
+- `.planning/STATE.md` records `b79ede4 | Verified` for 260730-u7z and no longer contains `3f3a06f`.
+- Focused tests, the full basicv2 package suite, lint, and diff checks pass.
+- No PR branch operation is performed.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
+++ b/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
@@ -1,0 +1,104 @@
+---
+phase: quick-260731-e0k
+plan: 01
+status: complete
+subsystem: api
+tags: [go, rank, typed-nil, search, rrf, testing]
+
+requires:
+  - phase: quick-260730-u7z
+    provides: Typed-nil search normalization
+provides:
+  - Typed-nil Rank operands fail cleanly through the existing UnknownRank marshal error
+  - Exact HTTP payload coverage for direct nil, nested RRF, and mixed-batch searches
+  - Recursive pointer-independence and JSON-equivalence coverage for nested RRF clones
+  - Corrected 260730-u7z quick-task ledger entry
+affects: [rank arithmetic, Search API, RRF cloning]
+
+tech-stack:
+  added: []
+  patterns:
+    - Guard typed-nil interface values at the shared operand conversion boundary
+    - Assert complete HTTP JSON payloads instead of shallow field presence
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/rank_test.go
+    - pkg/api/v2/collection_http_test.go
+    - .planning/STATE.md
+
+key-decisions:
+  - "Reused isNilRank in operandToRank so all six fluent binary operations share one typed-nil guard."
+  - "Preserved operandToRank(nil) as Val(0); only typed-nil Rank values become UnknownRank."
+  - "Kept cloneRank unchanged because focused recursive tests confirmed its existing deep-copy behavior."
+
+requirements-completed:
+  - REVIEW-01
+  - REVIEW-02
+  - REVIEW-03
+  - REVIEW-04
+  - REVIEW-05
+  - REVIEW-06
+  - REVIEW-07
+
+duration: 7 min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-e0k: Typed-Nil Rank Arithmetic and Search Regressions
+
+A shared `isNilRank` guard turns typed-nil arithmetic operands into stable marshal errors, backed by exact search payload and recursive RRF clone regressions.
+
+## Accomplishments
+
+- All six binary fluent rank operations reject a typed-nil Rank during marshal without panicking.
+- Search regressions pin complete JSON for direct typed nil, nested RRF, and ordered mixed-batch requests.
+- A three-level RRF tree clones into independent nodes and preserves complete marshal output.
+- The `260730-u7z` ledger row now names reachable commit `b79ede4` with status `Verified`.
+
+## TDD Execution
+
+- **RED:** Added a six-operation regression and confirmed each case reached a nil `*KnnRank` receiver and panicked.
+- **GREEN:** Added the shared `isNilRank` guard in `operandToRank`; the focused regression passed.
+- **REFACTOR:** No further production change was needed.
+
+## Commit
+
+- `b3ef969` — `fix(api): handle typed-nil rank operands`
+
+## Files Modified
+
+- `pkg/api/v2/rank.go` — Detects typed-nil Rank operands at the shared conversion boundary.
+- `pkg/api/v2/rank_test.go` — Covers Add, Multiply, Sub, Div, Max, and Min marshal behavior.
+- `pkg/api/v2/collection_http_test.go` — Pins exact search payloads and recursive RRF clone behavior.
+- `.planning/STATE.md` — Corrects the earlier ledger row and records this quick task.
+
+## Decisions
+
+- Reused the existing nillable-kind-aware helper instead of adding reflection or per-operation guards.
+- Kept untyped nil's established `Val(0)` fluent-chain behavior unchanged.
+- Added test-only recursive clone coverage because the production clone already performs the required deep copy.
+- Left PR-branch filtering out of scope because no PR operation was requested.
+
+## Verification
+
+- `go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankArithmeticTypedNilOperandMarshal$' -count=1` — passed.
+- `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCollectionSearchTypedNilRank|TestCloneRank)$' -count=1` — passed.
+- `go test -tags=basicv2 ./pkg/api/v2/... -count=1` — passed.
+- `make lint` — passed with `0 issues`.
+- `git diff --check` — passed.
+- Ledger verification confirmed `b79ede4` is reachable, the earlier row is `Verified`, and the stale hash is absent.
+
+## Deviations
+
+None.
+
+## User Setup Required
+
+None.
+
+## Self-Check
+
+Passed. The implementation commit is reachable on the feature branch, the requested regressions pass, and no PR or merge operation outside the isolated squash integration was performed.

--- a/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
+++ b/.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
@@ -32,7 +32,7 @@ key-files:
 key-decisions:
   - "Reused isNilRank in operandToRank so all six fluent binary operations share one typed-nil guard."
   - "Preserved operandToRank(nil) as Val(0); only typed-nil Rank values become UnknownRank."
-  - "Kept cloneRank unchanged because focused recursive tests confirmed its existing deep-copy behavior."
+  - "Historical decision, superseded by quick task 260731-ewm: kept cloneRank unchanged and accepted nested typed-nil RRF substitution as Val(0); the later task identifies that substitution as a defect and returns an error."
 
 requirements-completed:
   - REVIEW-01
@@ -54,13 +54,13 @@ A shared `isNilRank` guard turns typed-nil arithmetic operands into stable marsh
 ## Accomplishments
 
 - All six binary fluent rank operations reject a typed-nil Rank during marshal without panicking.
-- Search regressions pin complete JSON for direct typed nil, nested RRF, and ordered mixed-batch requests.
+- Search regressions pin complete JSON for direct typed nil, the then-accepted nested RRF substitution, and ordered mixed-batch requests. The nested substitution contract was later superseded by quick task `260731-ewm`.
 - A three-level RRF tree clones into independent nodes and preserves complete marshal output.
 - The `260730-u7z` ledger row now names reachable commit `b79ede4` with status `Verified`.
 
 ## TDD Execution
 
-- **RED:** Added a six-operation regression and confirmed each case reached a nil `*KnnRank` receiver and panicked.
+- **RED:** Added a six-operation regression using a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; composite marshaling then panicked when it invoked the operand.
 - **GREEN:** Added the shared `isNilRank` guard in `operandToRank`; the focused regression passed.
 - **REFACTOR:** No further production change was needed.
 
@@ -79,7 +79,7 @@ A shared `isNilRank` guard turns typed-nil arithmetic operands into stable marsh
 
 - Reused the existing nillable-kind-aware helper instead of adding reflection or per-operation guards.
 - Kept untyped nil's established `Val(0)` fluent-chain behavior unchanged.
-- Added test-only recursive clone coverage because the production clone already performs the required deep copy.
+- Historical decision, superseded by quick task `260731-ewm`: added test-only recursive clone coverage and accepted the cloned nested typed nil as `Val(0)`. The later task identifies that substitution as a defect and changes nested typed-nil RRF input to an error; that later fix is not part of commit `b3ef969`.
 - Left PR-branch filtering out of scope because no PR operation was requested.
 
 ## Verification

--- a/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-PLAN.md
+++ b/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-PLAN.md
@@ -1,0 +1,295 @@
+---
+phase: quick-260731-ewm
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/rank_test.go
+  - pkg/api/v2/options.go
+  - pkg/api/v2/search.go
+  - pkg/api/v2/collection_http.go
+  - pkg/api/v2/collection_http_test.go
+  - pkg/api/v2/search_test.go
+  - .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
+  - .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
+autonomous: true
+requirements:
+  - EWM-01
+  - EWM-02
+  - EWM-03
+  - EWM-04
+  - EWM-05
+  - EWM-06
+  - EWM-07
+  - EWM-08
+
+must_haves:
+  truths:
+    - "Arithmetic and unary expressions built from a typed-nil *KnnRank receiver never panic during composite marshaling and return an error matching ErrNilRank"
+    - "SumRank, SubRank, MulRank, DivRank, AbsRank, ExpRank, LogRank, MaxRank, and MinRank reject nil or typed-nil children before invoking their MarshalJSON methods"
+    - "A typed-nil Rank operand reports ErrNilRank, while an untyped nil Operand retains Val(0) chaining and a genuinely unsupported Operand retains the unknown-operand error"
+    - "A typed-nil child in RrfRank is preserved through cloneRank and fails through Collection.Search instead of being silently converted into a best-ranked Val(0) term"
+    - "WithRank rejects nil, a direct typed-nil SearchRequest.Rank remains an omitted optional field, and exported documentation states this difference"
+    - "The HTTP request-body regression cannot block forever waiting on its capture channel"
+    - "The earlier plan and summary accurately say their arithmetic test used a valid *ValRank receiver with a typed-nil *KnnRank operand"
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Shared nil-child marshal guard, accurate invalid-rank conversion, and RRF child validation"
+      contains: "func marshalRank"
+    - path: "pkg/api/v2/rank_test.go"
+      provides: "No-panic regressions for typed-nil receivers, every composite shape, RRF, and distinct nil/unknown errors"
+      contains: "TestRankTypedNilReceiverMarshal"
+    - path: "pkg/api/v2/collection_http.go"
+      provides: "Deep cloning that preserves nested typed-nil Rank identity"
+      contains: "func cloneRank"
+    - path: "pkg/api/v2/collection_http_test.go"
+      provides: "Collection.Search nested-RRF failure regression and bounded request-body capture"
+      contains: "TestCollectionSearchTypedNilRank"
+    - path: "pkg/api/v2/search.go"
+      provides: "Exported SearchRequest.Rank nil-behavior documentation"
+      contains: "type SearchRequest struct"
+    - path: ".planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md"
+      provides: "Correct historical account of the earlier arithmetic regression"
+      contains: "valid *ValRank"
+  key_links:
+    - from: "pkg/api/v2/rank.go:composite MarshalJSON methods"
+      to: "pkg/api/v2/rank.go:marshalRank"
+      via: "all nine composite shapes marshal children through the nil-aware helper"
+      pattern: "marshalRank\\("
+    - from: "pkg/api/v2/rank.go:marshalRank"
+      to: "pkg/api/v2/options.go:ErrNilRank"
+      via: "typed-nil children return the canonical nil-rank error"
+      pattern: "ErrNilRank"
+    - from: "pkg/api/v2/collection_http.go:cloneRank"
+      to: "pkg/api/v2/rank.go:RrfRank.Validate"
+      via: "the clone retains a nested typed nil so RRF validation can reject it"
+      pattern: "return rank"
+    - from: "pkg/api/v2/collection_http_test.go:TestCollectionSearchTypedNilRank"
+      to: "pkg/api/v2/collection_http.go:CollectionImpl.Search"
+      via: "the full HTTP path returns ErrNilRank without panicking or sending a substituted term"
+      pattern: "ErrorIs.*ErrNilRank"
+---
+
+<objective>
+Make every composite rank serialization boundary reject nil children predictably, and stop nested RRF cloning from turning invalid input into a valid-looking best-ranked term.
+
+Purpose: typed-nil ranks must produce an accurate, stable error instead of a panic or silent score corruption, while the intentionally different top-level SearchRequest omission behavior remains documented and tested.
+
+Output: one shared composite marshal guard, preserved nested typed-nil clone semantics, corrected RRF/Search regressions, bounded HTTP test synchronization, public nil-contract documentation, and corrected historical GSD wording.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+@pkg/api/v2/options.go
+@pkg/api/v2/search.go
+@pkg/api/v2/search_test.go
+@pkg/api/v2/collection_http.go
+@pkg/api/v2/collection_http_test.go
+@.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
+@.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
+
+**Locked behavior:**
+- Keep `operandToRank(nil) -> Val(0)` for an untyped nil Operand.
+- Keep `WithRank(nil or typed-nil)` returning `ErrNilRank`.
+- Keep a direct `SearchRequest{Rank: typedNil}` rank-free: both direct marshaling and `Collection.Search` omit the optional `rank` field.
+- Reject typed-nil arithmetic operands, typed-nil children created from receiver calls, and typed-nil `RankWithWeight.Rank` values with `ErrNilRank`; do not route nil input through `UnknownRank`.
+- Keep `UnknownRank` for genuinely unsupported Operand implementations and retain an accurate unknown-operand error for that case.
+- Preserve a nested typed-nil Rank's dynamic type in `cloneRank`; do not normalize it to untyped nil.
+- Use the nine composite `MarshalJSON` methods as the serialization boundary. Do not add nil guards across the arithmetic/unary method matrix.
+- Keep `isNilRank` and `isNilInterface` in `search.go`: moving two working helpers into a new file would add churn without changing this quick task's behavior or contract (EWM-07).
+</context>
+
+<interfaces>
+<!-- Existing contracts the executor should use directly. -->
+
+From `pkg/api/v2/rank.go`:
+
+```go
+type Rank interface {
+	Operand
+	Multiply(operand Operand) Rank
+	Sub(operand Operand) Rank
+	Add(operand Operand) Rank
+	Div(operand Operand) Rank
+	Negate() Rank
+	Abs() Rank
+	Exp() Rank
+	Log() Rank
+	Max(operand Operand) Rank
+	Min(operand Operand) Rank
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(b []byte) error
+}
+
+type RankWithWeight struct {
+	Rank   Rank
+	Weight float64
+}
+
+func operandToRank(operand Operand) Rank
+```
+
+From `pkg/api/v2/options.go`:
+
+```go
+var ErrNilRank = errors.New("rank cannot be nil")
+```
+
+From `pkg/api/v2/search.go`:
+
+```go
+type SearchRequest struct {
+	Filter  *SearchFilter
+	Limit   *SearchPage
+	Rank    Rank
+	Select  *SearchSelect
+	GroupBy *GroupBy
+}
+
+func WithRank(rank Rank) *rankOption
+func isNilRank(rank Rank) bool
+```
+
+From `pkg/api/v2/collection_http.go`:
+
+```go
+func cloneRank(rank Rank) Rank
+```
+</interfaces>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Reject nil children at every composite marshal boundary</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go, pkg/api/v2/options.go, pkg/api/v2/search.go</files>
+  <behavior>
+    - "For `var k *KnnRank`, each of Add, Multiply, Sub, Div, Max, Min, Negate, Abs, Exp, and Log can build an expression; marshaling that expression does not panic and returns an error matching ErrNilRank"
+    - "Sum/Mul/Max/Min reject a nil child in their variadic slices; Sub/Div reject nil on either side; Abs/Exp/Log reject their nil unary child"
+    - "RrfRank rejects a nil or typed-nil RankWithWeight.Rank with an indexed error matching ErrNilRank"
+    - "A typed-nil Rank passed as an arithmetic operand reports ErrNilRank, an untyped nil Operand still serializes as Val(0), and a custom unsupported Operand still reports unknown operand type"
+  </behavior>
+  <action>
+    For EWM-01, EWM-03, and EWM-08, first update `pkg/api/v2/rank_test.go`. Change `TestRankArithmeticTypedNilOperandMarshal` to require `ErrorIs(err, ErrNilRank)` rather than the misleading unknown-operand text. Add `TestRankTypedNilReceiverMarshal`, using `var k *KnnRank` (also assigned to a `Rank` interface for at least one row) and a table over all six binary and four unary methods; build the expression outside or inside `require.NotPanics` as appropriate, then marshal inside `require.NotPanics` and require `ErrNilRank`. This receiver table is specifically for the non-dereferencing `KnnRank` builders; do not claim arbitrary methods on every nil concrete Rank are valid.
+
+    Add `TestCompositeRankNilChildMarshal` as a table that directly constructs all nine package-private composite shapes. Cover SumRank, MulRank, MaxRank, and MinRank with a typed-nil child in the slice; SubRank and DivRank with separate left/right nil cases; and AbsRank, ExpRank, and LogRank with a typed-nil child. Every row must call `MarshalJSON` under `require.NotPanics` and require `ErrorIs(err, ErrNilRank)`. Add an RRF nil-child case to `TestRrfRank`, including `ErrorIs`, and extend operand conversion coverage with both untyped nil (still `Val(0)`) and a small test-only unsupported Operand type (still the unknown-operand error). Run the focused tests once before production edits and confirm the receiver/composite/RRF cases fail by panic or wrong error.
+
+    In `pkg/api/v2/rank.go`, add one unexported `marshalRank(rank Rank) ([]byte, error)` helper that returns `ErrNilRank` when `isNilRank(rank)` and otherwise delegates to `rank.MarshalJSON`. Route every child serialization in `SumRank.MarshalJSON`, `SubRank.MarshalJSON`, `MulRank.MarshalJSON`, `DivRank.MarshalJSON`, `AbsRank.MarshalJSON`, `ExpRank.MarshalJSON`, `LogRank.MarshalJSON`, `MaxRank.MarshalJSON`, and `MinRank.MarshalJSON` through this helper. Preserve term/depth/division checks and JSON shapes.
+
+    In `operandToRank`, retain the leading untyped-nil `Val(0)` branch, but return a true nil Rank from the typed-nil `case Rank` path so the enclosing composite reaches `marshalRank`; keep unsupported types returning `&UnknownRank{}`. In `RrfRank.Validate`, reject every nil or typed-nil `rw.Rank` before weight processing with an index-bearing error that wraps `ErrNilRank`. Update the `UnknownRank` and `operandToRank` comments so UnknownRank describes only unsupported Operand conversion and nil input describes `ErrNilRank`; do not use unknown-operand wording for nil rank input.
+
+    For EWM-04, update exported documentation without hiding the asymmetry: the `Rank` comment must state that expressions containing typed-nil operands/children fail with `ErrNilRank` during marshaling; `RankWithWeight.Rank` must be non-nil; `WithRank` rejects nil and typed nil while applying the option; and direct assignment of nil or typed nil to the optional `SearchRequest.Rank` field is omitted by `SearchRequest.MarshalJSON` and `Collection.Search`. Also broaden the `ErrNilRank` comment in `options.go` beyond only WithRank. State that directly calling methods on arbitrary nil concrete pointers is invalid; the guarantee is at supported option and composite serialization boundaries. Keep the existing helpers in `search.go` per EWM-07.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestUnknownRankError|TestRankArithmeticTypedNilOperandMarshal|TestRankTypedNilReceiverMarshal|TestCompositeRankNilChildMarshal|TestOperandConversion|TestRrfRank)$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>All ten typed-nil KnnRank receiver compositions and every composite child shape marshal without panic, nil errors match ErrNilRank, unsupported operands retain their distinct error, untyped nil retains Val(0), and exported docs accurately distinguish the supported entry paths.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Preserve nested typed nils and fail RRF searches cleanly</name>
+  <files>pkg/api/v2/collection_http.go, pkg/api/v2/collection_http_test.go, pkg/api/v2/search_test.go</files>
+  <behavior>
+    - "cloneRank(nil) remains nil, while cloneRank of a typed-nil Rank preserves its concrete dynamic type instead of laundering it to untyped nil"
+    - "A typed-nil Rank nested in RrfRank remains typed nil after the full RRF deep clone"
+    - "Collection.Search with a nested typed-nil RRF child does not panic, returns an error matching ErrNilRank, and sends no substituted Val(0) request"
+    - "Direct typed-nil SearchRequest.Rank omission and mixed-batch ordering continue to produce their existing exact payloads"
+    - "Every expected request body is received with a bounded select/time.After assertion"
+  </behavior>
+  <action>
+    For EWM-02 and EWM-08, update `TestCloneRankTypedNil` in `pkg/api/v2/search_test.go` before production code. Replace the “clones to true nil” expectation with assertions that a typed-nil `*KnnRank` or `*ValRank` remains `isNilRank` but retains the same concrete type after cloning. In the nested RRF subtest, type-assert the cloned child back to `*KnnRank` and require the pointer itself is nil; this distinguishes preservation from an untyped nil interface. Keep the top-level `embedTextQueries` regression proving a direct typed-nil request normalizes to omission.
+
+    In `cloneRank`, change the nil fast path to return the incoming `rank` value rather than a literal nil. This keeps untyped nil unchanged and preserves typed-nil interface identity. Update its comment to explain that the caller handles top-level omission before cloning, whereas nested typed nils must survive until validation; do not change the deep-copy branches for non-nil rank nodes.
+
+    Refactor `TestCollectionSearchTypedNilRank` for EWM-02 and EWM-06 so each subtest has isolated request capture. Keep the direct typed-nil case expecting `{"searches":[{}]}` and the direct-typed-nil-plus-`Val(2)` case expecting `{"searches":[{},{"rank":{"$val":2}}]}`. Change the nested RRF case from the old successful `Val(0)` payload to `require.NotPanics`, a nil result, and `require.ErrorIs(searchErr, ErrNilRank)` through the real `Collection.Search` path. For successful cases, replace the blocking `<-requestBodies` read with a `select` that receives and runs `require.JSONEq`, or calls `t.Fatal` after `time.After(time.Second)`. For the error case, assert the isolated server received no body using a bounded select; import `time`. No test may wait indefinitely, and no nested case may assert the former substituted `$val:0` term.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCollectionSearchTypedNilRank|TestCloneRankTypedNil|TestSearchRequestMarshalTypedNilRank)$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>cloneRank preserves nested typed-nil identity, Collection.Search returns ErrNilRank without panic or a corrupted HTTP payload, direct omission/mixed batches remain unchanged, and request-body assertions are bounded.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Correct the earlier GSD receiver claim and mark the RRF contract superseded</name>
+  <files>.planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md, .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md</files>
+  <action>
+    For EWM-05, correct the prior plan and summary without rewriting commit history. In the old PLAN Task 1 description, objective, and success criteria, add the exact clarification “The regression uses a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; the panic occurs later when the composite serializer invokes the operand.” Remove wording that says or implies the test invoked arithmetic on a nil receiver.
+
+    Replace the old SUMMARY RED sentence with: “Added a six-operation regression using a valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand; composite marshaling then panicked when it invoked the operand.” Preserve commit `b3ef969`, its implemented guard, verification results, and all unrelated historical details.
+
+    The prior PLAN/SUMMARY also record the nested RRF `Val(0)` substitution as intentional. Preserve that as history but annotate the relevant scope/decision text as superseded by quick task `260731-ewm`, which identifies the substitution as a defect and changes nested typed-nil RRF input to an error. Do not make the old artifacts claim that the new production fix was part of `b3ef969`.
+  </action>
+  <verify>
+    <automated>rg -n -F 'valid `*ValRank` arithmetic receiver and a typed-nil `*KnnRank` operand' .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md &amp;&amp; rg -n 'superseded.*260731-ewm|260731-ewm.*supersed' .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md</automated>
+  </verify>
+  <done>Both historical artifacts accurately describe the old test's receiver and operand, clearly mark the nested-RRF substitution contract as superseded, and retain the original commit and verification record.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller-provided Rank interface -> composite serializer | An interface can contain a nil concrete pointer that bypasses ordinary `rank == nil` checks |
+| User rank tree -> cloned Collection.Search request | Clone normalization must not convert invalid nested input into a valid expression with different ranking semantics |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-ewm-01 | Denial of Service | Nine composite `MarshalJSON` methods | mitigate | Route every child through `marshalRank`, detect typed nil before method dispatch, and cover every composite shape plus all KnnRank receiver compositions under no-panic tests |
+| T-ewm-02 | Tampering | `cloneRank` -> `RrfRank.MarshalJSON` | mitigate | Preserve nested typed-nil identity and reject it with ErrNilRank so it cannot be changed into a best-ranked Val(0) term |
+| T-ewm-03 | Repudiation | Prior PLAN/SUMMARY account | mitigate | Correct receiver/operand wording and mark the former nested-RRF contract superseded without rewriting the original commit record |
+| T-ewm-SC | Tampering | Package installation | accept | This plan adds no dependency and runs no package-manager install |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestUnknownRankError|TestRankArithmeticTypedNilOperandMarshal|TestRankTypedNilReceiverMarshal|TestCompositeRankNilChildMarshal|TestOperandConversion|TestRrfRank)$' -count=1 -timeout=30s`
+2. `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCollectionSearchTypedNilRank|TestCloneRankTypedNil|TestSearchRequestMarshalTypedNilRank)$' -count=1 -timeout=30s`
+3. `go test -tags=basicv2 ./pkg/api/v2/... -count=1 -timeout=120s`
+4. `make lint`
+5. `git diff --check`
+6. Inspect `git diff -- pkg/api/v2 .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re` and confirm changes are limited to nil handling, tests/docs, bounded synchronization, and factual record corrections.
+</verification>
+
+<source_coverage_audit>
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | — | Fix typed-nil rank panics, nested RRF laundering, errors/docs/tests, and inaccurate GSD records | 01 | COVERED | Tasks 1-3 |
+| REQ | EWM-01 | Typed-nil receivers fail through composite marshal instead of panicking | 01 | COVERED | Task 1 |
+| REQ | EWM-02 | Nested RRF typed nil is not laundered into Val(0) | 01 | COVERED | Task 2, with RRF validation from Task 1 |
+| REQ | EWM-03 | Nil-rank and unknown-operand errors are accurate and distinct | 01 | COVERED | Task 1 |
+| REQ | EWM-04 | Exported Rank and SearchRequest nil behavior is documented across entry paths | 01 | COVERED | Task 1 |
+| REQ | EWM-05 | Earlier PLAN/SUMMARY receiver wording is corrected | 01 | COVERED | Task 3 |
+| REQ | EWM-06 | Blocking request-body receive is bounded | 01 | COVERED | Task 2 |
+| REQ | EWM-07 | Consider nil-helper relocation without unnecessary churn | 01 | COVERED | Helpers remain in search.go by explicit cohesion/churn decision |
+| REQ | EWM-08 | Add receiver/composite/RRF/error/no-panic regressions and run focused/package tests | 01 | COVERED | Tasks 1-2 and overall verification |
+| RESEARCH | — | No research phase | — | EXCLUDED | Quick mode explicitly forbids a research phase; existing package patterns are sufficient |
+| CONTEXT | PROJECT-01 | Prefer the smallest complete code change | 01 | COVERED | One child-marshal helper and one clone fast-path correction; no method-matrix guards or helper move |
+| CONTEXT | PROJECT-02 | Keep repository artifacts free of prohibited internal details | 01 | COVERED | Plan and planned artifacts contain no such details |
+| CONTEXT | PROJECT-03 | Use squash merge | — | EXCLUDED | No merge operation is part of this planning or execution scope |
+</source_coverage_audit>
+
+<success_criteria>
+- Typed-nil KnnRank receiver compositions and all nine composite child shapes return ErrNilRank without panicking.
+- Typed-nil input no longer uses the misleading UnknownRank error; genuinely unsupported Operand implementations still do.
+- Nested RRF typed nils retain their dynamic type through cloning and fail consistently in direct marshal/validation and Collection.Search.
+- Direct optional SearchRequest.Rank typed nil remains omitted, WithRank still rejects it, and exported docs explain the difference.
+- HTTP regressions cannot hang on request-body capture.
+- The earlier PLAN/SUMMARY accurately distinguish the valid ValRank receiver from the typed-nil KnnRank operand and flag the old nested-RRF contract as superseded.
+- Focused tests, the full basicv2 package suite, lint, and diff checks pass.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
+++ b/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
@@ -1,0 +1,141 @@
+---
+phase: quick-260731-ewm
+plan: 01
+status: complete
+subsystem: api
+tags: [go, rank, typed-nil, rrf, serialization, testing]
+
+requires:
+  - phase: quick-260731-e0k
+    provides: Initial typed-nil arithmetic guard and search-path regressions
+provides:
+  - ErrNilRank failures instead of panics at every composite rank marshal boundary
+  - Nested typed-nil RRF identity preservation through cloning and rejection before HTTP transmission
+  - Bounded HTTP request-body regression synchronization
+  - Corrected historical receiver and nested-RRF contract records
+affects: [rank arithmetic, Search API, RRF validation, rank cloning]
+
+tech-stack:
+  added: []
+  patterns:
+    - Route composite child serialization through one nil-aware marshalRank helper
+    - Preserve nested invalid interface identity until validation while omitting direct optional nil ranks
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/rank_test.go
+    - pkg/api/v2/options.go
+    - pkg/api/v2/search.go
+    - pkg/api/v2/collection_http.go
+    - pkg/api/v2/collection_http_test.go
+    - pkg/api/v2/search_test.go
+    - .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-PLAN.md
+    - .planning/quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/260731-e0k-SUMMARY.md
+
+key-decisions:
+  - "Use one marshalRank helper at the nine composite serialization boundaries instead of adding guards to every fluent method."
+  - "Keep untyped nil Operand conversion as Val(0), return ErrNilRank for typed-nil Rank operands, and retain UnknownRank only for unsupported Operand implementations."
+  - "Keep direct SearchRequest.Rank nil or typed nil as optional omission, while preserving nested typed nils so RRF validation rejects them."
+  - "Keep isNilRank and isNilInterface in search.go to avoid unrelated helper relocation."
+
+patterns-established:
+  - "Composite serialization boundary: validate a child interface before invoking its MarshalJSON method."
+  - "Clone semantics: preserve nested invalid dynamic types when later validation must distinguish them from omitted top-level fields."
+
+requirements-completed:
+  - EWM-01
+  - EWM-02
+  - EWM-03
+  - EWM-04
+  - EWM-05
+  - EWM-06
+  - EWM-07
+  - EWM-08
+
+duration: 9 min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-ewm: Typed-Nil Composite Rank and Nested RRF Safety Summary
+
+**Nil-aware composite serialization now returns `ErrNilRank` without panics or nested RRF score substitution, while direct optional rank omission remains intact.**
+
+## Performance
+
+- **Duration:** 9 min
+- **Started:** 2026-07-31T07:55:19Z
+- **Completed:** 2026-07-31T08:04:07Z
+- **Tasks:** 3
+- **Files modified:** 9
+
+## Accomplishments
+
+- Routed all nine composite rank serializers through one typed-nil-aware child marshal helper.
+- Preserved nested typed-nil rank identity through recursive cloning so RRF validation returns `ErrNilRank` before any HTTP request is sent.
+- Kept untyped nil operands as `Val(0)`, unsupported operands as `UnknownRank`, and direct typed-nil `SearchRequest.Rank` values as omission.
+- Replaced blocking HTTP capture receives with bounded assertions and corrected the earlier quick-task receiver and RRF contract record.
+
+## TDD Execution
+
+- **Task 1 RED:** The focused suite failed with `UnknownRank` instead of `ErrNilRank`, panicked when composite serializers invoked typed-nil children, and accepted nil RRF children.
+- **Task 1 GREEN:** `marshalRank`, accurate operand conversion, and RRF validation made all receiver, composite, conversion, and RRF regressions pass.
+- **Task 2 RED:** Clone regressions failed because typed-nil `*KnnRank` and `*ValRank` values were converted to untyped nil.
+- **Task 2 GREEN:** Returning the incoming nil interface from `cloneRank` preserved concrete type identity and made the focused search/clone suite pass.
+- **REFACTOR:** HTTP capture setup was isolated per subtest and all waits were bounded with `time.After(time.Second)`.
+
+## Task Commits
+
+1. **Task 1: Reject nil children at every composite marshal boundary** — `584d073` (`fix`, isolated execution)
+2. **Task 2: Preserve nested typed nils and fail RRF searches cleanly** — `58f3b04` (`fix`, isolated execution)
+3. **Task 3: Correct the earlier GSD receiver claim and mark the RRF contract superseded** — included in the final GSD documentation commit
+
+The two isolated implementation commits were squash-integrated as `b0f52ed`.
+
+## Files Created/Modified
+
+- `pkg/api/v2/rank.go` — Adds the shared marshal guard, accurate operand conversion, and nil-aware RRF validation.
+- `pkg/api/v2/rank_test.go` — Covers all typed-nil receiver compositions, every composite shape, RRF validation, and distinct operand errors.
+- `pkg/api/v2/options.go` — Broadens the public `ErrNilRank` contract comment.
+- `pkg/api/v2/search.go` — Documents option rejection versus direct optional-field omission.
+- `pkg/api/v2/collection_http.go` — Preserves nested typed-nil dynamic types during deep cloning.
+- `pkg/api/v2/collection_http_test.go` — Proves clean nested-RRF failure, exact successful payloads, and bounded request capture.
+- `pkg/api/v2/search_test.go` — Proves typed-nil clone identity and direct omission behavior.
+- Earlier `260731-e0k` PLAN/SUMMARY — Corrects the valid receiver description and marks the former nested-RRF substitution contract superseded.
+
+## Decisions Made
+
+- Kept the fix at serialization and validation boundaries, which covers all composite shapes without duplicating guards across fluent methods.
+- Preserved the intentional asymmetry: `WithRank` rejects nil input, but direct assignment to the optional request field is omitted.
+- Kept historical changes factual: the earlier commit remains recorded as-is, while the later contract change is explicitly attributed to this task.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## Verification
+
+- Task 1 focused suite — passed: `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.447s`.
+- Task 2 focused suite — passed: `ok github.com/amikos-tech/chroma-go/pkg/api/v2 1.364s`.
+- Full basicv2 package suite — passed: `ok github.com/amikos-tech/chroma-go/pkg/api/v2 23.156s`.
+- `make lint` — passed with `0 issues`.
+- Historical record phrase and supersession checks — passed.
+- `git diff --check` for committed code and uncommitted planning changes — passed.
+
+## User Setup Required
+
+None.
+
+## Next Phase Readiness
+
+- The implementation was squash-integrated as `b0f52ed`, and the quick-task ledger records that reachable commit.
+- No follow-up implementation or user setup is required.
+
+## Self-Check: PASSED
+
+All nine planned modified files and the new summary exist, the isolated execution commits were squash-integrated as `b0f52ed`, no tracked files were deleted, no stub markers were introduced, and all diffs pass whitespace validation.

--- a/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
+++ b/.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
@@ -96,7 +96,7 @@ The two isolated implementation commits were squash-integrated as `b0f52ed`.
 ## Files Created/Modified
 
 - `pkg/api/v2/rank.go` — Adds the shared marshal guard, accurate operand conversion, and nil-aware RRF validation.
-- `pkg/api/v2/rank_test.go` — Covers all typed-nil receiver compositions, every composite shape, RRF validation, and distinct operand errors.
+- `pkg/api/v2/rank_test.go` — Covers the ten *KnnRank typed-nil receiver compositions exercised by this task, every composite shape, RRF validation, and distinct operand errors.
 - `pkg/api/v2/options.go` — Broadens the public `ErrNilRank` contract comment.
 - `pkg/api/v2/search.go` — Documents option rejection versus direct optional-field omission.
 - `pkg/api/v2/collection_http.go` — Preserves nested typed-nil dynamic types during deep cloning.

--- a/.planning/quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/260731-fvo-PLAN.md
+++ b/.planning/quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/260731-fvo-PLAN.md
@@ -1,0 +1,187 @@
+---
+phase: quick-260731-fvo
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/rank_test.go
+  - .planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
+autonomous: true
+requirements:
+  - FVO-01
+  - FVO-02
+  - FVO-03
+  - FVO-04
+  - FVO-05
+  - FVO-06
+
+must_haves:
+  truths:
+    - "Calling SumRank.Add, MulRank.Multiply, MaxRank.Max, or MinRank.Min on its typed-nil receiver does not panic while building the expression"
+    - "Expressions built from those typed-nil receivers preserve the invalid receiver and return an error matching ErrNilRank when marshaled"
+    - "SumRank, MulRank, MaxRank, and MinRank reject typed-nil children at the first position and within a three-element slice, not only at index 1 of a two-element slice"
+    - "A directly constructed invalid RrfRank is revalidated by MarshalJSON and rejected without relying on NewRrfRank"
+    - "An untyped nil Operand remains Val(0), and documentation distinguishes that compatibility behavior from typed-nil Rank rejection"
+    - "The prior quick-task summary describes only the typed-nil *KnnRank receiver compositions it actually tested"
+    - "UnknownRank documentation warns that its promoted arithmetic methods operate on the embedded zero-valued ValRank"
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Nil-safe self-flattening builders and precise nil/UnknownRank documentation"
+      contains: "func (s *SumRank) Add"
+    - path: "pkg/api/v2/rank_test.go"
+      provides: "Builder, child-position, direct-RRF-marshal, and compatibility regressions"
+      contains: "TestSelfFlatteningRankTypedNilReceiverMarshal"
+    - path: ".planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md"
+      provides: "Accurate historical description of the earlier receiver coverage"
+      contains: "ten *KnnRank typed-nil receiver compositions"
+  key_links:
+    - from: "pkg/api/v2/rank.go:self-flattening builders"
+      to: "pkg/api/v2/rank.go:marshalRank"
+      via: "a typed-nil receiver is retained as a child instead of dereferenced or discarded"
+      pattern: "marshalRank\\("
+    - from: "pkg/api/v2/rank.go:RrfRank.MarshalJSON"
+      to: "pkg/api/v2/rank.go:RrfRank.Validate"
+      via: "directly constructed RRF state is validated before expression construction"
+      pattern: "r\\.Validate\\(\\)"
+---
+
+<objective>
+Close the remaining typed-nil rank gaps without changing valid rank expression output or the established untyped-nil Operand behavior.
+
+Purpose: four self-flattening builders currently panic before the shared marshal guard can return ErrNilRank, while adjacent tests and documentation overstate or under-specify the protected cases.
+
+Output: nil-safe Sum/Mul/Max/Min self-flattening, broader child-position regressions, a direct invalid-RRF marshal regression, precise compatibility and UnknownRank notes, and corrected historical summary wording.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+@.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
+
+**Locked behavior:**
+- Preserve `operandToRank(nil) -> Val(0)` for an untyped nil Operand; this is an existing compatibility contract and is already pinned by `TestOperandConversion`.
+- Typed-nil Rank receivers or children must remain invalid and eventually return `ErrNilRank`; never make a nil receiver disappear from a successfully marshaled expression.
+- Preserve current flattening and JSON output for non-nil SumRank, MulRank, MaxRank, and MinRank values.
+- Keep UnknownRank as the unsupported-Operand leaf sentinel. Document its promoted-method caveat instead of adding arithmetic overrides that current construction paths do not need.
+- Correct the earlier summary as a historical record; do not claim this follow-up implementation was part of quick task `260731-ewm`.
+- Add no dependency and make no merge.
+</context>
+
+<interfaces>
+From `pkg/api/v2/rank.go`:
+
+```go
+func (s *SumRank) Add(operand Operand) Rank
+func (m *MulRank) Multiply(operand Operand) Rank
+func (m *MaxRank) Max(operand Operand) Rank
+func (m *MinRank) Min(operand Operand) Rank
+func (r *RrfRank) Validate() error
+func (r *RrfRank) MarshalJSON() ([]byte, error)
+func marshalRank(rank Rank) ([]byte, error)
+func operandToRank(operand Operand) Rank
+```
+</interfaces>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Make self-flattening builders nil-safe and close rank regressions</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go</files>
+  <behavior>
+    - "A typed-nil *SumRank.Add, *MulRank.Multiply, *MaxRank.Max, and *MinRank.Min call builds without panic; marshaling each result does not panic and returns ErrNilRank"
+    - "For SumRank, MulRank, MaxRank, and MinRank, a typed-nil child at index 0 of a two-element slice, index 1 of the existing two-element slice, and the middle of a three-element slice returns ErrNilRank without panic"
+    - "Calling MarshalJSON on an invalid &RrfRank value built without NewRrfRank invokes Validate and returns its indexed ErrNilRank failure"
+    - "The existing untyped-nil Operand regression still serializes that operand as Val(0), while typed-nil Rank inputs remain rejected"
+  </behavior>
+  <action>
+    Start with regressions in `pkg/api/v2/rank_test.go`. Add `TestSelfFlatteningRankTypedNilReceiverMarshal` with typed-nil `*SumRank`, `*MulRank`, `*MaxRank`, and `*MinRank` receivers. Exercise only their respective flattening methods (`Add`, `Multiply`, `Max`, and `Min`), wrap expression construction and marshaling in `require.NotPanics`, and require the marshal error to match `ErrNilRank`.
+
+    Expand `TestCompositeRankNilChildMarshal` for each of SumRank, MulRank, MaxRank, and MinRank. Retain the current typed-nil child at index 1 of two elements, and add cases with the child at index 0 of two elements and in the middle of three elements. Every case must marshal under `require.NotPanics` and use `require.ErrorIs(err, ErrNilRank)`.
+
+    Add a direct `RrfRank.MarshalJSON` subtest that constructs `&RrfRank{K: 60, Ranks: ...}` with a typed-nil `*KnnRank` child instead of calling `NewRrfRank`. Require an indexed error matching `ErrNilRank`; this proves `MarshalJSON` calls `Validate` for bypassed constructor state. Keep the existing `TestOperandConversion` case proving that an untyped nil Operand becomes `Val(0)`.
+
+    Run the focused tests and confirm the new four-builder table fails because the builders panic before marshaling. Then update only the four self-flattening methods in `pkg/api/v2/rank.go`. Build `newRanks` without reading `receiver.ranks` until the receiver is known non-nil. For a nil receiver, seed `newRanks` with that typed-nil receiver so the existing `marshalRank` guard reports `ErrNilRank`; for a non-nil receiver, copy its current flattened ranks exactly as today. Preserve the existing same-type operand flattening and all valid JSON shapes.
+
+    Correct the exported `Rank` comment so it says an untyped nil passed through the Operand API becomes `Val(0)` for compatibility, while nil or typed-nil Rank children fail with `ErrNilRank` during marshaling. Extend the `UnknownRank` comment with one concise warning: its promoted arithmetic methods operate on the embedded zero-valued `ValRank` and should not be called directly; normal conversion uses it only as a leaf whose `MarshalJSON` returns the unsupported-operand error. Do not add override methods or change `operandToRank`.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestSelfFlatteningRankTypedNilReceiverMarshal|TestCompositeRankNilChildMarshal|TestRrfRank|TestOperandConversion|TestUnknownRankError)$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>The four self-flattening calls cannot panic on typed-nil receivers, their results fail through ErrNilRank at marshal time, variadic child guards are exercised at the requested positions, direct invalid RRF state is revalidated, untyped nil still becomes Val(0), and comments state both compatibility boundaries plainly.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Correct the earlier receiver-coverage overclaim</name>
+  <files>.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md</files>
+  <action>
+    In the `pkg/api/v2/rank_test.go` bullet under “Files Created/Modified,” replace “Covers all typed-nil receiver compositions” with “Covers the ten *KnnRank typed-nil receiver compositions exercised by this task.” Retain the rest of the bullet's composite, RRF, and operand coverage description. This is a factual correction to what quick task `260731-ewm` tested at that time; do not rewrite its commits, verification results, or accomplishments to include the new SumRank, MulRank, MaxRank, and MinRank builder fix.
+  </action>
+  <verify>
+    <automated>rg -n -F 'Covers the ten *KnnRank typed-nil receiver compositions exercised by this task' .planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md</automated>
+  </verify>
+  <done>The prior summary names the exact *KnnRank receiver coverage it had and no longer implies the four self-flattening builders were covered before this follow-up.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller-provided Rank interface -> fluent self-flattening builder | An interface can dispatch a method on a nil concrete pointer before serialization guards run |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-fvo-01 | Denial of Service | SumRank.Add, MulRank.Multiply, MaxRank.Max, MinRank.Min | mitigate | Avoid nil receiver dereference, preserve the typed-nil receiver for marshal validation, and cover build plus marshal under no-panic tests |
+| T-fvo-02 | Tampering | Variadic composite child traversal | mitigate | Exercise typed nils at the first, existing second, and three-element middle positions for all four slice-backed composites |
+| T-fvo-SC | Tampering | Package installation | accept | This plan adds no dependency and performs no package-manager install |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestSelfFlatteningRankTypedNilReceiverMarshal|TestCompositeRankNilChildMarshal|TestRrfRank|TestOperandConversion|TestUnknownRankError)$' -count=1 -timeout=30s`
+2. `go test -tags=basicv2 ./pkg/api/v2/... -count=1 -timeout=120s`
+3. `make lint`
+4. `git diff --check`
+5. Inspect `git diff -- pkg/api/v2/rank.go pkg/api/v2/rank_test.go .planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md` and confirm the diff contains only the four nil-safe builders, requested tests/comments, and historical wording correction.
+</verification>
+
+<source_coverage_audit>
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | — | Fix typed-nil rank builder panics and close related test/documentation gaps | 01 | COVERED | Tasks 1-2 |
+| REQ | FVO-01 | Four self-flattening builders are safe on typed-nil receivers | 01 | COVERED | Task 1 |
+| REQ | FVO-02 | Composite nil-child tests cover index 0 and a three-element slice | 01 | COVERED | Task 1 |
+| REQ | FVO-03 | Direct invalid RrfRank marshaling proves Validate runs | 01 | COVERED | Task 1 |
+| REQ | FVO-04 | Untyped nil remains Val(0) with precise documentation | 01 | COVERED | Task 1 |
+| REQ | FVO-05 | Prior EWM summary overclaim is corrected historically | 01 | COVERED | Task 2 |
+| REQ | FVO-06 | UnknownRank promoted arithmetic caveat is documented | 01 | COVERED | Task 1 |
+| RESEARCH | — | No research phase | — | EXCLUDED | The task explicitly forbids research and follows established rank patterns |
+| CONTEXT | — | Prefer the least code needed | 01 | COVERED | Four local nil branches and comments; no new helper, dependency, or UnknownRank method matrix |
+| CONTEXT | — | Preserve repository artifact restrictions | 01 | COVERED | Planned artifacts contain no prohibited internal information |
+| CONTEXT | — | Always use squash merge | — | EXCLUDED | No merge is part of this plan |
+</source_coverage_audit>
+
+<success_criteria>
+- The four reported typed-nil builder calls build and marshal without panic, returning ErrNilRank.
+- Variadic composite nil-child coverage includes the first position and a three-element slice for Sum/Mul/Max/Min.
+- Directly marshaling an invalid RrfRank proves constructor bypass cannot skip validation.
+- Untyped nil Operand compatibility remains pinned as Val(0), and the Rank comment no longer implies otherwise.
+- UnknownRank's promoted arithmetic caveat is clear without adding unreachable implementation code.
+- The prior summary precisely limits its historical receiver claim to the ten *KnnRank cases it exercised.
+- Focused tests, the full basicv2 package suite, lint, and diff checks pass.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/260731-fvo-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/260731-fvo-SUMMARY.md
+++ b/.planning/quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/260731-fvo-SUMMARY.md
@@ -1,0 +1,126 @@
+---
+phase: quick-260731-fvo
+plan: 01
+status: complete
+subsystem: api
+tags: [go, rank, typed-nil, rrf, serialization, testing]
+
+requires:
+  - phase: quick-260731-ewm
+    provides: Nil-aware composite rank marshaling and RRF validation
+provides:
+  - Nil-safe SumRank, MulRank, MaxRank, and MinRank self-flattening builders
+  - Composite typed-nil child coverage at the first, second, and three-element middle positions
+  - Direct invalid RrfRank marshal revalidation coverage
+  - Precise nil Operand compatibility and UnknownRank documentation
+  - Corrected historical scope for the earlier typed-nil receiver tests
+affects: [rank arithmetic, RRF validation, rank documentation]
+
+tech-stack:
+  added: []
+  patterns:
+    - Preserve a typed-nil self-flattening receiver as an invalid child for marshal-time validation
+    - Revalidate directly constructed RRF state during MarshalJSON
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/rank_test.go
+    - .planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md
+
+key-decisions:
+  - "Retain a typed-nil self-flattening receiver as the first composite child so marshalRank returns ErrNilRank instead of dropping or dereferencing it."
+  - "Keep operandToRank(nil) as Val(0) for compatibility and document that boundary separately from typed-nil Rank rejection."
+  - "Document UnknownRank's promoted arithmetic caveat instead of adding unused override methods."
+
+patterns-established:
+  - "Nil-safe self-flattening: inspect the receiver before reading its rank slice, while preserving the receiver for later validation."
+
+requirements-completed:
+  - FVO-01
+  - FVO-02
+  - FVO-03
+  - FVO-04
+  - FVO-05
+  - FVO-06
+
+duration: 4 min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-fvo: Typed-Nil Self-Flattening Rank Builder Safety Summary
+
+**Sum, Mul, Max, and Min self-flattening builders now preserve typed-nil receivers for clean `ErrNilRank` failures instead of panicking.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-07-31T08:33:11Z
+- **Completed:** 2026-07-31T08:37:13Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+
+- Made the four self-flattening rank builders safe on typed-nil receivers without changing valid flattening or JSON output.
+- Added regressions for builder construction, composite child positions, and direct invalid `RrfRank` marshaling.
+- Clarified untyped-nil Operand compatibility and the `UnknownRank` promoted-method caveat.
+- Corrected the earlier summary to name only the ten `*KnnRank` receiver compositions it exercised.
+
+## TDD Execution
+
+- **RED:** The focused suite failed in all four new builder cases because `SumRank.Add`, `MulRank.Multiply`, `MaxRank.Max`, and `MinRank.Min` dereferenced typed-nil receivers during expression construction.
+- **GREEN:** Each builder now checks the receiver before reading its rank slice and retains a typed-nil receiver as an invalid child; the focused suite then passed.
+- **REFACTOR:** No separate refactor was needed; the four local guards are the smallest change that preserves existing flattening behavior.
+
+## Task Commits
+
+1. **Task 1: Make self-flattening builders nil-safe and close rank regressions** — `872069b` (`fix`, squash-integrated)
+2. **Task 2: Correct the earlier receiver-coverage overclaim** — included in the final quick-task documentation commit
+
+## Files Created/Modified
+
+- `pkg/api/v2/rank.go` — Adds nil-safe self-flattening and precise public compatibility notes.
+- `pkg/api/v2/rank_test.go` — Covers typed-nil builders, requested child positions, and direct RRF revalidation.
+- `.planning/quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/260731-ewm-SUMMARY.md` — Limits the historical receiver claim to the ten `*KnnRank` cases actually tested.
+
+## Decisions Made
+
+- Preserved typed-nil receivers inside the built composite so the shared marshal guard remains the single rejection boundary.
+- Left `operandToRank` unchanged, preserving the established untyped-nil-to-`Val(0)` contract.
+- Kept the implementation local to the four affected methods; no helper, dependency, or `UnknownRank` method matrix was added.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## Verification
+
+- RED focused run — failed as expected with nil-pointer panics in all four self-flattening builders.
+- Focused regressions — passed: `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.363s`.
+- Full basicv2 package suite — passed: `ok github.com/amikos-tech/chroma-go/pkg/api/v2 23.242s`.
+- `make lint` — passed with `0 issues`.
+- Historical wording check and `git diff --check` — passed.
+- Scoped base-to-worktree diff inspection — contained only the four nil-safe builders, requested tests/comments, and the historical wording correction.
+
+## User Setup Required
+
+None.
+
+## Next Phase Readiness
+
+- Implementation was squash-integrated as `872069b`.
+- No implementation blockers or external setup remain.
+
+## Self-Check: PASSED
+
+All three planned modified files and this summary exist, commit `872069b` is reachable, no tracked files were deleted, and `STATE.md` and `ROADMAP.md` were unchanged during execution.
+
+---
+*Phase: quick-260731-fvo*
+*Completed: 2026-07-31*

--- a/pkg/api/v2/collection_http.go
+++ b/pkg/api/v2/collection_http.go
@@ -469,12 +469,12 @@ func (c *CollectionImpl) embedTextQueries(ctx context.Context, req *SearchReques
 }
 
 // cloneRank creates a deep copy of a rank tree to avoid mutating user-provided rank objects.
-// SearchRequest.Rank is exported, so a struct-literal request can carry a typed nil past
-// WithRank's validation; isNilInterface stops it before the type switch below matches a
-// concrete case and dereferences it.
+// embedTextQueries handles direct nil or typed-nil SearchRequest.Rank values as
+// top-level omission before cloning. Nested typed nils retain their dynamic type
+// so later validation can reject them instead of silently changing semantics.
 func cloneRank(rank Rank) Rank {
 	if isNilInterface(rank) {
-		return nil
+		return rank
 	}
 	switch r := rank.(type) {
 	case *KnnRank:

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -706,20 +706,33 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 	var typedNilRank *KnnRank
 	tests := []struct {
 		name     string
-		rank     Rank
-		wantRank bool
+		searches []SearchRequest
+		expected string
 	}{
 		{
-			name: "direct typed nil rank is omitted",
-			rank: typedNilRank,
+			name:     "direct typed nil rank is omitted",
+			searches: []SearchRequest{{Rank: typedNilRank}},
+			expected: `{"searches":[{}]}`,
 		},
 		{
 			name: "typed nil rank nested in RRF remains valid JSON",
-			rank: &RrfRank{
-				Ranks: []RankWithWeight{{Rank: typedNilRank, Weight: 1}},
-				K:     60,
+			searches: []SearchRequest{
+				{
+					Rank: &RrfRank{
+						Ranks: []RankWithWeight{{Rank: typedNilRank, Weight: 1}},
+						K:     60,
+					},
+				},
 			},
-			wantRank: true,
+			expected: `{"searches":[{"rank":{"$mul":[{"$val":-1},{"$div":{"left":{"$val":1},"right":{"$sum":[{"$val":60},{"$val":0}]}}}]}}]}`,
+		},
+		{
+			name: "typed nil and normal ranks preserve mixed batch order",
+			searches: []SearchRequest{
+				{Rank: typedNilRank},
+				{Rank: Val(2)},
+			},
+			expected: `{"searches":[{},{"rank":{"$val":2}}]}`,
 		},
 	}
 
@@ -755,7 +768,7 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			appendRequest := func(query *SearchQuery) error {
-				query.Searches = append(query.Searches, SearchRequest{Rank: tt.rank})
+				query.Searches = append(query.Searches, tt.searches...)
 				return nil
 			}
 
@@ -767,16 +780,7 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 			require.NoError(t, searchErr)
 			require.NotNil(t, result)
 
-			var payload struct {
-				Searches []map[string]json.RawMessage `json:"searches"`
-			}
-			require.NoError(t, json.Unmarshal(<-requestBodies, &payload))
-			require.Len(t, payload.Searches, 1)
-			rankJSON, hasRank := payload.Searches[0]["rank"]
-			require.Equal(t, tt.wantRank, hasRank)
-			if tt.wantRank {
-				require.NotEqual(t, "null", string(rankJSON))
-			}
+			require.JSONEq(t, tt.expected, string(<-requestBodies))
 		})
 	}
 }
@@ -1229,5 +1233,38 @@ func TestCloneRank(t *testing.T) {
 		clonedJSON, err := cloned.MarshalJSON()
 		require.NoError(t, err)
 		require.Equal(t, string(origJSON), string(clonedJSON))
+	})
+
+	t.Run("multi-level nested RRF tree is deep cloned", func(t *testing.T) {
+		leaf, err := NewKnnRank(KnnQueryText("nested query"), WithKnnReturnRank())
+		require.NoError(t, err)
+		inner, err := NewRrfRank(WithRrfRanks(RankWithWeight{Rank: leaf, Weight: 1}))
+		require.NoError(t, err)
+		middle, err := NewRrfRank(WithRrfRanks(RankWithWeight{Rank: inner, Weight: 1}))
+		require.NoError(t, err)
+		outer, err := NewRrfRank(WithRrfRanks(RankWithWeight{Rank: middle, Weight: 1}))
+		require.NoError(t, err)
+
+		clonedOuter := cloneRank(outer).(*RrfRank)
+		clonedMiddle := clonedOuter.Ranks[0].Rank.(*RrfRank)
+		clonedInner := clonedMiddle.Ranks[0].Rank.(*RrfRank)
+		clonedLeaf := clonedInner.Ranks[0].Rank.(*KnnRank)
+
+		require.NotSame(t, outer, clonedOuter)
+		require.NotSame(t, middle, clonedMiddle)
+		require.NotSame(t, inner, clonedInner)
+		require.NotSame(t, leaf, clonedLeaf)
+
+		var originalJSON, clonedJSON []byte
+		var originalErr, clonedErr error
+		require.NotPanics(t, func() {
+			originalJSON, originalErr = outer.MarshalJSON()
+		})
+		require.NoError(t, originalErr)
+		require.NotPanics(t, func() {
+			clonedJSON, clonedErr = clonedOuter.MarshalJSON()
+		})
+		require.NoError(t, clonedErr)
+		require.JSONEq(t, string(originalJSON), string(clonedJSON))
 	})
 }

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -702,6 +702,85 @@ func TestCollectionQuery(t *testing.T) {
 	require.NotNil(t, r)
 }
 
+func TestCollectionSearchTypedNilRank(t *testing.T) {
+	var typedNilRank *KnnRank
+	tests := []struct {
+		name     string
+		rank     Rank
+		wantRank bool
+	}{
+		{
+			name: "direct typed nil rank is omitted",
+			rank: typedNilRank,
+		},
+		{
+			name: "typed nil rank nested in RRF remains valid JSON",
+			rank: &RrfRank{
+				Ranks: []RankWithWeight{{Rank: typedNilRank, Weight: 1}},
+				K:     60,
+			},
+			wantRank: true,
+		},
+	}
+
+	const searchPath = "/api/v2/tenants/default_tenant/databases/default_database/collections/8ecf0f7e-e806-47f8-96a1-4732ef42359e/search"
+	requestBodies := make(chan []byte, len(tests))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != searchPath {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+
+		requestBodies <- []byte(chhttp.ReadRespBody(r.Body))
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write search response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+	require.NoError(t, err)
+	collection := &CollectionImpl{
+		name:              "test",
+		id:                "8ecf0f7e-e806-47f8-96a1-4732ef42359e",
+		tenant:            NewDefaultTenant(),
+		database:          NewDefaultDatabase(),
+		metadata:          NewMetadata(),
+		client:            client.(*APIClientV2),
+		embeddingFunction: embeddings.NewConsistentHashEmbeddingFunction(),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appendRequest := func(query *SearchQuery) error {
+				query.Searches = append(query.Searches, SearchRequest{Rank: tt.rank})
+				return nil
+			}
+
+			var result SearchResult
+			var searchErr error
+			require.NotPanics(t, func() {
+				result, searchErr = collection.Search(context.Background(), appendRequest)
+			})
+			require.NoError(t, searchErr)
+			require.NotNil(t, result)
+
+			var payload struct {
+				Searches []map[string]json.RawMessage `json:"searches"`
+			}
+			require.NoError(t, json.Unmarshal(<-requestBodies, &payload))
+			require.Len(t, payload.Searches, 1)
+			rankJSON, hasRank := payload.Searches[0]["rank"]
+			require.Equal(t, tt.wantRank, hasRank)
+			if tt.wantRank {
+				require.NotEqual(t, "null", string(rankJSON))
+			}
+		})
+	}
+}
+
 func TestCollectionModifyName(t *testing.T) {
 	rx1 := regexp.MustCompile(`/api/v2/tenants/[^/]+/databases/[^/]+/collections/[^/]+`)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -705,9 +706,10 @@ func TestCollectionQuery(t *testing.T) {
 func TestCollectionSearchTypedNilRank(t *testing.T) {
 	var typedNilRank *KnnRank
 	tests := []struct {
-		name     string
-		searches []SearchRequest
-		expected string
+		name      string
+		searches  []SearchRequest
+		expected  string
+		expectErr bool
 	}{
 		{
 			name:     "direct typed nil rank is omitted",
@@ -715,7 +717,7 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 			expected: `{"searches":[{}]}`,
 		},
 		{
-			name: "typed nil rank nested in RRF remains valid JSON",
+			name: "typed nil rank nested in RRF returns ErrNilRank",
 			searches: []SearchRequest{
 				{
 					Rank: &RrfRank{
@@ -724,7 +726,7 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 					},
 				},
 			},
-			expected: `{"searches":[{"rank":{"$mul":[{"$val":-1},{"$div":{"left":{"$val":1},"right":{"$sum":[{"$val":60},{"$val":0}]}}}]}}]}`,
+			expectErr: true,
 		},
 		{
 			name: "typed nil and normal ranks preserve mixed batch order",
@@ -737,36 +739,36 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 	}
 
 	const searchPath = "/api/v2/tenants/default_tenant/databases/default_database/collections/8ecf0f7e-e806-47f8-96a1-4732ef42359e/search"
-	requestBodies := make(chan []byte, len(tests))
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != searchPath {
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
-			http.NotFound(w, r)
-			return
-		}
-
-		requestBodies <- []byte(chhttp.ReadRespBody(r.Body))
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte(`{}`)); err != nil {
-			t.Errorf("write search response: %v", err)
-		}
-	}))
-	defer server.Close()
-
-	client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
-	require.NoError(t, err)
-	collection := &CollectionImpl{
-		name:              "test",
-		id:                "8ecf0f7e-e806-47f8-96a1-4732ef42359e",
-		tenant:            NewDefaultTenant(),
-		database:          NewDefaultDatabase(),
-		metadata:          NewMetadata(),
-		client:            client.(*APIClientV2),
-		embeddingFunction: embeddings.NewConsistentHashEmbeddingFunction(),
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			requestBodies := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != searchPath {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.NotFound(w, r)
+					return
+				}
+
+				requestBodies <- []byte(chhttp.ReadRespBody(r.Body))
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(`{}`)); err != nil {
+					t.Errorf("write search response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+			require.NoError(t, err)
+			collection := &CollectionImpl{
+				name:              "test",
+				id:                "8ecf0f7e-e806-47f8-96a1-4732ef42359e",
+				tenant:            NewDefaultTenant(),
+				database:          NewDefaultDatabase(),
+				metadata:          NewMetadata(),
+				client:            client.(*APIClientV2),
+				embeddingFunction: embeddings.NewConsistentHashEmbeddingFunction(),
+			}
+
 			appendRequest := func(query *SearchQuery) error {
 				query.Searches = append(query.Searches, tt.searches...)
 				return nil
@@ -777,10 +779,26 @@ func TestCollectionSearchTypedNilRank(t *testing.T) {
 			require.NotPanics(t, func() {
 				result, searchErr = collection.Search(context.Background(), appendRequest)
 			})
+
+			if tt.expectErr {
+				require.Nil(t, result)
+				require.ErrorIs(t, searchErr, ErrNilRank)
+				select {
+				case body := <-requestBodies:
+					t.Fatalf("unexpected request body: %s", body)
+				case <-time.After(time.Second):
+				}
+				return
+			}
+
 			require.NoError(t, searchErr)
 			require.NotNil(t, result)
-
-			require.JSONEq(t, tt.expected, string(<-requestBodies))
+			select {
+			case body := <-requestBodies:
+				require.JSONEq(t, tt.expected, string(body))
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for search request body")
+			}
 		})
 	}
 }

--- a/pkg/api/v2/options.go
+++ b/pkg/api/v2/options.go
@@ -931,7 +931,8 @@ var (
 	// ErrNilFilter is returned when [WithSearchFilter] receives a nil filter.
 	ErrNilFilter = errors.New("filter cannot be nil")
 
-	// ErrNilRank is returned when [WithRank] receives a nil rank.
+	// ErrNilRank is returned when supported rank options, RRF validation, or
+	// composite serialization encounter a nil or typed-nil rank.
 	ErrNilRank = errors.New("rank cannot be nil")
 
 	// ErrNilGroupBy is returned when [WithGroupBy] receives a nil group by.

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -48,6 +48,11 @@ func (f FloatOperand) IsOperand() {}
 // Example - log compression with offset:
 //
 //	rank := NewKnnRank(KnnQueryText("query")).Add(FloatOperand(1)).Log()
+//
+// Expressions containing nil or typed-nil operands or children fail with
+// [ErrNilRank] when marshaled. This guarantee applies at supported option and
+// composite serialization boundaries; directly calling methods on an arbitrary
+// nil concrete Rank pointer is invalid.
 type Rank interface {
 	Operand
 	Multiply(operand Operand) Rank
@@ -64,7 +69,9 @@ type Rank interface {
 	UnmarshalJSON(b []byte) error
 }
 
-// RankWithWeight pairs a Rank with a weight for use in Reciprocal Rank Fusion (RRF).
+// RankWithWeight pairs a non-nil Rank with a weight for use in Reciprocal Rank
+// Fusion (RRF). RRF validation rejects nil and typed-nil Rank values with
+// [ErrNilRank].
 //
 // Create using the WithWeight method on KnnRank:
 //
@@ -75,15 +82,22 @@ type RankWithWeight struct {
 	Weight float64
 }
 
-// UnknownRank is a sentinel type returned by operandToRank when an unknown
-// operand type is encountered. It errors on MarshalJSON to surface programming
-// errors instead of silently producing incorrect results.
+// UnknownRank is a sentinel type returned by operandToRank when an unsupported
+// Operand implementation is encountered. It errors on MarshalJSON to surface
+// programming errors instead of silently producing incorrect results.
 type UnknownRank struct {
 	ValRank
 }
 
 func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
+}
+
+func marshalRank(rank Rank) ([]byte, error) {
+	if isNilRank(rank) {
+		return nil, ErrNilRank
+	}
+	return rank.MarshalJSON()
 }
 
 // ValRank represents a constant numeric value in rank expressions.
@@ -215,7 +229,7 @@ func (s *SumRank) MarshalJSON() ([]byte, error) {
 	}
 	rankMaps := make([]json.RawMessage, len(s.ranks))
 	for i, r := range s.ranks {
-		data, err := r.MarshalJSON()
+		data, err := marshalRank(r)
 		if err != nil {
 			return nil, err
 		}
@@ -278,11 +292,11 @@ func (s *SubRank) Min(operand Operand) Rank {
 }
 
 func (s *SubRank) MarshalJSON() ([]byte, error) {
-	leftData, err := s.left.MarshalJSON()
+	leftData, err := marshalRank(s.left)
 	if err != nil {
 		return nil, err
 	}
-	rightData, err := s.right.MarshalJSON()
+	rightData, err := marshalRank(s.right)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +369,7 @@ func (m *MulRank) MarshalJSON() ([]byte, error) {
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := r.MarshalJSON()
+		data, err := marshalRank(r)
 		if err != nil {
 			return nil, err
 		}
@@ -426,15 +440,15 @@ func (d *DivRank) MarshalJSON() ([]byte, error) {
 	// Check for division by zero literal.
 	// NOTE: Only catches literal Val(0). Complex expressions like Val(1).Sub(Val(1))
 	// are not detected; the server will return Inf/NaN following NumPy semantics.
-	if v, ok := d.right.(*ValRank); ok && v.value == 0 {
+	if v, ok := d.right.(*ValRank); ok && v != nil && v.value == 0 {
 		return nil, errors.New("division by zero: denominator is a zero literal")
 	}
 
-	leftData, err := d.left.MarshalJSON()
+	leftData, err := marshalRank(d.left)
 	if err != nil {
 		return nil, err
 	}
-	rightData, err := d.right.MarshalJSON()
+	rightData, err := marshalRank(d.right)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +510,7 @@ func (a *AbsRank) Min(operand Operand) Rank {
 }
 
 func (a *AbsRank) MarshalJSON() ([]byte, error) {
-	data, err := a.rank.MarshalJSON()
+	data, err := marshalRank(a.rank)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +570,7 @@ func (e *ExpRank) Min(operand Operand) Rank {
 }
 
 func (e *ExpRank) MarshalJSON() ([]byte, error) {
-	data, err := e.rank.MarshalJSON()
+	data, err := marshalRank(e.rank)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +630,7 @@ func (l *LogRank) Min(operand Operand) Rank {
 }
 
 func (l *LogRank) MarshalJSON() ([]byte, error) {
-	data, err := l.rank.MarshalJSON()
+	data, err := marshalRank(l.rank)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +701,7 @@ func (m *MaxRank) MarshalJSON() ([]byte, error) {
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := r.MarshalJSON()
+		data, err := marshalRank(r)
 		if err != nil {
 			return nil, err
 		}
@@ -760,7 +774,7 @@ func (m *MinRank) MarshalJSON() ([]byte, error) {
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := r.MarshalJSON()
+		data, err := marshalRank(r)
 		if err != nil {
 			return nil, err
 		}
@@ -1139,6 +1153,9 @@ func (r *RrfRank) Validate() error {
 		return errors.Errorf("rrf cannot have more than %d ranks", MaxRrfRanks)
 	}
 	for i, rw := range r.Ranks {
+		if isNilRank(rw.Rank) {
+			return errors.Wrapf(ErrNilRank, "rank %d", i)
+		}
 		if rw.Weight < 0 {
 			return errors.Errorf("rank %d has negative weight %v: weights must be non-negative", i, rw.Weight)
 		}
@@ -1249,9 +1266,9 @@ func (r *RrfRank) UnmarshalJSON(_ []byte) error {
 
 // operandToRank converts an Operand to a Rank.
 // Supported operand types: Rank, IntOperand, FloatOperand.
-// An untyped nil is substituted with Val(0) for fluent API chaining. A
-// typed-nil Rank and unknown operand types become *UnknownRank, which errors
-// at MarshalJSON time instead of panicking or producing incorrect results.
+// An untyped nil is substituted with Val(0) for fluent API chaining. A typed-nil
+// Rank becomes a nil Rank so the enclosing composite reports [ErrNilRank].
+// Unsupported Operand implementations become *UnknownRank.
 func operandToRank(operand Operand) Rank {
 	if operand == nil {
 		return Val(0)
@@ -1259,7 +1276,7 @@ func operandToRank(operand Operand) Rank {
 	switch v := operand.(type) {
 	case Rank:
 		if isNilRank(v) {
-			return &UnknownRank{}
+			return nil
 		}
 		return v
 	case IntOperand:

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -1249,15 +1249,18 @@ func (r *RrfRank) UnmarshalJSON(_ []byte) error {
 
 // operandToRank converts an Operand to a Rank.
 // Supported operand types: Rank, IntOperand, FloatOperand.
-// Nil is silently substituted with Val(0) for fluid API chaining. Unknown
-// types return *UnknownRank which errors at MarshalJSON time, surfacing
-// programming errors instead of producing incorrect results.
+// An untyped nil is substituted with Val(0) for fluent API chaining. A
+// typed-nil Rank and unknown operand types become *UnknownRank, which errors
+// at MarshalJSON time instead of panicking or producing incorrect results.
 func operandToRank(operand Operand) Rank {
 	if operand == nil {
 		return Val(0)
 	}
 	switch v := operand.(type) {
 	case Rank:
+		if isNilRank(v) {
+			return &UnknownRank{}
+		}
 		return v
 	case IntOperand:
 		return Val(float64(v))

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -50,7 +50,9 @@ func (f FloatOperand) IsOperand() {}
 //	rank := NewKnnRank(KnnQueryText("query")).Add(FloatOperand(1)).Log()
 //
 // An untyped nil passed through the Operand API becomes Val(0) for compatibility.
-// Nil or typed-nil Rank children fail with [ErrNilRank] when marshaled.
+// Composite serialization rejects nil or typed-nil Rank children with [ErrNilRank].
+// This guarantee does not cover direct MarshalJSON calls on nil concrete Rank
+// pointers; those calls are unsupported and may panic.
 type Rank interface {
 	Operand
 	Multiply(operand Operand) Rank
@@ -496,6 +498,9 @@ func (a *AbsRank) Negate() Rank {
 }
 
 func (a *AbsRank) Abs() Rank {
+	if a == nil {
+		return &AbsRank{rank: a}
+	}
 	return a // abs(abs(x)) = abs(x)
 }
 

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -49,10 +49,8 @@ func (f FloatOperand) IsOperand() {}
 //
 //	rank := NewKnnRank(KnnQueryText("query")).Add(FloatOperand(1)).Log()
 //
-// Expressions containing nil or typed-nil operands or children fail with
-// [ErrNilRank] when marshaled. This guarantee applies at supported option and
-// composite serialization boundaries; directly calling methods on an arbitrary
-// nil concrete Rank pointer is invalid.
+// An untyped nil passed through the Operand API becomes Val(0) for compatibility.
+// Nil or typed-nil Rank children fail with [ErrNilRank] when marshaled.
 type Rank interface {
 	Operand
 	Multiply(operand Operand) Rank
@@ -84,7 +82,9 @@ type RankWithWeight struct {
 
 // UnknownRank is a sentinel type returned by operandToRank when an unsupported
 // Operand implementation is encountered. It errors on MarshalJSON to surface
-// programming errors instead of silently producing incorrect results.
+// programming errors instead of silently producing incorrect results. Its
+// promoted arithmetic methods operate on the embedded zero-valued ValRank and
+// should not be called directly; normal conversion uses it only as a leaf.
 type UnknownRank struct {
 	ValRank
 }
@@ -187,8 +187,11 @@ func (s *SumRank) Sub(operand Operand) Rank {
 
 func (s *SumRank) Add(operand Operand) Rank {
 	r := operandToRank(operand)
-	newRanks := make([]Rank, len(s.ranks))
-	copy(newRanks, s.ranks)
+	newRanks := []Rank{s}
+	if s != nil {
+		newRanks = make([]Rank, len(s.ranks))
+		copy(newRanks, s.ranks)
+	}
 	if sum, ok := r.(*SumRank); ok {
 		return &SumRank{ranks: append(newRanks, sum.ranks...)}
 	}
@@ -319,8 +322,11 @@ func (m *MulRank) IsOperand() {}
 
 func (m *MulRank) Multiply(operand Operand) Rank {
 	r := operandToRank(operand)
-	newRanks := make([]Rank, len(m.ranks))
-	copy(newRanks, m.ranks)
+	newRanks := []Rank{m}
+	if m != nil {
+		newRanks = make([]Rank, len(m.ranks))
+		copy(newRanks, m.ranks)
+	}
 	if mul, ok := r.(*MulRank); ok {
 		return &MulRank{ranks: append(newRanks, mul.ranks...)}
 	}
@@ -683,8 +689,11 @@ func (m *MaxRank) Log() Rank {
 
 func (m *MaxRank) Max(operand Operand) Rank {
 	r := operandToRank(operand)
-	newRanks := make([]Rank, len(m.ranks))
-	copy(newRanks, m.ranks)
+	newRanks := []Rank{m}
+	if m != nil {
+		newRanks = make([]Rank, len(m.ranks))
+		copy(newRanks, m.ranks)
+	}
 	if max, ok := r.(*MaxRank); ok {
 		return &MaxRank{ranks: append(newRanks, max.ranks...)}
 	}
@@ -760,8 +769,11 @@ func (m *MinRank) Max(operand Operand) Rank {
 
 func (m *MinRank) Min(operand Operand) Rank {
 	r := operandToRank(operand)
-	newRanks := make([]Rank, len(m.ranks))
-	copy(newRanks, m.ranks)
+	newRanks := []Rank{m}
+	if m != nil {
+		newRanks = make([]Rank, len(m.ranks))
+		copy(newRanks, m.ranks)
+	}
 	if min, ok := r.(*MinRank); ok {
 		return &MinRank{ranks: append(newRanks, min.ranks...)}
 	}

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/amikos-tech/chroma-go/pkg/embeddings"
 )
 
+type unsupportedOperand struct{}
+
+func (unsupportedOperand) IsOperand() {}
+
 // mustNewKnnRank is a test helper that panics if NewKnnRank returns an error
 func mustNewKnnRank(t *testing.T, query KnnQueryOption, knnOptions ...KnnOption) *KnnRank {
 	t.Helper()
@@ -356,8 +360,74 @@ func TestRankArithmeticTypedNilOperandMarshal(t *testing.T) {
 			require.NotPanics(t, func() {
 				_, err = rank.MarshalJSON()
 			})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "unknown operand type")
+			require.ErrorIs(t, err, ErrNilRank)
+		})
+	}
+}
+
+func TestRankTypedNilReceiverMarshal(t *testing.T) {
+	var knn *KnnRank
+	var rankReceiver Rank = knn
+
+	tests := []struct {
+		name  string
+		build func() Rank
+	}{
+		{name: "Add through Rank interface", build: func() Rank { return rankReceiver.Add(Val(1)) }},
+		{name: "Multiply", build: func() Rank { return knn.Multiply(Val(1)) }},
+		{name: "Sub", build: func() Rank { return knn.Sub(Val(1)) }},
+		{name: "Div", build: func() Rank { return knn.Div(Val(1)) }},
+		{name: "Max", build: func() Rank { return knn.Max(Val(1)) }},
+		{name: "Min", build: func() Rank { return knn.Min(Val(1)) }},
+		{name: "Negate", build: func() Rank { return knn.Negate() }},
+		{name: "Abs", build: func() Rank { return knn.Abs() }},
+		{name: "Exp", build: func() Rank { return knn.Exp() }},
+		{name: "Log", build: func() Rank { return knn.Log() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rank Rank
+			require.NotPanics(t, func() {
+				rank = tt.build()
+			})
+
+			var err error
+			require.NotPanics(t, func() {
+				_, err = rank.MarshalJSON()
+			})
+			require.ErrorIs(t, err, ErrNilRank)
+		})
+	}
+}
+
+func TestCompositeRankNilChildMarshal(t *testing.T) {
+	var child *KnnRank
+
+	tests := []struct {
+		name string
+		rank Rank
+	}{
+		{name: "SumRank", rank: &SumRank{ranks: []Rank{Val(1), child}}},
+		{name: "SubRank left", rank: &SubRank{left: child, right: Val(1)}},
+		{name: "SubRank right", rank: &SubRank{left: Val(1), right: child}},
+		{name: "MulRank", rank: &MulRank{ranks: []Rank{Val(1), child}}},
+		{name: "DivRank left", rank: &DivRank{left: child, right: Val(1)}},
+		{name: "DivRank right", rank: &DivRank{left: Val(1), right: child}},
+		{name: "AbsRank", rank: &AbsRank{rank: child}},
+		{name: "ExpRank", rank: &ExpRank{rank: child}},
+		{name: "LogRank", rank: &LogRank{rank: child}},
+		{name: "MaxRank", rank: &MaxRank{ranks: []Rank{Val(1), child}}},
+		{name: "MinRank", rank: &MinRank{ranks: []Rank{Val(1), child}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = tt.rank.MarshalJSON()
+			})
+			require.ErrorIs(t, err, ErrNilRank)
 		})
 	}
 }
@@ -515,6 +585,22 @@ func TestRrfRank(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "overflowed")
 	})
+
+	for _, tt := range []struct {
+		name string
+		rank Rank
+	}{
+		{name: "nil rank", rank: nil},
+		{name: "typed nil rank", rank: (*KnnRank)(nil)},
+	} {
+		t.Run("rrf rejects "+tt.name, func(t *testing.T) {
+			_, err := NewRrfRank(
+				WithRrfRanks(RankWithWeight{Rank: tt.rank, Weight: 1}),
+			)
+			require.ErrorIs(t, err, ErrNilRank)
+			require.Contains(t, err.Error(), "rank 0")
+		})
+	}
 }
 
 func TestRrfRankArithmetic(t *testing.T) {
@@ -671,6 +757,22 @@ func TestOperandConversion(t *testing.T) {
 		data, err := rank.MarshalJSON()
 		require.NoError(t, err)
 		require.JSONEq(t, `{"$mul":[{"$val":1},{"$val":2.5}]}`, string(data))
+	})
+
+	t.Run("untyped nil operand becomes zero", func(t *testing.T) {
+		var operand Operand
+		rank := Val(1.0).Add(operand)
+		data, err := rank.MarshalJSON()
+		require.NoError(t, err)
+		require.JSONEq(t, `{"$sum":[{"$val":1},{"$val":0}]}`, string(data))
+	})
+
+	t.Run("unsupported operand remains unknown", func(t *testing.T) {
+		rank := Val(1.0).Add(unsupportedOperand{})
+		_, err := rank.MarshalJSON()
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrNilRank)
+		require.Contains(t, err.Error(), "unknown operand type")
 	})
 }
 

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -401,6 +401,38 @@ func TestRankTypedNilReceiverMarshal(t *testing.T) {
 	}
 }
 
+func TestSelfFlatteningRankTypedNilReceiverMarshal(t *testing.T) {
+	var sum *SumRank
+	var mul *MulRank
+	var max *MaxRank
+	var min *MinRank
+
+	tests := []struct {
+		name  string
+		build func() Rank
+	}{
+		{name: "SumRank.Add", build: func() Rank { return sum.Add(Val(1)) }},
+		{name: "MulRank.Multiply", build: func() Rank { return mul.Multiply(Val(1)) }},
+		{name: "MaxRank.Max", build: func() Rank { return max.Max(Val(1)) }},
+		{name: "MinRank.Min", build: func() Rank { return min.Min(Val(1)) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rank Rank
+			require.NotPanics(t, func() {
+				rank = tt.build()
+			})
+
+			var err error
+			require.NotPanics(t, func() {
+				_, err = rank.MarshalJSON()
+			})
+			require.ErrorIs(t, err, ErrNilRank)
+		})
+	}
+}
+
 func TestCompositeRankNilChildMarshal(t *testing.T) {
 	var child *KnnRank
 
@@ -408,17 +440,25 @@ func TestCompositeRankNilChildMarshal(t *testing.T) {
 		name string
 		rank Rank
 	}{
-		{name: "SumRank", rank: &SumRank{ranks: []Rank{Val(1), child}}},
+		{name: "SumRank first of two", rank: &SumRank{ranks: []Rank{child, Val(1)}}},
+		{name: "SumRank second of two", rank: &SumRank{ranks: []Rank{Val(1), child}}},
+		{name: "SumRank middle of three", rank: &SumRank{ranks: []Rank{Val(1), child, Val(2)}}},
 		{name: "SubRank left", rank: &SubRank{left: child, right: Val(1)}},
 		{name: "SubRank right", rank: &SubRank{left: Val(1), right: child}},
-		{name: "MulRank", rank: &MulRank{ranks: []Rank{Val(1), child}}},
+		{name: "MulRank first of two", rank: &MulRank{ranks: []Rank{child, Val(1)}}},
+		{name: "MulRank second of two", rank: &MulRank{ranks: []Rank{Val(1), child}}},
+		{name: "MulRank middle of three", rank: &MulRank{ranks: []Rank{Val(1), child, Val(2)}}},
 		{name: "DivRank left", rank: &DivRank{left: child, right: Val(1)}},
 		{name: "DivRank right", rank: &DivRank{left: Val(1), right: child}},
 		{name: "AbsRank", rank: &AbsRank{rank: child}},
 		{name: "ExpRank", rank: &ExpRank{rank: child}},
 		{name: "LogRank", rank: &LogRank{rank: child}},
-		{name: "MaxRank", rank: &MaxRank{ranks: []Rank{Val(1), child}}},
-		{name: "MinRank", rank: &MinRank{ranks: []Rank{Val(1), child}}},
+		{name: "MaxRank first of two", rank: &MaxRank{ranks: []Rank{child, Val(1)}}},
+		{name: "MaxRank second of two", rank: &MaxRank{ranks: []Rank{Val(1), child}}},
+		{name: "MaxRank middle of three", rank: &MaxRank{ranks: []Rank{Val(1), child, Val(2)}}},
+		{name: "MinRank first of two", rank: &MinRank{ranks: []Rank{child, Val(1)}}},
+		{name: "MinRank second of two", rank: &MinRank{ranks: []Rank{Val(1), child}}},
+		{name: "MinRank middle of three", rank: &MinRank{ranks: []Rank{Val(1), child, Val(2)}}},
 	}
 
 	for _, tt := range tests {
@@ -601,6 +641,20 @@ func TestRrfRank(t *testing.T) {
 			require.Contains(t, err.Error(), "rank 0")
 		})
 	}
+
+	t.Run("direct invalid rrf is revalidated on marshal", func(t *testing.T) {
+		var rank *KnnRank
+		rrf := &RrfRank{
+			K: 60,
+			Ranks: []RankWithWeight{
+				{Rank: rank, Weight: 1},
+			},
+		}
+
+		_, err := rrf.MarshalJSON()
+		require.ErrorIs(t, err, ErrNilRank)
+		require.Contains(t, err.Error(), "rank 0")
+	})
 }
 
 func TestRrfRankArithmetic(t *testing.T) {

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -406,6 +406,7 @@ func TestSelfFlatteningRankTypedNilReceiverMarshal(t *testing.T) {
 	var mul *MulRank
 	var max *MaxRank
 	var min *MinRank
+	var abs *AbsRank
 
 	tests := []struct {
 		name  string
@@ -415,6 +416,7 @@ func TestSelfFlatteningRankTypedNilReceiverMarshal(t *testing.T) {
 		{name: "MulRank.Multiply", build: func() Rank { return mul.Multiply(Val(1)) }},
 		{name: "MaxRank.Max", build: func() Rank { return max.Max(Val(1)) }},
 		{name: "MinRank.Min", build: func() Rank { return min.Min(Val(1)) }},
+		{name: "AbsRank.Abs", build: func() Rank { return abs.Abs() }},
 	}
 
 	for _, tt := range tests {

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -334,6 +334,34 @@ func TestUnknownRankError(t *testing.T) {
 	})
 }
 
+func TestRankArithmeticTypedNilOperandMarshal(t *testing.T) {
+	var operand *KnnRank
+
+	tests := []struct {
+		name  string
+		build func() Rank
+	}{
+		{name: "Add", build: func() Rank { return Val(1).Add(operand) }},
+		{name: "Multiply", build: func() Rank { return Val(1).Multiply(operand) }},
+		{name: "Sub", build: func() Rank { return Val(1).Sub(operand) }},
+		{name: "Div", build: func() Rank { return Val(1).Div(operand) }},
+		{name: "Max", build: func() Rank { return Val(1).Max(operand) }},
+		{name: "Min", build: func() Rank { return Val(1).Min(operand) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rank := tt.build()
+			var err error
+			require.NotPanics(t, func() {
+				_, err = rank.MarshalJSON()
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unknown operand type")
+		})
+	}
+}
+
 func TestComplexExpressions(t *testing.T) {
 	t.Run("weighted combination", func(t *testing.T) {
 		// weighted_combo = knn1 * 0.7 + knn2 * 0.3

--- a/pkg/api/v2/search.go
+++ b/pkg/api/v2/search.go
@@ -286,7 +286,9 @@ type SearchRequest struct {
 	// Limit specifies pagination (limit and offset).
 	Limit *SearchPage `json:"limit,omitempty"`
 
-	// Rank specifies the ranking expression (e.g., KNN similarity).
+	// Rank specifies the optional ranking expression (e.g., KNN similarity).
+	// Direct assignment of nil or a typed nil is omitted by MarshalJSON and
+	// Collection.Search. Use [WithRank] when nil input should be rejected.
 	Rank Rank `json:"rank,omitempty"`
 
 	// Select specifies which fields to include in results.
@@ -628,9 +630,11 @@ type rankOption struct {
 //	    ),
 //	)
 //
-// Passing nil causes the enclosing search request to fail with [ErrNilRank] instead of
-// being treated as omission — callers who want to omit the rank should simply not call
-// this option.
+// Passing nil or a typed nil causes the enclosing search request to fail with
+// [ErrNilRank] when the option is applied. This differs from direct assignment
+// to the optional [SearchRequest.Rank] field, where nil and typed nil are omitted
+// by SearchRequest.MarshalJSON and Collection.Search. Callers who want omission
+// should simply not call this option.
 func WithRank(rank Rank) *rankOption {
 	return &rankOption{rank: rank}
 }

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1139,26 +1139,34 @@ func TestTypedNilWhereBypassesOptionPipeline(t *testing.T) {
 	})
 }
 
-// TestCloneRankTypedNil covers the rank clone/embed path reached by constructing a
-// SearchRequest as a struct literal: SearchRequest.Rank is exported, so WithRank's
-// isNilRank guard is bypassed and a typed nil reaches cloneRank's type switch, where
-// `case *KnnRank:` matches a nil *KnnRank and the deref panics.
+// TestCloneRankTypedNil covers direct typed-nil omission and nested typed-nil
+// preservation through the clone/embed path.
 func TestCloneRankTypedNil(t *testing.T) {
-	t.Run("typed nil KnnRank clones to true nil", func(t *testing.T) {
+	t.Run("untyped nil remains nil", func(t *testing.T) {
+		require.Nil(t, cloneRank(nil))
+	})
+
+	t.Run("typed nil KnnRank retains its concrete type", func(t *testing.T) {
 		var kr *KnnRank
 		var got Rank
 		require.NotPanics(t, func() { got = cloneRank(kr) })
-		require.Nil(t, got)
+		require.True(t, isNilRank(got))
+		cloned, ok := got.(*KnnRank)
+		require.True(t, ok)
+		require.Nil(t, cloned)
 	})
 
-	t.Run("typed nil ValRank clones to true nil", func(t *testing.T) {
+	t.Run("typed nil ValRank retains its concrete type", func(t *testing.T) {
 		var vr *ValRank
 		var got Rank
 		require.NotPanics(t, func() { got = cloneRank(vr) })
-		require.Nil(t, got)
+		require.True(t, isNilRank(got))
+		cloned, ok := got.(*ValRank)
+		require.True(t, ok)
+		require.Nil(t, cloned)
 	})
 
-	t.Run("typed nil nested in RrfRank clones without panicking", func(t *testing.T) {
+	t.Run("typed nil nested in RrfRank retains its concrete type", func(t *testing.T) {
 		var kr *KnnRank
 		parent := &RrfRank{Ranks: []RankWithWeight{{Rank: kr, Weight: 1}}}
 		var got Rank
@@ -1167,16 +1175,20 @@ func TestCloneRankTypedNil(t *testing.T) {
 		clone, ok := got.(*RrfRank)
 		require.True(t, ok)
 		require.Len(t, clone.Ranks, 1)
-		require.Nil(t, clone.Ranks[0].Rank)
+		require.True(t, isNilRank(clone.Ranks[0].Rank))
+		clonedChild, ok := clone.Ranks[0].Rank.(*KnnRank)
+		require.True(t, ok)
+		require.Nil(t, clonedChild)
 	})
 
-	t.Run("embedTextQueries tolerates a typed nil Rank on a struct-literal request", func(t *testing.T) {
+	t.Run("embedTextQueries omits a direct typed nil Rank", func(t *testing.T) {
 		var kr *KnnRank
 		req := &SearchRequest{Rank: kr}
 		c := &CollectionImpl{}
 		var err error
 		require.NotPanics(t, func() { err = c.embedTextQueries(context.Background(), req) })
 		require.NoError(t, err)
+		require.Nil(t, req.Rank)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes #515 — `cloneRank` and rank marshaling panicked on typed-nil `Rank` values (e.g. a nil `*KnnRank` passed as a fluent-arithmetic operand or nested inside an RRF composite), because a typed-nil pointer is a non-nil interface value and slips past plain `== nil` checks.

This branch closes the defect across every entry point a caller can reach: arithmetic operands, composite marshaling, RRF cloning/validation, and the self-flattening builders (`Sum`/`Mul`/`Max`/`Min`/`Abs`). Nil and typed-nil `Rank` values now fail cleanly with `ErrNilRank` (or the existing `UnknownRank` marshal error for arithmetic operands) instead of crashing the process mid-request.

## Changes

### Typed-nil rank arithmetic operands (`b3ef969`)
Reused a shared `isNilRank` guard in `operandToRank` so all six fluent binary operations (`Add`, `Sub`, `Multiply`, `Div`, `Max`, `Min`) reject a typed-nil `Rank` operand during marshal instead of panicking. Untyped `nil` keeps its existing `Val(0)` fallback.

### Composite marshal and nested RRF safety (`b0f52ed`)
Routed all nine composite rank serializers through one nil-aware `marshalRank` helper, so a typed-nil child anywhere in a composite tree returns `ErrNilRank` instead of being dereferenced. Nested typed-nil RRF children are preserved (not silently substituted with `Val(0)`) through cloning, so RRF validation rejects them before any HTTP request is sent.

### Self-flattening builder safety (`872069b`, `0498fee`)
`SumRank.Add`, `MulRank.Multiply`, `MaxRank.Max`, `MinRank.Min`, and `AbsRank.Abs` now check their receiver before reading its internal rank slice, preserving a typed-nil receiver as an invalid child for the shared marshal guard to catch, rather than dereferencing it directly.

**Key files:**
- `pkg/api/v2/rank.go` — nil-aware operand conversion, composite marshal guard, self-flattening builder safety, RRF validation
- `pkg/api/v2/rank_test.go` — typed-nil coverage for arithmetic operands, composite positions, self-flattening builders, direct RRF revalidation
- `pkg/api/v2/collection_http.go` / `collection_http_test.go` — nested-clone identity preservation, exact HTTP payload regressions
- `pkg/api/v2/search.go` / `search_test.go` — documents optional-field omission vs. rejection asymmetry
- `pkg/api/v2/options.go` — `ErrNilRank` contract documentation

## Verification

- `go test -tags=basicv2 ./pkg/api/v2/... -count=1` — passed after each change
- `make lint` — passed, 0 issues
- Each fix followed RED/GREEN TDD: a focused regression reproduced the panic first, then the guard made it pass
- No formal phase VERIFICATION.md exists for this work — it shipped as a chain of quick tasks (260730-u7z, 260731-e0k, 260731-ewm, 260731-fvo), each with its own passing Self-Check and test/lint evidence in `.planning/quick/`

## Key Decisions

- Centralized the fix at the shared serialization/validation boundaries (`operandToRank`, `marshalRank`, RRF validation) instead of adding a guard to every fluent method individually
- Kept untyped `nil` → `Val(0)` compatibility behavior unchanged; only typed-nil `Rank` values are rejected
- Preserved nested typed-nil identity through cloning so RRF validation can distinguish an invalid child from an intentionally omitted top-level field
