### PR TITLE
docs(rank): document nil-receiver panic on UnknownRank promoted methods

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 30
 Plan: Not started
 Status: Quick task chain (u7z/e0k/ewm/fvo) shipped — PR #527
-Last activity: 2026-07-31
+Last activity: 2026-07-31 - Completed quick task 260731-n7b: Document nil-receiver panic on UnknownRank promoted methods (GH #526)
 
 Progress: [██████████] 100%
 
@@ -80,6 +80,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-e0k | Address typed-nil rank arithmetic and review findings | 2026-07-31 | b3ef969 | Verified | [260731-e0k-address-typed-nil-rank-arithmetic-and-re](./quick/260731-e0k-address-typed-nil-rank-arithmetic-and-re/) |
 | 260731-ewm | Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records | 2026-07-31 | b0f52ed | Verified | [260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil](./quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/) |
 | 260731-fvo | Fix typed-nil rank builder panics and close related tests and documentation gaps | 2026-07-31 | 872069b | Complete | [260731-fvo-fix-typed-nil-rank-builder-panics-and-cl](./quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/) |
+| 260731-n7b | Document nil-receiver panic on UnknownRank promoted methods (GH #526) | 2026-07-31 | 3c0aa73 | Complete | [260731-n7b-fix-526-document-nil-receiver-panic-on-u](./quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/260731-n7b-PLAN.md
+++ b/.planning/quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/260731-n7b-PLAN.md
@@ -1,0 +1,201 @@
+---
+phase: quick-260731-n7b
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+autonomous: true
+requirements: [GH-526]
+
+must_haves:
+  truths:
+    - "A developer reading UnknownRank's godoc learns that calling any promoted arithmetic method (or IsOperand) on a nil *UnknownRank panics."
+    - "The doc explains WHY it panics: ValRank is embedded by value, so Go's promoted-method call dereferences the receiver before the method body runs."
+    - "The doc frames this as the same class of unsupported usage as the existing Rank interface nil-pointer caveat, not as a bug to be fixed."
+    - "No runtime behavior of UnknownRank, ValRank, or operandToRank changes."
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Updated UnknownRank doc comment with nil-receiver caveat"
+      contains: "type UnknownRank struct"
+  key_links:
+    - from: "pkg/api/v2/rank.go (UnknownRank doc)"
+      to: "pkg/api/v2/rank.go (Rank interface doc, lines 52-55)"
+      via: "consistent unsupported-usage phrasing"
+      pattern: "unsupported"
+---
+
+<objective>
+Document the nil-receiver panic on `*UnknownRank`'s promoted arithmetic methods in
+`pkg/api/v2/rank.go`, closing GitHub issue #526.
+
+Purpose: `UnknownRank` embeds `ValRank` **by value**. Go desugars a promoted-method
+call `u.Add(x)` to `(*u).ValRank.Add(x)`, which dereferences `u` to materialize the
+embedded field before the method body ever runs. A nil `*UnknownRank` therefore panics
+on every promoted method — including `IsOperand()`, whose body is empty. Issue #526
+evaluated changing the embedding to `*ValRank` and rejected it: `UnknownRank` is
+exported only so `operandToRank` can return it as a `Rank`, has no exported
+constructor, and `operandToRank` only ever returns a non-nil `&UnknownRank{}`
+(rank.go:1304). Real-world reachability is effectively nil, so the correct fix is to
+document the boundary rather than rework the type.
+
+Output: An expanded doc comment on `UnknownRank`. No code logic, no new tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@CLAUDE.md
+
+@pkg/api/v2/rank.go
+
+<interfaces>
+<!-- Current state of the code being documented. No exploration needed. -->
+
+pkg/api/v2/rank.go:85-96 — the target of this change:
+
+```go
+// UnknownRank is a sentinel type returned by operandToRank when an unsupported
+// Operand implementation is encountered. It errors on MarshalJSON to surface
+// programming errors instead of silently producing incorrect results. Its
+// promoted arithmetic methods operate on the embedded zero-valued ValRank and
+// should not be called directly; normal conversion uses it only as a leaf.
+type UnknownRank struct {
+	ValRank
+}
+
+func (u *UnknownRank) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
+}
+```
+
+pkg/api/v2/rank.go:52-55 — the existing precedent whose tone and framing this change
+must match:
+
+```go
+// An untyped nil passed through the Operand API becomes Val(0) for compatibility.
+// Composite serialization rejects nil or typed-nil Rank children with [ErrNilRank].
+// This guarantee does not cover direct MarshalJSON calls on nil concrete Rank
+// pointers; those calls are unsupported and may panic.
+```
+
+Methods promoted from `*ValRank` onto `*UnknownRank`: `IsOperand`, `Multiply`, `Sub`,
+`Add`, `Div`, `Negate`, `Abs`, `Exp`, `Log`, `Max`, `Min`. (`MarshalJSON` is NOT
+promoted — `*UnknownRank` defines its own at line 94.)
+
+Only construction site, rank.go:1288-1304:
+```go
+// Unsupported Operand implementations become *UnknownRank.
+...
+	return &UnknownRank{}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Document the nil-receiver panic boundary on UnknownRank</name>
+  <files>pkg/api/v2/rank.go</files>
+  <action>
+Extend the existing doc comment immediately above `type UnknownRank struct` (currently
+rank.go:85-89). Keep the existing four-sentence body intact — it correctly describes the
+sentinel role, the MarshalJSON error, and the leaf-only usage — and append a short
+caveat paragraph after it.
+
+The appended text must convey three things, in godoc prose matching the surrounding
+style (plain `//` comment lines, no code fences, sentence case, wrapped near the file's
+existing ~78-column comment width):
+
+1. Calling any promoted method on a nil `*UnknownRank` panics — name that this includes
+   `IsOperand`, whose body is empty, so the panic is not about what the method does.
+2. The reason: `ValRank` is embedded by value, so Go's promoted-method call convention
+   dereferences the receiver to reach the embedded field before invoking the method.
+3. The framing: this is unsupported usage, in the same class as the nil-concrete-pointer
+   `MarshalJSON` caveat documented on the [Rank] interface. Reference `[Rank]` with
+   godoc link brackets so it renders as a link, mirroring how `[ErrNilRank]`,
+   `[IntOperand]`, and `[FloatOperand]` are already referenced in this file.
+
+Additionally state that `UnknownRank` has no exported constructor and callers obtain it
+only as a non-nil value from internal conversion — this is what makes the boundary
+acceptable rather than a defect, and it preempts the "why not just fix it" question for
+the next reader.
+
+Scope guardrails — this task is comment-only. Do NOT:
+- change `ValRank` to `*ValRank` in the struct (issue #526 explicitly rejected this),
+- add nil-receiver checks, `recover()`, or fallbacks to any `*ValRank` or `*UnknownRank`
+  method,
+- add a constructor (exported or unexported) for `UnknownRank`,
+- add or modify tests — `UnknownRank`'s runtime behavior is unchanged, so
+  `pkg/api/v2/rank_test.go:324-334` stays as-is,
+- touch the [Rank] interface doc at lines 52-55 — it is the reference precedent, not a
+  target.
+
+The only diff in this task should be added `//` comment lines. If `git diff` shows any
+non-comment line changed, revert that hunk.
+
+Closing the loop on issue #526: the orchestrator closes the GitHub issue after this plan
+executes. Do NOT run `gh issue close` — issue closure happens outside plan execution.
+  </action>
+  <verify>
+    <automated>go build ./... && go vet ./pkg/api/v2/... && CHANGED=$(git diff -U0 -- pkg/api/v2/rank.go | grep -cE '^[+-][^+-]' || true) && NONCOMMENT=$(git diff -U0 -- pkg/api/v2/rank.go | grep -E '^[+-][^+-]' | grep -vcE '^[+-][[:space:]]*//' || true) && [ "$CHANGED" != "0" ] && [ "$NONCOMMENT" = "0" ] && echo "COMMENT-ONLY DIFF CONFIRMED ($CHANGED lines)"</automated>
+  </verify>
+  <done>
+- `go build ./...` succeeds and `go vet ./pkg/api/v2/...` reports nothing.
+- The verify command prints "COMMENT-ONLY DIFF CONFIRMED (N lines)" with N greater than
+  zero, proving the doc actually changed AND that every changed line is a comment line.
+  A zero-line diff fails the gate, so a no-op cannot pass as success.
+- `UnknownRank`'s godoc states that promoted methods panic on a nil receiver, names the
+  value-embedding dereference as the cause, notes `IsOperand` panics despite its empty
+  body, and links `[Rank]` when framing this as unsupported usage.
+- `git diff --stat` lists `pkg/api/v2/rank.go` as the only modified file.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none crossed) | Comment-only change. No input parsing, no serialization path, no network or filesystem I/O is added or modified. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-n7b-01 | Denial of Service | `*UnknownRank` promoted methods on a nil receiver | accept | Documented, not mitigated. Per issue #526: no exported constructor exists, `operandToRank` returns only non-nil `&UnknownRank{}` (rank.go:1304), so an attacker-reachable nil `*UnknownRank` cannot be produced through any public API. Documenting the boundary is the agreed disposition. |
+| T-n7b-02 | Tampering | Scope creep into `ValRank` runtime behavior | mitigate | The verify gate mechanically rejects any non-comment diff line in rank.go, so no logic change can land under this plan. |
+| T-n7b-SC | Tampering | npm/pip/cargo installs | n/a | No dependency changes. `go.mod` and `go.sum` are untouched; no package-manager install tasks in this plan. |
+</threat_model>
+
+<verification>
+1. `go build ./...` — the package compiles with the edited comment.
+2. `go vet ./pkg/api/v2/...` — no vet diagnostics.
+3. `git diff -- pkg/api/v2/rank.go` — the diff is non-empty and every changed line
+   begins with `//`. (`grep -c` is filtered with `grep -vcE '^[+-][[:space:]]*//'` rather
+   than counting raw lines, so comment prose cannot self-invalidate the gate.)
+4. `git diff --stat` — `pkg/api/v2/rank.go` is the only file touched.
+5. `make lint` — per CLAUDE.md, lint must pass before committing.
+6. Read the rendered doc (`go doc github.com/amikos-tech/chroma-go/pkg/api/v2.UnknownRank`)
+   and confirm the caveat reads clearly and the `[Rank]` link is well-formed.
+</verification>
+
+<success_criteria>
+- A developer running `go doc ...v2.UnknownRank` learns the nil-receiver panic exists,
+  why it exists (value embedding dereferences the receiver), that it affects even
+  `IsOperand`, and that it is unsupported usage rather than a latent bug.
+- Zero behavioral change: no test file edits, no logic edits, `go test` results for
+  `pkg/api/v2` are identical to pre-change.
+- GitHub issue #526 is resolvable by the orchestrator on the strength of this doc alone.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/260731-n7b-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/260731-n7b-SUMMARY.md
+++ b/.planning/quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/260731-n7b-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: quick-260731-n7b
+plan: 01
+subsystem: api
+tags: [go, godoc, rank, v2-api, nil-safety]
+
+requires:
+  - phase: quick-260731-fvo
+    provides: typed-nil Rank guard work that established the nil-handling doc precedent on the Rank interface
+provides:
+  - "UnknownRank godoc documenting the nil-receiver panic on promoted methods, its cause, and why it is unsupported usage rather than a defect"
+affects: [rank, v2-search, nil-handling-docs]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Nil-receiver boundaries on unconstructable sentinel types are documented, not defended, when the public API cannot produce a nil instance"
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+
+key-decisions:
+  - "Documented the nil *UnknownRank panic instead of switching the embedded ValRank to *ValRank — issue #526 rejected the type rework since UnknownRank has no exported constructor and operandToRank only ever returns a non-nil &UnknownRank{}."
+  - "Matched the existing Rank interface nil-pointer caveat wording (unsupported usage) so both boundaries read as one policy rather than two unrelated warnings."
+
+patterns-established:
+  - "Godoc link brackets ([Rank]) used when cross-referencing the interface-level nil contract from concrete type docs"
+
+requirements-completed: [GH-526]
+
+duration: 6min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-n7b: Document UnknownRank nil-receiver panic Summary
+
+**UnknownRank's godoc now explains that promoted methods (including the empty-bodied IsOperand) panic on a nil receiver because ValRank is embedded by value, and frames it as unsupported usage unreachable through the public API.**
+
+## Performance
+
+- **Duration:** ~6 min
+- **Started:** 2026-07-31T11:34:00Z
+- **Completed:** 2026-07-31T11:40:00Z
+- **Tasks:** 1
+- **Files modified:** 1
+
+## Accomplishments
+
+- Appended a caveat paragraph to the `UnknownRank` doc comment covering all three required points: that promoted methods panic on a nil `*UnknownRank`, that value embedding of `ValRank` makes the call convention dereference the receiver before the method body runs, and that `IsOperand` panics despite an empty body.
+- Linked `[Rank]` with godoc brackets so the caveat reads as an extension of the existing interface-level nil-pointer contract (rank.go:52-55) rather than a separate warning.
+- Stated that `UnknownRank` has no exported constructor and is only ever handed out as a non-nil value from internal conversion, preempting the "why not just fix it" question for the next reader.
+- Kept the change strictly comment-only — the plan's mechanical gate confirmed 9 changed lines, 0 of them non-comment.
+
+## Task Commits
+
+1. **Task 1: Document the nil-receiver panic boundary on UnknownRank** - `3c0aa73` (docs)
+
+## Files Created/Modified
+
+- `pkg/api/v2/rank.go` - Added a 9-line caveat paragraph to the `UnknownRank` doc comment (lines 90-98); the struct, its `MarshalJSON`, and all `ValRank` methods are byte-identical.
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `go build ./...` | Clean |
+| `go vet ./pkg/api/v2/...` | No diagnostics |
+| Comment-only diff gate | `COMMENT-ONLY DIFF CONFIRMED (9 lines)` — 9 changed, 0 non-comment |
+| `git diff --stat` | `pkg/api/v2/rank.go` only, 1 file / 9 insertions |
+| `make lint` | `0 issues.` |
+| `go test ./pkg/api/v2/...` | `ok` (0.475s) — unchanged from pre-change |
+| `go doc ...v2.UnknownRank` | Caveat renders as a separate paragraph; `[Rank]` resolves as a doc link |
+
+## Decisions Made
+
+- **Kept `ValRank` embedded by value.** Issue #526 evaluated switching to `*ValRank` and rejected it. Changing the embedding would alter the zero value of an exported type and every promoted method's behavior for a case that is unreachable: `UnknownRank` has no exported constructor, and its only construction site (`operandToRank`, rank.go:1304) returns `&UnknownRank{}`. Documenting the boundary is cheaper and carries no compatibility risk.
+- **No nil-receiver guards or `recover()` added.** CLAUDE.md's panic-prevention rules target paths a user can actually reach through the public API. Adding defensive checks to `*ValRank` methods to protect an unconstructable type would add cost to every rank operation for zero real-world benefit, and the plan's threat register accepted T-n7b-01 on exactly that basis.
+- **Mirrored the existing interface-level phrasing.** The `Rank` doc already says nil concrete-pointer `MarshalJSON` calls "are unsupported and may panic"; reusing "unsupported usage" makes both caveats one consistent policy.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None. Two Bash invocations chaining `&&` with a `git diff | grep` pipeline were rejected by the worktree-isolation guard; each verification step was re-run as a separate plain command with identical results.
+
+## Threat Flags
+
+None. Comment-only change; no trust boundary, parsing path, or I/O surface added or modified.
+
+## Next Phase Readiness
+
+- Issue #526 is resolvable on the strength of this doc alone. The orchestrator closes it; `gh issue close` was deliberately not run here.
+- No follow-up work implied. If a future change ever adds an exported `UnknownRank` constructor, this caveat becomes stale and the nil-guard question should be reopened.
+
+## Self-Check: PASSED
+
+- `pkg/api/v2/rank.go` — FOUND
+- Commit `3c0aa73` — FOUND
+
+---
+*Quick task: 260731-n7b*
+*Completed: 2026-07-31*

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -87,6 +87,15 @@ type RankWithWeight struct {
 // programming errors instead of silently producing incorrect results. Its
 // promoted arithmetic methods operate on the embedded zero-valued ValRank and
 // should not be called directly; normal conversion uses it only as a leaf.
+//
+// Calling any promoted method on a nil *UnknownRank panics, including IsOperand,
+// whose body is empty. ValRank is embedded by value, so a promoted call
+// dereferences the receiver to reach the embedded field before the method body
+// runs; the panic comes from the call convention, not from what the method does.
+// Like direct MarshalJSON calls on nil concrete [Rank] pointers, this is
+// unsupported usage rather than a defect. UnknownRank has no exported
+// constructor and callers obtain it only as a non-nil value from internal
+// conversion, so the boundary is not reachable through the public API.
 type UnknownRank struct {
 	ValRank
 }


### PR DESCRIPTION
## Summary
- Documents that calling any promoted arithmetic method (or `IsOperand`) on a nil `*UnknownRank` panics, and explains why: `ValRank` is embedded by value, so Go's promoted-method call convention dereferences the receiver before the method body runs.
- Frames this as unsupported usage in the same class as the existing nil-concrete-pointer `MarshalJSON` caveat on `[Rank]`, since `UnknownRank` has no exported constructor and `operandToRank` only ever returns a non-nil instance — reachability through the public API is effectively nil.
- Doc-only change, per the issue's own recommended fix given near-zero reachability. No behavior change to `UnknownRank`, `ValRank`, or `operandToRank`.

Closes #526

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/api/v2/...`
- [x] `go test ./pkg/api/v2/...`
- [x] `make lint`
- [x] Diff confirmed comment-only (`pkg/api/v2/rank.go` only, every changed line is `//`)