### PR TITLE
fix(api): guard Rank JSON marshaling depth

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 30
 Plan: Not started
 Status: Quick task chain (u7z/e0k/ewm/fvo) shipped — PR #527
-Last activity: 2026-07-31 - Completed quick task 260731-n7b: Document nil-receiver panic on UnknownRank promoted methods (GH #526)
+Last activity: 2026-07-31 - Completed quick task 260731-nj1: work in a PR branch to address issue #528
 
 Progress: [██████████] 100%
 
@@ -81,6 +81,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-ewm | Fix typed-nil Rank panics, nested RRF nil laundering, error docs, tests, and inaccurate GSD records | 2026-07-31 | b0f52ed | Verified | [260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil](./quick/260731-ewm-fix-typed-nil-rank-panics-nested-rrf-nil/) |
 | 260731-fvo | Fix typed-nil rank builder panics and close related tests and documentation gaps | 2026-07-31 | 872069b | Complete | [260731-fvo-fix-typed-nil-rank-builder-panics-and-cl](./quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/) |
 | 260731-n7b | Document nil-receiver panic on UnknownRank promoted methods (GH #526) | 2026-07-31 | 3c0aa73 | Complete | [260731-n7b-fix-526-document-nil-receiver-panic-on-u](./quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/) |
+| 260731-nj1 | work in a PR branch to address issue #528 | 2026-07-31 | 379bd4a | Complete | [260731-nj1-work-in-a-pr-branch-to-address-issue-528](./quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 30
 Plan: Not started
 Status: Quick task chain (u7z/e0k/ewm/fvo) shipped — PR #527
-Last activity: 2026-07-31 - Completed quick task 260731-nj1: work in a PR branch to address issue #528
+Last activity: 2026-07-31 - Completed quick task 260731-pb1: Harden Rank depth tracking and add complete depth-guard coverage, including RrfRank
 
 Progress: [██████████] 100%
 
@@ -82,6 +82,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-fvo | Fix typed-nil rank builder panics and close related tests and documentation gaps | 2026-07-31 | 872069b | Complete | [260731-fvo-fix-typed-nil-rank-builder-panics-and-cl](./quick/260731-fvo-fix-typed-nil-rank-builder-panics-and-cl/) |
 | 260731-n7b | Document nil-receiver panic on UnknownRank promoted methods (GH #526) | 2026-07-31 | 3c0aa73 | Complete | [260731-n7b-fix-526-document-nil-receiver-panic-on-u](./quick/260731-n7b-fix-526-document-nil-receiver-panic-on-u/) |
 | 260731-nj1 | work in a PR branch to address issue #528 | 2026-07-31 | 379bd4a | Complete | [260731-nj1-work-in-a-pr-branch-to-address-issue-528](./quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/) |
+| 260731-pb1 | Harden Rank depth tracking and add complete depth-guard coverage, including RrfRank | 2026-07-31 | 3243aa4 | Complete | [260731-pb1-harden-rank-depth-tracking-and-add-compl](./quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-PLAN.md
+++ b/.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-PLAN.md
@@ -1,0 +1,169 @@
+---
+phase: quick-260731-nj1
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/rank_test.go
+autonomous: true
+requirements:
+  - GH-528
+
+must_haves:
+  truths:
+    - "A Rank expression nested exactly MaxExpressionDepth levels marshals successfully"
+    - "A Rank expression nested MaxExpressionDepth plus one levels returns a bounded error instead of continuing recursive JSON marshaling"
+    - "Depth is carried through every built-in recursive Rank serializer, including RRF expansion, without changing valid JSON output"
+    - "Caller-supplied Rank implementations remain marshalable through the existing Rank interface"
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Zero-based depth tracking and MaxExpressionDepth enforcement for recursive Rank JSON marshaling"
+      contains: "rank expression exceeds maximum depth"
+    - path: "pkg/api/v2/rank_test.go"
+      provides: "Regression coverage at the accepted depth boundary and one level beyond it"
+      contains: "TestRankMarshalExpressionDepthGuard"
+  key_links:
+    - from: "pkg/api/v2/rank.go:composite MarshalJSON methods"
+      to: "pkg/api/v2/rank.go:marshalRank"
+      via: "each recursive child is marshaled with depth+1"
+      pattern: "marshalRank\\(.*depth\\+1\\)"
+    - from: "pkg/api/v2/rank.go:marshalRank"
+      to: "pkg/api/v2/rank.go:MaxExpressionDepth"
+      via: "reject depth values greater than the shared maximum before dispatching deeper"
+      pattern: "depth > MaxExpressionDepth"
+---
+
+<objective>
+Bound recursive Rank JSON marshaling at the same shared expression-depth limit already used by query embedding.
+
+Purpose: deeply nested caller-built Rank trees must return a normal error before recursive MarshalJSON calls can exhaust the process stack.
+
+Output: depth-aware Rank marshaling plus exact boundary regressions in the existing rank test suite.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+@pkg/api/v2/collection_http.go
+
+**Locked constraints:**
+- Work on the already checked-out `fix/528-rank-marshal-depth-guard` branch; do not create, rename, or switch branches.
+- Keep `MaxExpressionDepth` as the single shared limit and mirror `embedRankTextQueriesWithDepth`: the root starts at depth 0, depth equal to the maximum is accepted, and only `depth > MaxExpressionDepth` fails.
+- Preserve the exported `Rank` interface, existing valid JSON shapes, `ErrNilRank` behavior, expression-term limits, and division/RRF validation.
+- Add no dependency and do not broaden the change beyond Rank marshaling and its focused tests.
+- Do not push, open a PR, or merge as part of this plan. Any later merge must be a squash merge.
+- Keep commits and related artifacts free of internal repository or host information.
+</context>
+
+<interfaces>
+<!-- Existing contracts the executor should retain. -->
+
+From `pkg/api/v2/rank.go`:
+
+```go
+type Rank interface {
+	Operand
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON([]byte) error
+}
+
+func marshalRank(rank Rank) ([]byte, error)
+
+const MaxExpressionDepth = 100
+```
+
+Recursive built-in serializers: `SumRank`, `SubRank`, `MulRank`, `DivRank`, `AbsRank`, `ExpRank`, `LogRank`, `MaxRank`, `MinRank`, and `RrfRank`.
+
+From `pkg/api/v2/collection_http.go`:
+
+```go
+func (c *CollectionImpl) embedRankTextQueriesWithDepth(ctx context.Context, rank Rank, depth int) error
+```
+
+Its boundary error text is `rank expression exceeds maximum depth of %d`.
+</interfaces>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Guard recursive Rank marshaling at MaxExpressionDepth</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go</files>
+  <behavior>
+    - "A public Rank tree built with exactly MaxExpressionDepth nested Log operations returns non-empty JSON and no error"
+    - "The same tree with MaxExpressionDepth+1 nested Log operations does not panic and returns `rank expression exceeds maximum depth of MaxExpressionDepth`"
+    - "Existing arithmetic, mathematical-function, RRF, nil-rank, term-limit, and custom Rank marshaling behavior remains unchanged"
+  </behavior>
+  <action>
+    Start in `pkg/api/v2/rank_test.go` by replacing the loose 50-level coverage in `TestDeepExpressionChain` with `TestRankMarshalExpressionDepthGuard` (or renaming and tightening that test). Build expressions from `Val(0)` by calling `Log()` in a loop so every iteration adds one real node; do not use repeated `Abs()` because `AbsRank.Abs()` intentionally returns the existing wrapper. Cover exactly two table cases: `MaxExpressionDepth`, which must marshal successfully with non-empty bytes, and `MaxExpressionDepth+1`, which must run under `require.NotPanics` and return the same formatted maximum-depth error used by the embedding traversal. Run the focused test before editing production code and confirm the over-limit case fails.
+
+    In `pkg/api/v2/rank.go`, keep the exported `Rank` interface unchanged and add one private depth-aware marshal contract, such as `marshalJSONWithDepth(depth int) ([]byte, error)`. Change the private `marshalRank` helper to accept the current depth, preserve its `ErrNilRank` check, reject only values greater than `MaxExpressionDepth` with `errors.Errorf("rank expression exceeds maximum depth of %d", MaxExpressionDepth)`, dispatch built-in depth-aware ranks through the private contract, and fall back to `rank.MarshalJSON()` for caller-supplied Rank implementations.
+
+    Move the existing recursive serialization bodies for `SumRank`, `SubRank`, `MulRank`, `DivRank`, `AbsRank`, `ExpRank`, `LogRank`, `MaxRank`, `MinRank`, and `RrfRank` behind that private contract. Each public `MarshalJSON` must enter its private method at depth 0; every recursive child call must go through `marshalRank(child, depth+1)`. Route the expression produced inside `RrfRank` back through the same helper with an incremented depth so RRF cannot reset the guard. Leave `ValRank`, `KnnRank`, and `UnknownRank` as leaf serializers, preserve all existing validation and output construction, and do not introduce shared mutable depth state or change public method signatures.
+
+    Run the focused boundary test, then the full tagged V2 package suite. Existing JSON equality tests must prove valid wire output did not change, while the new one-level-over test proves recursion stops with an ordinary error.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankMarshalExpressionDepthGuard$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>MaxExpressionDepth is accepted, MaxExpressionDepth+1 returns the shared depth error without panic, every built-in recursive marshal path propagates depth, custom Rank fallback remains intact, and existing valid Rank JSON is unchanged.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller-built Rank tree -> JSON marshaler | A caller controls expression shape and nesting before the library recursively serializes it on the process stack |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-nj1-01 | Denial of Service | `marshalRank` and recursive Rank `MarshalJSON` methods | mitigate | Carry zero-based depth through every built-in recursive edge, reject depth above `MaxExpressionDepth`, and pin both sides of the boundary with no-panic tests |
+| T-nj1-02 | Tampering | Rank JSON wire representation | mitigate | Retain existing serializer bodies and run the full tagged V2 suite so the guard cannot silently alter accepted expressions |
+| T-nj1-SC | Tampering | Package installation | accept | This plan adds no dependency and performs no package-manager install |
+</threat_model>
+
+<verification>
+1. `test "$(git branch --show-current)" = "fix/528-rank-marshal-depth-guard"`
+2. `go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankMarshalExpressionDepthGuard$' -count=1 -timeout=30s`
+3. `go test -tags=basicv2 ./pkg/api/v2/... -count=1 -timeout=120s`
+4. `make lint`
+5. `git diff --check`
+6. Inspect `git diff -- pkg/api/v2/rank.go pkg/api/v2/rank_test.go` and confirm the diff contains only depth propagation, the boundary regression, and any directly related comment adjustment.
+</verification>
+
+<source_coverage_audit>
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | — | Prevent unbounded recursion while marshaling deeply nested Rank expressions | 01 | COVERED | Task 1 adds bounded depth propagation and error handling |
+| REQ | GH-528 | Give Rank JSON marshaling the MaxExpressionDepth guard already present in query embedding | 01 | COVERED | Task 1 mirrors the zero-based boundary and error text |
+| RESEARCH | — | No research phase | — | EXCLUDED | Quick-task constraints explicitly prohibit research; the implementation follows existing package patterns |
+| CONTEXT | — | Test the accepted maximum depth and one level beyond it | 01 | COVERED | Task 1 pins both exact boundary cases |
+| CONTEXT | — | Work on `fix/528-rank-marshal-depth-guard` | 01 | COVERED | Branch is already checked out and verification asserts it remains active |
+| CONTEXT | — | Prefer the least code and add no dependency | 01 | COVERED | One private contract reuses existing serializer bodies and public APIs |
+| CONTEXT | — | Keep internal repository information out of artifacts | 01 | COVERED | The plan and planned changes contain no internal host or repository references |
+| CONTEXT | — | Always squash merge | — | EXCLUDED | No merge is part of this implementation plan |
+</source_coverage_audit>
+
+<success_criteria>
+- Exactly MaxExpressionDepth nested Rank operations marshal successfully.
+- MaxExpressionDepth+1 nested Rank operations return the shared maximum-depth error without panicking.
+- All recursive built-in Rank serializers carry depth without changing accepted JSON output or public interfaces.
+- Focused tests, the full basicv2 V2 suite, lint, branch, and diff checks pass.
+- No dependency, unrelated file, branch operation, push, PR, or merge is introduced.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-SUMMARY.md
+++ b/.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-SUMMARY.md
@@ -1,0 +1,110 @@
+---
+phase: quick-260731-nj1
+plan: "01"
+status: complete
+subsystem: api
+tags: [go, json, rank, recursion, depth-guard]
+
+requires: []
+provides:
+  - "Bounded recursive Rank JSON marshaling at MaxExpressionDepth"
+  - "Exact accepted and rejected depth-boundary regression coverage"
+affects: [v2-rank-expressions, v2-search]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Private depth-aware dispatch for recursive serializers with public zero-depth entry points"
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/rank_test.go
+
+key-decisions:
+  - "Kept Rank unchanged and used a private depth-aware interface so caller-defined Rank implementations retain the existing MarshalJSON fallback"
+  - "Counted the public root as depth zero and rejected only depth values greater than MaxExpressionDepth"
+
+requirements-completed: [GH-528]
+
+duration: 5 min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-nj1: Rank Marshal Depth Guard Summary
+
+**Rank JSON marshaling now stops recursive built-in expressions beyond the shared depth limit while preserving valid output and custom Rank compatibility.**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-07-31T14:09:18Z
+- **Completed:** 2026-07-31T14:13:55Z
+- **Tasks:** 1
+- **Files modified:** 2
+
+## Accomplishments
+
+- Added zero-based depth tracking across all ten recursive built-in Rank serializers, including generated RRF expressions.
+- Preserved the exported Rank interface, nil-rank handling, validation, valid JSON shapes, and caller-defined Rank fallback.
+- Replaced loose deep-chain coverage with exact success and bounded-error checks at both sides of MaxExpressionDepth.
+
+## TDD Cycle
+
+- **RED:** `TestRankMarshalExpressionDepthGuard` failed because the over-limit expression returned no error.
+- **GREEN:** Private depth-aware dispatch rejects depth above MaxExpressionDepth and passes the focused and full tagged suites.
+- **REFACTOR:** No separate refactor was needed; the minimal implementation follows the existing serializer bodies.
+
+## Task Commits
+
+1. **RED: Add rank marshal depth boundary coverage** - `f6c4ddf` (test)
+2. **GREEN: Bound recursive rank marshaling** - `304446b` (fix)
+
+The summary and planning state remain uncommitted as required by the quick-task orchestrator.
+
+## Files Created/Modified
+
+- `pkg/api/v2/rank.go` - Adds the depth guard and propagates depth through recursive built-in serializers.
+- `pkg/api/v2/rank_test.go` - Tests successful marshaling at the maximum and a no-panic error one level beyond it.
+
+## Decisions Made
+
+- Used an unexported depth-aware interface so no public API or caller implementation requirement changed.
+- Routed RRF's generated expression through the same guarded helper rather than restarting at depth zero.
+- Kept `ErrNilRank` precedence by checking nil ranks before checking depth.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## Verification
+
+- `go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankMarshalExpressionDepthGuard$' -count=1 -timeout=30s` - passed.
+- `go test -tags=basicv2 ./pkg/api/v2/... -count=1 -timeout=120s` - passed.
+- `make lint` - passed with 0 issues.
+- `git diff --check` - passed.
+- Scope inspection confirmed changes are limited to `pkg/api/v2/rank.go` and `pkg/api/v2/rank_test.go`.
+
+## User Setup Required
+
+None - no external service configuration or dependency changes.
+
+## Next Phase Readiness
+
+- Ready for the orchestrator to integrate the two TDD commits into the final PR branch.
+- No blockers or deferred issues.
+
+## Self-Check: PASSED
+
+- Both modified files and this summary exist.
+- RED commit `f6c4ddf` and GREEN commit `304446b` exist in git history.
+- `STATE.md` and the plan remain unchanged; only this summary is uncommitted.
+
+---
+*Quick task: 260731-nj1*
+*Completed: 2026-07-31*

--- a/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-PLAN.md
+++ b/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-PLAN.md
@@ -1,0 +1,200 @@
+---
+phase: quick-260731-pb1
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/rank_test.go
+  - pkg/api/v2/search_test.go
+autonomous: true
+requirements:
+  - GH-528
+
+must_haves:
+  truths:
+    - "Every Rank implementation explicitly participates in depth-aware JSON marshaling; marshalRank has no plain MarshalJSON fallback"
+    - "Every composite Rank serializer accepts its deepest valid child expression and rejects the next level without panicking"
+    - "RrfRank accepts an inner depth of 96, rejects an inner depth of 97, and reports cannot marshal RrfRank context"
+    - "Accepted Rank expressions retain their existing JSON representation, while expressions deeper than 100 now return an error even if they previously marshaled"
+  artifacts:
+    - path: "pkg/api/v2/rank.go"
+      provides: "Exhaustive depth-aware Rank contract, leaf implementations, and contextual RRF error propagation"
+      contains: "marshalJSONWithDepth(depth int) ([]byte, error)"
+    - path: "pkg/api/v2/rank_test.go"
+      provides: "Boundary coverage for every composite Rank path, including the RRF expansion offset"
+      contains: "TestRankMarshalExpressionDepthGuard"
+    - path: "pkg/api/v2/search_test.go"
+      provides: "A package-local map-backed Rank test double compatible with the exhaustive Rank contract"
+      contains: "mapBackedRank"
+  key_links:
+    - from: "pkg/api/v2/rank.go:Rank"
+      to: "pkg/api/v2/rank.go:marshalRank"
+      via: "marshalRank dispatches directly through the required depth-aware method after nil and limit checks"
+      pattern: "return rank\\.marshalJSONWithDepth\\(depth\\)"
+    - from: "pkg/api/v2/rank.go:RrfRank.marshalJSONWithDepth"
+      to: "pkg/api/v2/rank.go:marshalRank"
+      via: "the generated RRF expression retains depth+1 rather than restarting at zero"
+      pattern: "marshalRank\\(result, depth\\+1\\)"
+    - from: "pkg/api/v2/rank_test.go:TestRankMarshalExpressionDepthGuard"
+      to: "all composite Rank serializers"
+      via: "public fluent builders and NewRrfRank place the deep child on each real serialization path"
+      pattern: "build func\\(Rank\\) Rank"
+---
+
+<objective>
+Make Rank depth tracking exhaustive and prove that every composite serializer, especially RRF's generated expression, enforces the shared recursion boundary.
+
+Purpose: remove the silent dispatch path that can bypass depth accounting and turn the existing Log-only regression into complete composite coverage.
+
+Output: an exhaustive Rank interface contract, explicit leaf implementations, contextual RRF failures, and focused boundary regressions.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/quick/260731-nj1-work-in-a-pr-branch-to-address-issue-528/260731-nj1-SUMMARY.md
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+@pkg/api/v2/search_test.go
+@pkg/api/v2/collection_http.go
+
+**Locked constraints:**
+- Keep `MaxExpressionDepth == 100`, zero-based root accounting, `ErrNilRank` precedence, existing validation, term limits, and accepted JSON shapes.
+- Put `marshalJSONWithDepth(depth int) ([]byte, error)` directly on `Rank`; the type-assertion dispatch and plain `MarshalJSON` fallback must be removed.
+- Cover `SumRank`, `SubRank`, `MulRank`, `DivRank`, `AbsRank`, `ExpRank`, `LogRank`, `MaxRank`, `MinRank`, and `RrfRank` through real child-marshaling paths.
+- Keep `cloneRank` recursion out of implementation scope. Do not edit `collection_http.go`, add a code TODO, or create an external issue; retain it only as a follow-up concern in the final summary/handoff.
+- The final summary/handoff must call out the intentional behavior change: expressions deeper than 100 now return an error even if they previously marshaled.
+- Add no dependency, do not push or open/merge a PR, and keep all artifacts free of prohibited internal repository or company information. Any later merge must be a squash merge.
+</context>
+
+<interfaces>
+<!-- Existing contracts and test double that this plan changes. -->
+
+From `pkg/api/v2/rank.go`:
+
+```go
+type Rank interface {
+	Operand
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON([]byte) error
+}
+
+type depthAwareRank interface {
+	marshalJSONWithDepth(depth int) ([]byte, error)
+}
+
+func marshalRank(rank Rank, depth int) ([]byte, error)
+```
+
+Existing composite implementations of `marshalJSONWithDepth`: `SumRank`, `SubRank`, `MulRank`, `DivRank`, `AbsRank`, `ExpRank`, `LogRank`, `MaxRank`, `MinRank`, and `RrfRank`.
+
+Leaf Rank types that need explicit implementations: `ValRank`, `UnknownRank`, and `KnnRank`. `UnknownRank` embeds `ValRank`, so it must override the promoted method and preserve its unknown-operand error.
+
+From `pkg/api/v2/search_test.go`:
+
+```go
+type mapBackedRank map[string]string
+func (m mapBackedRank) MarshalJSON() ([]byte, error)
+```
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Make depth-aware marshaling an exhaustive Rank contract</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/search_test.go</files>
+  <action>
+    Add `marshalJSONWithDepth(depth int) ([]byte, error)` to `Rank`, delete the redundant `depthAwareRank` interface, and simplify `marshalRank` so it preserves the current nil check and `depth > MaxExpressionDepth` check before directly calling the required method. Remove the type assertion and the `rank.MarshalJSON()` fallback completely; future Rank implementations must opt into depth-aware marshaling at compile time.
+
+    Add explicit leaf implementations for `ValRank`, `UnknownRank`, and `KnnRank` that delegate to their existing non-recursive `MarshalJSON` behavior. Define `UnknownRank.marshalJSONWithDepth` on `UnknownRank` itself rather than relying on its embedded `ValRank`, otherwise an unknown operand could incorrectly serialize as `$val`. Do not duplicate leaf encoding or validation logic.
+
+    Update the package-local `mapBackedRank` test double in `search_test.go` with the same depth-aware method, delegating to its existing `MarshalJSON`, so the package continues to compile and its nil-map coverage remains useful. Correct the nearby comment so it no longer claims an external package can implement the now-sealed interface. Do not change the behavior asserted by `TestWithRankNilNonPointerImplementation`.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestValRank|TestOperandConversion|TestWithRankNilNonPointerImplementation)$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>`Rank` requires depth-aware marshaling, no fallback remains, all three leaf types preserve their existing output/errors, and the map-backed nil-handling regression still compiles and passes.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Exercise every composite boundary and retain RRF error context</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go</files>
+  <behavior>
+    - "Each ordinary composite wrapping an inner Log chain accepts inner depth 99 and rejects inner depth 100 because the outer composite consumes one level"
+    - "RrfRank accepts inner depth 96 and rejects inner depth 97 because its generated Mul, Div, and denominator Sum path places the RRF child four levels below the public RRF root"
+    - "Every rejected case returns the shared maximum-depth text without panic; RrfRank also adds cannot marshal RrfRank context"
+    - "Replacing marshalRank(result, depth+1) with result.MarshalJSON() makes the RrfRank depth-97 regression fail"
+  </behavior>
+  <action>
+    Refactor `TestRankMarshalExpressionDepthGuard` into a composite table containing `name` and `build func(Rank) Rank` for all ten composite Rank types. Construct an inner chain by repeatedly calling `Log()` on `Val(0)`, then pass it through each builder. Use public fluent operations for arithmetic/function composites and `NewRrfRank`/`WithRrfRanks` for RRF instead of direct struct literals, so each test reaches the actual recursive child call. Exercise both sides of each effective boundary under `require.NotPanics`: ordinary composites use inner depths 99 (non-empty JSON, no error) and 100 (depth error); the explicit RRF cases use 96 (success) and 97 (depth error). Check rejected errors contain `rank expression exceeds maximum depth of 100`, and additionally require the RRF failure to contain `cannot marshal RrfRank`. These exact RRF values must remain capable of detecting a reset from `marshalRank(result, depth+1)` to `result.MarshalJSON()`.
+
+    Run the expanded focused test before the RRF production edit and confirm the new context assertion fails for the intended reason. In `RrfRank.marshalJSONWithDepth`, keep the final generated expression routed through `marshalRank(result, depth+1)`, capture its error, and wrap that error with `cannot marshal RrfRank` before returning. Preserve the existing validation context and successful bytes unchanged.
+
+    After focused and package-wide verification, record only in the generated summary/handoff that `cloneRank` still has independent recursive traversal as a follow-up concern; do not implement it or create an issue. In the same handoff, explicitly state that expressions deeper than 100 now return an error even if earlier behavior allowed them to marshal.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankMarshalExpressionDepthGuard$' -count=1 -timeout=30s</automated>
+  </verify>
+  <done>Every composite's real marshal path is boundary-tested, RRF proves the 96/97 inner-depth cutoff and contextual error, the guarded final RRF call cannot silently regress to a zero-depth public call, and handoff notes capture both the intentional behavior change and the cloneRank-only follow-up.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| Caller-built Rank tree -> JSON marshaler | Caller-controlled nesting crosses into recursive library serialization on the process stack |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-pb1-01 | Denial of Service | `Rank`, `marshalRank`, and composite serializers | mitigate | Require depth-aware marshaling on every Rank and remove fallback dispatch that can reset or bypass the shared depth limit |
+| T-pb1-02 | Denial of Service | `RrfRank.marshalJSONWithDepth` generated expression | mitigate | Preserve `marshalRank(result, depth+1)` and pin its hidden four-level expansion with explicit inner-depth 96/97 regressions |
+| T-pb1-03 | Tampering | Accepted Rank JSON wire representation | mitigate | Delegate leaf implementations to existing encoders and run the full tagged V2 suite to prove accepted output remains unchanged |
+| T-pb1-SC | Tampering | Package installation | accept | The plan adds no dependency and performs no package-manager install |
+</threat_model>
+
+<verification>
+1. `go test -tags=basicv2 ./pkg/api/v2 -run '^TestRankMarshalExpressionDepthGuard$' -count=1 -timeout=30s`
+2. `go test -tags=basicv2 ./pkg/api/v2/... -count=1 -timeout=120s`
+3. `make lint`
+4. `git diff --check`
+5. Inspect `git diff -- pkg/api/v2/rank.go pkg/api/v2/rank_test.go pkg/api/v2/search_test.go` and confirm it contains only the exhaustive depth contract, leaf/test-double adapters, composite boundary coverage, and RRF context.
+6. Confirm `git diff -- pkg/api/v2/collection_http.go` is empty and no external issue was created for `cloneRank`.
+</verification>
+
+<source_coverage_audit>
+| Source | ID | Feature/Requirement | Plan | Status | Notes |
+|--------|----|---------------------|------|--------|-------|
+| GOAL | — | Harden Rank depth tracking and complete depth-guard coverage, including RRF | 01 | COVERED | Tasks 1-2 make the contract exhaustive and cover every composite serializer |
+| REQ | GH-528 | Bound recursive Rank JSON marshaling at MaxExpressionDepth | 01 | COVERED | Both the dispatch contract and every recursive composite path are verified |
+| RESEARCH | — | No research phase | — | EXCLUDED | Quick-task constraints explicitly prohibit research; implementation follows the existing serializer and test patterns |
+| CONTEXT | 1 | Parameterize the existing depth test with a builder for every composite and prove RRF inner depths 96/97 | 01 | COVERED | Task 2 specifies public builders, ordinary boundaries, and the regression-sensitive RRF boundary |
+| CONTEXT | 2 | Put depth-aware marshaling on Rank, remove fallback, and implement all leaves | 01 | COVERED | Task 1 covers the interface, direct dispatch, all three production leaves, and the affected test double |
+| CONTEXT | 3 | Add useful context around RRF's final guarded marshal | 01 | COVERED | Task 2 wraps only the final `marshalRank(result, depth+1)` error |
+| CONTEXT | 4 | Keep cloneRank recursion out of implementation and record it only as follow-up | 01 | COVERED | It is excluded from files_modified and reserved for the summary/handoff without an external issue |
+| CONTEXT | 5 | State the intentional error behavior for expressions deeper than 100 | 01 | COVERED | Task 2 and success criteria require the final handoff note |
+| CONTEXT | AGENTS | Prefer the least code and use squash merge | 01 | COVERED | Existing encoders are delegated to, no dependency is added, and no merge occurs in this plan |
+</source_coverage_audit>
+
+<success_criteria>
+- `Rank` itself requires depth-aware marshaling; the private type assertion and plain MarshalJSON fallback no longer exist.
+- `ValRank`, `UnknownRank`, `KnnRank`, and the package-local map-backed test double explicitly implement the contract without duplicating encoding logic.
+- All ten composite Rank serializers are exercised through real public construction paths at their accepted and rejected inner-depth boundaries.
+- RrfRank inner depth 96 succeeds, inner depth 97 returns an error containing both the shared depth message and `cannot marshal RrfRank`, and valid RRF JSON remains unchanged.
+- Focused tests, the full tagged V2 suite, lint, and diff checks pass with no change to `cloneRank` and no new dependency.
+- The final handoff states that expressions deeper than 100 now error even if they previously marshaled and records `cloneRank` recursion only as a follow-up concern.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-SUMMARY.md` when done.
+</output>

--- a/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-SUMMARY.md
+++ b/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-SUMMARY.md
@@ -1,0 +1,122 @@
+---
+phase: quick-260731-pb1
+plan: "01"
+status: complete
+subsystem: api
+tags: [go, json, rank, recursion, depth-guard]
+
+requires:
+  - phase: quick-260731-nj1
+    provides: "Initial bounded recursive marshaling for built-in Rank expressions"
+provides:
+  - "Exhaustive depth-aware marshaling contract for every Rank implementation"
+  - "Boundary regressions for all ten composite Rank serializers"
+  - "RRF depth failures with RrfRank-specific error context"
+affects: [v2-rank-expressions, v2-search]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Rank implementations must provide package-controlled depth-aware JSON marshaling"
+    - "Leaf depth adapters delegate to existing non-recursive encoders"
+
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/rank_test.go
+    - pkg/api/v2/search_test.go
+
+key-decisions:
+  - "Made depth-aware marshaling mandatory on Rank so no implementation can bypass or reset the shared recursion guard"
+  - "Delegated leaf depth adapters to existing MarshalJSON methods to preserve encoding and validation behavior"
+  - "Kept RRF's generated expression at depth+1 and wrapped only its final marshaling error"
+
+requirements-completed: [GH-528]
+
+duration: 7 min
+completed: 2026-07-31
+---
+
+# Quick Task 260731-pb1: Rank Depth Contract Hardening Summary
+
+**Every Rank serializer now participates in one shared depth limit, with complete composite boundary coverage and contextual RRF failures.**
+
+## Performance
+
+- **Duration:** 7 min
+- **Started:** 2026-07-31T15:22:49Z
+- **Completed:** 2026-07-31T15:29:22Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added depth-aware marshaling directly to Rank, removed fallback dispatch, and adapted all production leaves plus the package-local map-backed test double.
+- Exercised Sum, Sub, Mul, Div, Abs, Exp, Log, Max, Min, and RRF through public construction paths at their exact accepted and rejected child-depth boundaries.
+- Preserved RRF's hidden four-level expansion accounting while adding cannot marshal RrfRank context to final generated-expression failures.
+
+## TDD Cycle
+
+- **RED:** The expanded focused test failed only for rrf/rejects_next_child_depth: the shared depth error did not yet contain cannot marshal RrfRank.
+- **GREEN:** Wrapping the error from marshalRank(result, depth+1) made all composite boundaries pass while preserving successful RRF bytes.
+- **REFACTOR:** No separate refactor was needed; the production change is one guarded call plus contextual error propagation.
+
+## Task Commits
+
+1. **Task 1: Make depth-aware marshaling an exhaustive Rank contract** - 62a6688 (fix)
+2. **Task 2 RED: Cover every composite Rank depth boundary** - ec756f1 (test)
+3. **Task 2 GREEN: Retain context for RRF depth errors** - c4a1592 (feat)
+
+The task commits were integrated with a squash merge as required by the repository workflow.
+
+## Files Created/Modified
+
+- pkg/api/v2/rank.go - Makes depth-aware marshaling exhaustive, delegates leaf encoders, and contextualizes final RRF depth failures.
+- pkg/api/v2/rank_test.go - Covers both sides of every composite boundary, including RRF inner depths 96 and 97.
+- pkg/api/v2/search_test.go - Adapts the package-local map-backed Rank test double to the exhaustive contract.
+
+## Decisions Made
+
+- Kept nil-rank validation ahead of the depth check, retaining ErrNilRank precedence.
+- Kept zero-based root accounting and MaxExpressionDepth == 100.
+- Used existing leaf encoders rather than duplicating JSON or validation logic.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None. The expected RED failure confirmed that the new RRF context assertion detected the intended missing behavior.
+
+## Verification
+
+- Task 1 focused test command passed (ok, 0.553s).
+- RED focused depth test failed as expected only because the RRF depth error lacked cannot marshal RrfRank.
+- Final focused depth test passed (ok, 0.366s).
+- Full tagged V2 package suite passed (ok, 22.914s).
+- make lint passed with 0 issues.
+- git diff --check and the base-to-HEAD diff check passed with no whitespace errors.
+- Base-to-HEAD scope inspection found only pkg/api/v2/rank.go, pkg/api/v2/rank_test.go, and pkg/api/v2/search_test.go.
+- pkg/api/v2/collection_http.go, go.mod, and go.sum are unchanged; no external issue was created.
+
+## User Setup Required
+
+None - no dependency or external service changes.
+
+## Next Phase Readiness
+
+- Expressions deeper than 100 now return an error even if the former fallback path allowed them to marshal.
+- cloneRank still performs independent recursive traversal; it remains a follow-up concern only, with no code TODO or external issue created in this task.
+- Ready for final planning metadata to be committed.
+
+## Self-Check: PASSED
+
+- All three modified code files and this summary exist.
+- Code commits 62a6688, ec756f1, and c4a1592 were created in order from the expected base and squash-integrated.
+- STATE.md, ROADMAP.md, REQUIREMENTS.md, the plan, and collection_http.go remain unchanged by the executor.
+
+---
+*Quick task: 260731-pb1*
+*Completed: 2026-07-31*

--- a/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-SUMMARY.md
+++ b/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-SUMMARY.md
@@ -9,27 +9,29 @@ requires:
   - phase: quick-260731-nj1
     provides: "Initial bounded recursive marshaling for built-in Rank expressions"
 provides:
-  - "Exhaustive depth-aware marshaling contract for every Rank implementation"
+  - "Shared depth-aware marshaling for every built-in Rank implementation"
   - "Boundary regressions for all ten composite Rank serializers"
   - "RRF depth failures with RrfRank-specific error context"
+  - "Compatibility for external Rank implementations that embed built-in composites"
 affects: [v2-rank-expressions, v2-search]
 
 tech-stack:
   added: []
   patterns:
-    - "Rank implementations must provide package-controlled depth-aware JSON marshaling"
-    - "Leaf depth adapters delegate to existing non-recursive encoders"
+    - "Exact built-in composite dispatch keeps depth accounting private without sealing Rank"
+    - "Leaf and caller-defined Rank implementations retain the plain MarshalJSON fallback"
 
 key-files:
-  created: []
+  created:
+    - pkg/api/v2/rank_external_test.go
   modified:
     - pkg/api/v2/rank.go
     - pkg/api/v2/rank_test.go
     - pkg/api/v2/search_test.go
 
 key-decisions:
-  - "Made depth-aware marshaling mandatory on Rank so no implementation can bypass or reset the shared recursion guard"
-  - "Delegated leaf depth adapters to existing MarshalJSON methods to preserve encoding and validation behavior"
+  - "Kept depth-aware marshaling private and dispatches exact built-in composite types so external Rank implementations retain their MarshalJSON behavior"
+  - "Kept leaves on their existing MarshalJSON methods to preserve encoding and validation behavior"
   - "Kept RRF's generated expression at depth+1 and wrapped only its final marshaling error"
 
 requirements-completed: [GH-528]
@@ -40,7 +42,7 @@ completed: 2026-07-31
 
 # Quick Task 260731-pb1: Rank Depth Contract Hardening Summary
 
-**Every Rank serializer now participates in one shared depth limit, with complete composite boundary coverage and contextual RRF failures.**
+**Every built-in Rank serializer now participates in one shared depth limit, while external Rank implementations retain their existing marshaling contract.**
 
 ## Performance
 
@@ -52,39 +54,41 @@ completed: 2026-07-31
 
 ## Accomplishments
 
-- Added depth-aware marshaling directly to Rank, removed fallback dispatch, and adapted all production leaves plus the package-local map-backed test double.
+- Added private depth-aware marshaling for every built-in composite with exact-type dispatch and an external implementation fallback.
 - Exercised Sum, Sub, Mul, Div, Abs, Exp, Log, Max, Min, and RRF through public construction paths at their exact accepted and rejected child-depth boundaries.
 - Preserved RRF's hidden four-level expansion accounting while adding cannot marshal RrfRank context to final generated-expression failures.
+- Added an external-package regression proving that embedding a built-in composite does not override a caller's custom MarshalJSON method.
 
 ## TDD Cycle
 
 - **RED:** The expanded focused test failed only for rrf/rejects_next_child_depth: the shared depth error did not yet contain cannot marshal RrfRank.
 - **GREEN:** Wrapping the error from marshalRank(result, depth+1) made all composite boundaries pass while preserving successful RRF bytes.
-- **REFACTOR:** No separate refactor was needed; the production change is one guarded call plus contextual error propagation.
+- **COMPATIBILITY:** Review exposed that putting a package-private method on Rank prevented external implementations and that interface-based dispatch could capture embedded built-ins. Exact concrete-type dispatch fixes both cases.
 
 ## Task Commits
 
-1. **Task 1: Make depth-aware marshaling an exhaustive Rank contract** - 62a6688 (fix)
-2. **Task 2 RED: Cover every composite Rank depth boundary** - ec756f1 (test)
-3. **Task 2 GREEN: Retain context for RRF depth errors** - c4a1592 (feat)
-
-The task commits were integrated with a squash merge as required by the repository workflow.
+1. **Harden built-in Rank depth tracking** - 3243aa4 (fix)
+2. **Restore the private depth-aware marshal interface** - d150679 (fix)
+3. **Tighten depth-guard docs, tests, and consistency** - 0316b27 (fix)
+4. **Preserve embedded custom marshaling** - 21cc467 (fix)
 
 ## Files Created/Modified
 
-- pkg/api/v2/rank.go - Makes depth-aware marshaling exhaustive, delegates leaf encoders, and contextualizes final RRF depth failures.
+- pkg/api/v2/rank.go - Guards every exact built-in composite, preserves the leaf/external fallback, and contextualizes final RRF depth failures.
 - pkg/api/v2/rank_test.go - Covers both sides of every composite boundary, including RRF inner depths 96 and 97.
-- pkg/api/v2/search_test.go - Adapts the package-local map-backed Rank test double to the exhaustive contract.
+- pkg/api/v2/search_test.go - Documents and tests the package-local caller-defined Rank fallback.
+- pkg/api/v2/rank_external_test.go - Proves an external type embedding SumRank keeps its custom MarshalJSON output.
 
 ## Decisions Made
 
 - Kept nil-rank validation ahead of the depth check, retaining ErrNilRank precedence.
 - Kept zero-based root accounting and MaxExpressionDepth == 100.
-- Used existing leaf encoders rather than duplicating JSON or validation logic.
+- Kept existing leaf encoders rather than duplicating JSON or validation logic.
+- Kept Rank externally implementable and matched exact built-in composite types before falling back to caller-defined MarshalJSON methods.
 
 ## Deviations from Plan
 
-None - plan executed exactly as written.
+Post-plan compatibility review found that the exhaustive private method on Rank sealed the public interface and that interface-based dispatch could intercept external types embedding built-in composites. The implementation now uses exact built-in type dispatch and preserves the documented external fallback.
 
 ## Issues Encountered
 
@@ -92,13 +96,10 @@ None. The expected RED failure confirmed that the new RRF context assertion dete
 
 ## Verification
 
-- Task 1 focused test command passed (ok, 0.553s).
-- RED focused depth test failed as expected only because the RRF depth error lacked cannot marshal RrfRank.
-- Final focused depth test passed (ok, 0.366s).
-- Full tagged V2 package suite passed (ok, 22.914s).
+- Focused depth, fallback, external-embedding, and nil-sentinel regressions passed (ok, 0.534s).
+- Full basicv2 suite passed: 1,981 tests, 7 expected skips, in 34.213s.
 - make lint passed with 0 issues.
-- git diff --check and the base-to-HEAD diff check passed with no whitespace errors.
-- Base-to-HEAD scope inspection found only pkg/api/v2/rank.go, pkg/api/v2/rank_test.go, and pkg/api/v2/search_test.go.
+- git diff --check passed with no whitespace errors.
 - pkg/api/v2/collection_http.go, go.mod, and go.sum are unchanged; no external issue was created.
 
 ## User Setup Required
@@ -108,13 +109,14 @@ None - no dependency or external service changes.
 ## Next Phase Readiness
 
 - Expressions deeper than 100 now return an error even if the former fallback path allowed them to marshal.
+- External Rank implementations, including types embedding built-in composites, keep control of their MarshalJSON output.
 - cloneRank still performs independent recursive traversal; it remains a follow-up concern only, with no code TODO or external issue created in this task.
 - Ready for final planning metadata to be committed.
 
 ## Self-Check: PASSED
 
-- All three modified code files and this summary exist.
-- Code commits 62a6688, ec756f1, and c4a1592 were created in order from the expected base and squash-integrated.
+- All four code/test files and this summary exist.
+- Compatibility commit 21cc467 follows the original hardening and review-fix commits on the PR branch.
 - STATE.md, ROADMAP.md, REQUIREMENTS.md, the plan, and collection_http.go remain unchanged by the executor.
 
 ---

--- a/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-VERIFICATION.md
+++ b/.planning/quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/260731-pb1-VERIFICATION.md
@@ -1,0 +1,43 @@
+---
+quick_task: 260731-pb1
+includes: [260731-nj1]
+status: passed
+verified: 2026-07-31
+commit: 21cc467
+requirements: [GH-528]
+---
+
+# Rank Marshal Depth Guard Verification
+
+## Goal
+
+Bound recursive JSON marshaling for built-in Rank expressions without changing accepted JSON or breaking caller-defined Rank implementations.
+
+## Verdict
+
+Passed. Built-in composite Rank values preserve zero-based depth accounting and reject expressions beyond MaxExpressionDepth. External Rank implementations continue to use their own MarshalJSON methods, including types that embed a built-in composite.
+
+## Acceptance Evidence
+
+- `TestRankMarshalExpressionDepthGuard` covers accepted and rejected boundaries for Sum, Sub, Mul, Div, Abs, Exp, Log, Max, Min, and RRF.
+- `TestCustomRankEmbeddingCompositePreservesMarshalJSON` runs from the external `v2_test` package and proves an embedded SumRank does not capture custom JSON serialization.
+- `TestMarshalRankFallbackForNestedNonCompositeChild` proves caller-defined ranks nested inside built-in expressions still use the fallback.
+- `TestNilOptionSentinels` confirms nil Rank behavior and sentinels remain intact.
+
+## Fresh Verification
+
+- `go test -count=1 -tags=basicv2 -run 'Test(CustomRankEmbeddingCompositePreservesMarshalJSON|MarshalRankFallbackForNestedNonCompositeChild|RankMarshalExpressionDepthGuard|NilOptionSentinels)$' ./pkg/api/v2` — passed (`ok`, 0.534s).
+- `make test` — passed: 1,981 tests, 7 expected skips, 34.213s.
+- `make lint` — passed with 0 issues.
+- `git diff --check` — passed.
+
+## Scope Check
+
+- Production behavior changes are limited to Rank JSON depth dispatch.
+- Tests cover internal boundary behavior and the public external-implementation contract.
+- No dependency changes were introduced.
+- `pkg/api/v2/collection_http.go`, `go.mod`, and `go.sum` remain unchanged.
+
+## Follow-up
+
+`cloneRank` has an independent recursive traversal and remains outside this change. Expressions deeper than 100 now return a normal error instead of continuing recursive built-in JSON marshaling.

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -65,7 +65,6 @@ type Rank interface {
 	Log() Rank
 	Max(operand Operand) Rank
 	Min(operand Operand) Rank
-	marshalJSONWithDepth(depth int) ([]byte, error)
 	MarshalJSON() ([]byte, error)
 	UnmarshalJSON(b []byte) error
 }
@@ -105,8 +104,13 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
 }
 
-func (u *UnknownRank) marshalJSONWithDepth(_ int) ([]byte, error) {
-	return u.MarshalJSON()
+// depthAwareRank is implemented by composite Rank types that recurse into
+// child Rank values during marshaling. Types that don't implement it (leaves,
+// and any caller-supplied Rank implementation) fall back to plain
+// MarshalJSON() in marshalRank, since they can't contribute unbounded
+// recursion depth themselves.
+type depthAwareRank interface {
+	marshalJSONWithDepth(depth int) ([]byte, error)
 }
 
 func marshalRank(rank Rank, depth int) ([]byte, error) {
@@ -116,7 +120,10 @@ func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if depth > MaxExpressionDepth {
 		return nil, errors.Errorf("rank expression exceeds maximum depth of %d", MaxExpressionDepth)
 	}
-	return rank.marshalJSONWithDepth(depth)
+	if dr, ok := rank.(depthAwareRank); ok {
+		return dr.marshalJSONWithDepth(depth)
+	}
+	return rank.MarshalJSON()
 }
 
 // ValRank represents a constant numeric value in rank expressions.
@@ -182,10 +189,6 @@ func (v *ValRank) Min(operand Operand) Rank {
 
 func (v *ValRank) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]float64{"$val": v.value})
-}
-
-func (v *ValRank) marshalJSONWithDepth(_ int) ([]byte, error) {
-	return v.MarshalJSON()
 }
 
 func (v *ValRank) UnmarshalJSON(b []byte) error {
@@ -1083,10 +1086,6 @@ func (k *KnnRank) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{"$knn": inner})
 }
 
-func (k *KnnRank) marshalJSONWithDepth(_ int) ([]byte, error) {
-	return k.MarshalJSON()
-}
-
 func (k *KnnRank) UnmarshalJSON(b []byte) error {
 	return errors.New("json: cannot unmarshal KnnRank JSON object")
 }
@@ -1341,7 +1340,7 @@ func (r *RrfRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	result := rrfSum.Negate()
 	data, err := marshalRank(result, depth+1)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot marshal RrfRank")
+		return nil, errors.Wrap(err, "cannot marshal RrfRank expression")
 	}
 	return data, nil
 }

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -104,32 +104,6 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
 }
 
-// depthAwareRank is implemented by composite Rank types that recurse into
-// child Rank values during marshaling. Types that don't implement it (leaves,
-// and any caller-supplied Rank implementation) fall back to plain
-// MarshalJSON() in marshalRank. Because depthAwareRank is unexported,
-// caller-supplied Rank implementations can never satisfy it: a Rank that
-// wraps and recurses into further child Ranks outside this package is not
-// depth-guarded, and marshaling such a type resets the depth count to 0 at
-// the hand-off. This is an accepted limitation of not sealing the exported
-// Rank interface.
-type depthAwareRank interface {
-	marshalJSONWithDepth(depth int) ([]byte, error)
-}
-
-var (
-	_ depthAwareRank = (*SumRank)(nil)
-	_ depthAwareRank = (*SubRank)(nil)
-	_ depthAwareRank = (*MulRank)(nil)
-	_ depthAwareRank = (*DivRank)(nil)
-	_ depthAwareRank = (*AbsRank)(nil)
-	_ depthAwareRank = (*ExpRank)(nil)
-	_ depthAwareRank = (*LogRank)(nil)
-	_ depthAwareRank = (*MaxRank)(nil)
-	_ depthAwareRank = (*MinRank)(nil)
-	_ depthAwareRank = (*RrfRank)(nil)
-)
-
 func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if isNilRank(rank) {
 		return nil, ErrNilRank
@@ -137,9 +111,32 @@ func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if depth > MaxExpressionDepth {
 		return nil, errors.Errorf("rank expression exceeds maximum depth of %d", MaxExpressionDepth)
 	}
-	if dr, ok := rank.(depthAwareRank); ok {
-		return dr.marshalJSONWithDepth(depth)
+
+	// Match exact built-in composites so an external Rank that embeds one
+	// still controls its own serialization through MarshalJSON.
+	switch rank := rank.(type) {
+	case *SumRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *SubRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *MulRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *DivRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *AbsRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *ExpRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *LogRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *MaxRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *MinRank:
+		return rank.marshalJSONWithDepth(depth)
+	case *RrfRank:
+		return rank.marshalJSONWithDepth(depth)
 	}
+
 	return rank.MarshalJSON()
 }
 

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -107,11 +107,28 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 // depthAwareRank is implemented by composite Rank types that recurse into
 // child Rank values during marshaling. Types that don't implement it (leaves,
 // and any caller-supplied Rank implementation) fall back to plain
-// MarshalJSON() in marshalRank, since they can't contribute unbounded
-// recursion depth themselves.
+// MarshalJSON() in marshalRank. Because depthAwareRank is unexported,
+// caller-supplied Rank implementations can never satisfy it: a Rank that
+// wraps and recurses into further child Ranks outside this package is not
+// depth-guarded, and marshaling such a type resets the depth count to 0 at
+// the hand-off. This is an accepted limitation of not sealing the exported
+// Rank interface.
 type depthAwareRank interface {
 	marshalJSONWithDepth(depth int) ([]byte, error)
 }
+
+var (
+	_ depthAwareRank = (*SumRank)(nil)
+	_ depthAwareRank = (*SubRank)(nil)
+	_ depthAwareRank = (*MulRank)(nil)
+	_ depthAwareRank = (*DivRank)(nil)
+	_ depthAwareRank = (*AbsRank)(nil)
+	_ depthAwareRank = (*ExpRank)(nil)
+	_ depthAwareRank = (*LogRank)(nil)
+	_ depthAwareRank = (*MaxRank)(nil)
+	_ depthAwareRank = (*MinRank)(nil)
+	_ depthAwareRank = (*RrfRank)(nil)
+)
 
 func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if isNilRank(rank) {
@@ -1200,7 +1217,10 @@ const MaxRrfRanks = 100
 // MaxExpressionTerms is the maximum number of terms allowed in variadic rank expressions (Sum, Mul, Max, Min).
 const MaxExpressionTerms = 1000
 
-// MaxExpressionDepth is the maximum nesting depth for rank expressions to prevent stack overflow.
+// MaxExpressionDepth is the maximum number of recursive marshalRank calls
+// permitted below a rank expression's top-level node, to prevent stack
+// overflow. A value of 100 allows expressions up to 101 nodes deep (the
+// top-level node plus 100 levels of nesting beneath it).
 const MaxExpressionDepth = 100
 
 func NewRrfRank(opts ...RrfOption) (*RrfRank, error) {

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -104,9 +104,19 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
 }
 
-func marshalRank(rank Rank) ([]byte, error) {
+type depthAwareRank interface {
+	marshalJSONWithDepth(depth int) ([]byte, error)
+}
+
+func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if isNilRank(rank) {
 		return nil, ErrNilRank
+	}
+	if depth > MaxExpressionDepth {
+		return nil, errors.Errorf("rank expression exceeds maximum depth of %d", MaxExpressionDepth)
+	}
+	if rank, ok := rank.(depthAwareRank); ok {
+		return rank.marshalJSONWithDepth(depth)
 	}
 	return rank.MarshalJSON()
 }
@@ -238,12 +248,16 @@ func (s *SumRank) Min(operand Operand) Rank {
 }
 
 func (s *SumRank) MarshalJSON() ([]byte, error) {
+	return s.marshalJSONWithDepth(0)
+}
+
+func (s *SumRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	if len(s.ranks) > MaxExpressionTerms {
 		return nil, errors.Errorf("sum expression exceeds maximum of %d terms", MaxExpressionTerms)
 	}
 	rankMaps := make([]json.RawMessage, len(s.ranks))
 	for i, r := range s.ranks {
-		data, err := marshalRank(r)
+		data, err := marshalRank(r, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -306,11 +320,15 @@ func (s *SubRank) Min(operand Operand) Rank {
 }
 
 func (s *SubRank) MarshalJSON() ([]byte, error) {
-	leftData, err := marshalRank(s.left)
+	return s.marshalJSONWithDepth(0)
+}
+
+func (s *SubRank) marshalJSONWithDepth(depth int) ([]byte, error) {
+	leftData, err := marshalRank(s.left, depth+1)
 	if err != nil {
 		return nil, err
 	}
-	rightData, err := marshalRank(s.right)
+	rightData, err := marshalRank(s.right, depth+1)
 	if err != nil {
 		return nil, err
 	}
@@ -381,12 +399,16 @@ func (m *MulRank) Min(operand Operand) Rank {
 }
 
 func (m *MulRank) MarshalJSON() ([]byte, error) {
+	return m.marshalJSONWithDepth(0)
+}
+
+func (m *MulRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	if len(m.ranks) > MaxExpressionTerms {
 		return nil, errors.Errorf("mul expression exceeds maximum of %d terms", MaxExpressionTerms)
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := marshalRank(r)
+		data, err := marshalRank(r, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -454,6 +476,10 @@ func (d *DivRank) Min(operand Operand) Rank {
 }
 
 func (d *DivRank) MarshalJSON() ([]byte, error) {
+	return d.marshalJSONWithDepth(0)
+}
+
+func (d *DivRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	// Check for division by zero literal.
 	// NOTE: Only catches literal Val(0). Complex expressions like Val(1).Sub(Val(1))
 	// are not detected; the server will return Inf/NaN following NumPy semantics.
@@ -461,11 +487,11 @@ func (d *DivRank) MarshalJSON() ([]byte, error) {
 		return nil, errors.New("division by zero: denominator is a zero literal")
 	}
 
-	leftData, err := marshalRank(d.left)
+	leftData, err := marshalRank(d.left, depth+1)
 	if err != nil {
 		return nil, err
 	}
-	rightData, err := marshalRank(d.right)
+	rightData, err := marshalRank(d.right, depth+1)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +556,11 @@ func (a *AbsRank) Min(operand Operand) Rank {
 }
 
 func (a *AbsRank) MarshalJSON() ([]byte, error) {
-	data, err := marshalRank(a.rank)
+	return a.marshalJSONWithDepth(0)
+}
+
+func (a *AbsRank) marshalJSONWithDepth(depth int) ([]byte, error) {
+	data, err := marshalRank(a.rank, depth+1)
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +620,11 @@ func (e *ExpRank) Min(operand Operand) Rank {
 }
 
 func (e *ExpRank) MarshalJSON() ([]byte, error) {
-	data, err := marshalRank(e.rank)
+	return e.marshalJSONWithDepth(0)
+}
+
+func (e *ExpRank) marshalJSONWithDepth(depth int) ([]byte, error) {
+	data, err := marshalRank(e.rank, depth+1)
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +684,11 @@ func (l *LogRank) Min(operand Operand) Rank {
 }
 
 func (l *LogRank) MarshalJSON() ([]byte, error) {
-	data, err := marshalRank(l.rank)
+	return l.marshalJSONWithDepth(0)
+}
+
+func (l *LogRank) marshalJSONWithDepth(depth int) ([]byte, error) {
+	data, err := marshalRank(l.rank, depth+1)
 	if err != nil {
 		return nil, err
 	}
@@ -719,12 +757,16 @@ func (m *MaxRank) Min(operand Operand) Rank {
 }
 
 func (m *MaxRank) MarshalJSON() ([]byte, error) {
+	return m.marshalJSONWithDepth(0)
+}
+
+func (m *MaxRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	if len(m.ranks) > MaxExpressionTerms {
 		return nil, errors.Errorf("max expression exceeds maximum of %d terms", MaxExpressionTerms)
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := marshalRank(r)
+		data, err := marshalRank(r, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -795,12 +837,16 @@ func (m *MinRank) Min(operand Operand) Rank {
 }
 
 func (m *MinRank) MarshalJSON() ([]byte, error) {
+	return m.marshalJSONWithDepth(0)
+}
+
+func (m *MinRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	if len(m.ranks) > MaxExpressionTerms {
 		return nil, errors.Errorf("min expression exceeds maximum of %d terms", MaxExpressionTerms)
 	}
 	rankMaps := make([]json.RawMessage, len(m.ranks))
 	for i, r := range m.ranks {
-		data, err := marshalRank(r)
+		data, err := marshalRank(r, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -1235,6 +1281,10 @@ func (r *RrfRank) Min(operand Operand) Rank {
 }
 
 func (r *RrfRank) MarshalJSON() ([]byte, error) {
+	return r.marshalJSONWithDepth(0)
+}
+
+func (r *RrfRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 	err := r.Validate()
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot marshal RrfRank")
@@ -1283,7 +1333,7 @@ func (r *RrfRank) MarshalJSON() ([]byte, error) {
 
 	// Negate (RRF gives higher scores for better, Chroma needs lower for better)
 	result := rrfSum.Negate()
-	return result.MarshalJSON()
+	return marshalRank(result, depth+1)
 }
 
 func (r *RrfRank) UnmarshalJSON(_ []byte) error {

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -65,6 +65,7 @@ type Rank interface {
 	Log() Rank
 	Max(operand Operand) Rank
 	Min(operand Operand) Rank
+	marshalJSONWithDepth(depth int) ([]byte, error)
 	MarshalJSON() ([]byte, error)
 	UnmarshalJSON(b []byte) error
 }
@@ -104,8 +105,8 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
 }
 
-type depthAwareRank interface {
-	marshalJSONWithDepth(depth int) ([]byte, error)
+func (u *UnknownRank) marshalJSONWithDepth(_ int) ([]byte, error) {
+	return u.MarshalJSON()
 }
 
 func marshalRank(rank Rank, depth int) ([]byte, error) {
@@ -115,10 +116,7 @@ func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if depth > MaxExpressionDepth {
 		return nil, errors.Errorf("rank expression exceeds maximum depth of %d", MaxExpressionDepth)
 	}
-	if rank, ok := rank.(depthAwareRank); ok {
-		return rank.marshalJSONWithDepth(depth)
-	}
-	return rank.MarshalJSON()
+	return rank.marshalJSONWithDepth(depth)
 }
 
 // ValRank represents a constant numeric value in rank expressions.
@@ -184,6 +182,10 @@ func (v *ValRank) Min(operand Operand) Rank {
 
 func (v *ValRank) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]float64{"$val": v.value})
+}
+
+func (v *ValRank) marshalJSONWithDepth(_ int) ([]byte, error) {
+	return v.MarshalJSON()
 }
 
 func (v *ValRank) UnmarshalJSON(b []byte) error {
@@ -1081,6 +1083,10 @@ func (k *KnnRank) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{"$knn": inner})
 }
 
+func (k *KnnRank) marshalJSONWithDepth(_ int) ([]byte, error) {
+	return k.MarshalJSON()
+}
+
 func (k *KnnRank) UnmarshalJSON(b []byte) error {
 	return errors.New("json: cannot unmarshal KnnRank JSON object")
 }
@@ -1333,7 +1339,11 @@ func (r *RrfRank) marshalJSONWithDepth(depth int) ([]byte, error) {
 
 	// Negate (RRF gives higher scores for better, Chroma needs lower for better)
 	result := rrfSum.Negate()
-	return marshalRank(result, depth+1)
+	data, err := marshalRank(result, depth+1)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot marshal RrfRank")
+	}
+	return data, nil
 }
 
 func (r *RrfRank) UnmarshalJSON(_ []byte) error {

--- a/pkg/api/v2/rank_external_test.go
+++ b/pkg/api/v2/rank_external_test.go
@@ -1,0 +1,29 @@
+//go:build basicv2 && !cloud
+
+package v2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/amikos-tech/chroma-go/pkg/api/v2"
+)
+
+type customEmbeddedSumRank struct {
+	*v2.SumRank
+}
+
+func (*customEmbeddedSumRank) MarshalJSON() ([]byte, error) {
+	return []byte(`{"$custom":true}`), nil
+}
+
+func TestCustomRankEmbeddingCompositePreservesMarshalJSON(t *testing.T) {
+	sum := v2.Val(1).Add(v2.Val(2)).(*v2.SumRank)
+	custom := &customEmbeddedSumRank{SumRank: sum}
+
+	data, err := json.Marshal(&v2.SearchRequest{Rank: custom})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"rank":{"$custom":true}}`, string(data))
+}

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -876,6 +876,12 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 			rejectedDepth: 100,
 		},
 		{
+			name:          "sub-right",
+			build:         func(rank Rank) Rank { return Val(1).Sub(rank) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
 			name:          "mul",
 			build:         func(rank Rank) Rank { return rank.Multiply(Val(1)) },
 			acceptedDepth: 99,
@@ -884,6 +890,12 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 		{
 			name:          "div",
 			build:         func(rank Rank) Rank { return rank.Div(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "div-right",
+			build:         func(rank Rank) Rank { return Val(1).Div(rank) },
 			acceptedDepth: 99,
 			rejectedDepth: 100,
 		},

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -979,13 +979,11 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 	}
 }
 
-// TestMarshalRankFallbackForNestedNonDepthAwareChild exercises the
-// depthAwareRank fallback path (rank.go marshalRank) with a caller-supplied
-// Rank nested inside a built-in composite, not just used standalone. This is
-// what the depthAwareRank doc comment describes: a type that doesn't
-// implement depthAwareRank still marshals correctly via its own
-// MarshalJSON() when it's a child of a depth-tracked expression.
-func TestMarshalRankFallbackForNestedNonDepthAwareChild(t *testing.T) {
+// TestMarshalRankFallbackForNestedNonCompositeChild exercises the marshalRank
+// fallback with a caller-supplied Rank nested inside a built-in composite, not
+// just used standalone. Caller-supplied ranks still marshal through their own
+// MarshalJSON method when they are children of a depth-tracked expression.
+func TestMarshalRankFallbackForNestedNonCompositeChild(t *testing.T) {
 	mr := mapBackedRank{"k": "v"}
 	rank := Val(0).Add(mr)
 

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -857,39 +857,112 @@ func TestMaxExpressionDepthConstant(t *testing.T) {
 
 func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 	tests := []struct {
-		name    string
-		depth   int
-		wantErr string
+		name          string
+		build         func(Rank) Rank
+		acceptedDepth int
+		rejectedDepth int
+		wantContext   string
 	}{
 		{
-			name:  "at maximum depth",
-			depth: MaxExpressionDepth,
+			name:          "sum",
+			build:         func(rank Rank) Rank { return rank.Add(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
 		},
 		{
-			name:    "over maximum depth",
-			depth:   MaxExpressionDepth + 1,
-			wantErr: fmt.Sprintf("rank expression exceeds maximum depth of %d", MaxExpressionDepth),
+			name:          "sub",
+			build:         func(rank Rank) Rank { return rank.Sub(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "mul",
+			build:         func(rank Rank) Rank { return rank.Multiply(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "div",
+			build:         func(rank Rank) Rank { return rank.Div(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "abs",
+			build:         func(rank Rank) Rank { return rank.Abs() },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "exp",
+			build:         func(rank Rank) Rank { return rank.Exp() },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "log",
+			build:         func(rank Rank) Rank { return rank.Log() },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "max",
+			build:         func(rank Rank) Rank { return rank.Max(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name:          "min",
+			build:         func(rank Rank) Rank { return rank.Min(Val(1)) },
+			acceptedDepth: 99,
+			rejectedDepth: 100,
+		},
+		{
+			name: "rrf",
+			build: func(rank Rank) Rank {
+				return mustNewRrfRank(t, WithRrfRanks(RankWithWeight{Rank: rank, Weight: 1}))
+			},
+			acceptedDepth: 96,
+			rejectedDepth: 97,
+			wantContext:   "cannot marshal RrfRank",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var rank Rank = Val(0)
-			for i := 0; i < tt.depth; i++ {
-				rank = rank.Log()
-			}
+			t.Run("accepts deepest valid child", func(t *testing.T) {
+				var inner Rank = Val(0)
+				for i := 0; i < tt.acceptedDepth; i++ {
+					inner = inner.Log()
+				}
+				rank := tt.build(inner)
 
-			var data []byte
-			var err error
-			require.NotPanics(t, func() {
-				data, err = rank.MarshalJSON()
+				var data []byte
+				var err error
+				require.NotPanics(t, func() {
+					data, err = rank.MarshalJSON()
+				})
+				require.NoError(t, err)
+				require.NotEmpty(t, data)
 			})
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.NotEmpty(t, data)
+
+			t.Run("rejects next child depth", func(t *testing.T) {
+				var inner Rank = Val(0)
+				for i := 0; i < tt.rejectedDepth; i++ {
+					inner = inner.Log()
+				}
+				rank := tt.build(inner)
+
+				var err error
+				require.NotPanics(t, func() {
+					_, err = rank.MarshalJSON()
+				})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), fmt.Sprintf("rank expression exceeds maximum depth of %d", MaxExpressionDepth))
+				if tt.wantContext != "" {
+					require.Contains(t, err.Error(), tt.wantContext)
+				}
+			})
 		})
 	}
 }

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -936,7 +936,7 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 			},
 			acceptedDepth: 96,
 			rejectedDepth: 97,
-			wantContext:   "cannot marshal RrfRank",
+			wantContext:   "cannot marshal RrfRank expression",
 		},
 	}
 
@@ -977,4 +977,30 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestMarshalRankFallbackForNestedNonDepthAwareChild exercises the
+// depthAwareRank fallback path (rank.go marshalRank) with a caller-supplied
+// Rank nested inside a built-in composite, not just used standalone. This is
+// what the depthAwareRank doc comment describes: a type that doesn't
+// implement depthAwareRank still marshals correctly via its own
+// MarshalJSON() when it's a child of a depth-tracked expression.
+func TestMarshalRankFallbackForNestedNonDepthAwareChild(t *testing.T) {
+	mr := mapBackedRank{"k": "v"}
+	rank := Val(0).Add(mr)
+
+	data, err := rank.MarshalJSON()
+	require.NoError(t, err)
+
+	var result map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &result))
+	require.Contains(t, result, "$sum")
+
+	var terms []json.RawMessage
+	require.NoError(t, json.Unmarshal(result["$sum"], &terms))
+	require.Len(t, terms, 2)
+
+	mrData, err := mr.MarshalJSON()
+	require.NoError(t, err)
+	require.JSONEq(t, string(mrData), string(terms[1]))
 }

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"testing"
 
@@ -854,16 +855,41 @@ func TestMaxExpressionDepthConstant(t *testing.T) {
 	require.LessOrEqual(t, MaxExpressionDepth, 1000)
 }
 
-func TestDeepExpressionChain(t *testing.T) {
-	// Create a deeply nested Sub expression (which doesn't flatten)
-	// This tests that such expressions can be built and serialized
-	var rank Rank = Val(0.0)
-	for i := 0; i < 50; i++ {
-		rank = rank.Sub(Val(1.0))
+func TestRankMarshalExpressionDepthGuard(t *testing.T) {
+	tests := []struct {
+		name    string
+		depth   int
+		wantErr string
+	}{
+		{
+			name:  "at maximum depth",
+			depth: MaxExpressionDepth,
+		},
+		{
+			name:    "over maximum depth",
+			depth:   MaxExpressionDepth + 1,
+			wantErr: fmt.Sprintf("rank expression exceeds maximum depth of %d", MaxExpressionDepth),
+		},
 	}
 
-	// Should serialize without error (50 < MaxExpressionDepth)
-	data, err := rank.MarshalJSON()
-	require.NoError(t, err)
-	require.NotEmpty(t, data)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rank Rank = Val(0)
+			for i := 0; i < tt.depth; i++ {
+				rank = rank.Log()
+			}
+
+			var data []byte
+			var err error
+			require.NotPanics(t, func() {
+				data, err = rank.MarshalJSON()
+			})
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotEmpty(t, data)
+		})
+	}
 }

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -938,6 +938,21 @@ func TestRankMarshalExpressionDepthGuard(t *testing.T) {
 			rejectedDepth: 97,
 			wantContext:   "cannot marshal RrfRank expression",
 		},
+		{
+			// A second RRF rank adds an extra SumRank wrapper around the
+			// per-rank terms, costing one more level of depth budget than
+			// the single-rank case above.
+			name: "rrf-multi",
+			build: func(rank Rank) Rank {
+				return mustNewRrfRank(t, WithRrfRanks(
+					RankWithWeight{Rank: rank, Weight: 1},
+					RankWithWeight{Rank: Val(0), Weight: 1},
+				))
+			},
+			acceptedDepth: 95,
+			rejectedDepth: 96,
+			wantContext:   "cannot marshal RrfRank expression",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/api/v2/search.go
+++ b/pkg/api/v2/search.go
@@ -322,7 +322,7 @@ func (r *SearchRequest) MarshalJSON() ([]byte, error) {
 	// Rank is an exported interface field, so a struct-literal request can carry a
 	// typed nil that never passed through WithRank or embedTextQueries.
 	if !isNilInterface(r.Rank) {
-		rankData, err := r.Rank.MarshalJSON()
+		rankData, err := marshalRank(r.Rank, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1005,23 +1005,24 @@ func TestNilOptionSentinels(t *testing.T) {
 	})
 }
 
-// mapBackedRank is a caller-supplied Rank implementation backed by a nillable
-// non-pointer type, which external packages may legitimately write.
+// mapBackedRank is a package-local Rank test double backed by a nillable
+// non-pointer type.
 type mapBackedRank map[string]string
 
-func (m mapBackedRank) IsOperand()                   {}
-func (m mapBackedRank) Multiply(Operand) Rank        { return m }
-func (m mapBackedRank) Sub(Operand) Rank             { return m }
-func (m mapBackedRank) Add(Operand) Rank             { return m }
-func (m mapBackedRank) Div(Operand) Rank             { return m }
-func (m mapBackedRank) Negate() Rank                 { return m }
-func (m mapBackedRank) Abs() Rank                    { return m }
-func (m mapBackedRank) Exp() Rank                    { return m }
-func (m mapBackedRank) Log() Rank                    { return m }
-func (m mapBackedRank) Max(Operand) Rank             { return m }
-func (m mapBackedRank) Min(Operand) Rank             { return m }
-func (m mapBackedRank) UnmarshalJSON([]byte) error   { return nil }
-func (m mapBackedRank) MarshalJSON() ([]byte, error) { return json.Marshal(map[string]string(m)) }
+func (m mapBackedRank) IsOperand()                                 {}
+func (m mapBackedRank) Multiply(Operand) Rank                      { return m }
+func (m mapBackedRank) Sub(Operand) Rank                           { return m }
+func (m mapBackedRank) Add(Operand) Rank                           { return m }
+func (m mapBackedRank) Div(Operand) Rank                           { return m }
+func (m mapBackedRank) Negate() Rank                               { return m }
+func (m mapBackedRank) Abs() Rank                                  { return m }
+func (m mapBackedRank) Exp() Rank                                  { return m }
+func (m mapBackedRank) Log() Rank                                  { return m }
+func (m mapBackedRank) Max(Operand) Rank                           { return m }
+func (m mapBackedRank) Min(Operand) Rank                           { return m }
+func (m mapBackedRank) UnmarshalJSON([]byte) error                 { return nil }
+func (m mapBackedRank) MarshalJSON() ([]byte, error)               { return json.Marshal(map[string]string(m)) }
+func (m mapBackedRank) marshalJSONWithDepth(_ int) ([]byte, error) { return m.MarshalJSON() }
 
 func TestIsNilInterfaceNillableKinds(t *testing.T) {
 	var nilMap map[string]string

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1007,9 +1007,9 @@ func TestNilOptionSentinels(t *testing.T) {
 
 // mapBackedRank is a caller-supplied Rank implementation backed by a nillable
 // non-pointer type, which external packages may legitimately write. It does
-// not implement depthAwareRank, so marshalRank must fall back to its plain
-// MarshalJSON() rather than requiring every Rank implementation to know about
-// internal depth tracking.
+// not implement depthAwareRank; TestMarshalRankFallbackForNestedNonDepthAwareChild
+// (rank_test.go) verifies marshalRank falls back to its plain MarshalJSON()
+// when it's nested inside a depth-tracked composite Rank.
 type mapBackedRank map[string]string
 
 func (m mapBackedRank) IsOperand()                   {}

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1005,24 +1005,26 @@ func TestNilOptionSentinels(t *testing.T) {
 	})
 }
 
-// mapBackedRank is a package-local Rank test double backed by a nillable
-// non-pointer type.
+// mapBackedRank is a caller-supplied Rank implementation backed by a nillable
+// non-pointer type, which external packages may legitimately write. It does
+// not implement depthAwareRank, so marshalRank must fall back to its plain
+// MarshalJSON() rather than requiring every Rank implementation to know about
+// internal depth tracking.
 type mapBackedRank map[string]string
 
-func (m mapBackedRank) IsOperand()                                 {}
-func (m mapBackedRank) Multiply(Operand) Rank                      { return m }
-func (m mapBackedRank) Sub(Operand) Rank                           { return m }
-func (m mapBackedRank) Add(Operand) Rank                           { return m }
-func (m mapBackedRank) Div(Operand) Rank                           { return m }
-func (m mapBackedRank) Negate() Rank                               { return m }
-func (m mapBackedRank) Abs() Rank                                  { return m }
-func (m mapBackedRank) Exp() Rank                                  { return m }
-func (m mapBackedRank) Log() Rank                                  { return m }
-func (m mapBackedRank) Max(Operand) Rank                           { return m }
-func (m mapBackedRank) Min(Operand) Rank                           { return m }
-func (m mapBackedRank) UnmarshalJSON([]byte) error                 { return nil }
-func (m mapBackedRank) MarshalJSON() ([]byte, error)               { return json.Marshal(map[string]string(m)) }
-func (m mapBackedRank) marshalJSONWithDepth(_ int) ([]byte, error) { return m.MarshalJSON() }
+func (m mapBackedRank) IsOperand()                   {}
+func (m mapBackedRank) Multiply(Operand) Rank        { return m }
+func (m mapBackedRank) Sub(Operand) Rank             { return m }
+func (m mapBackedRank) Add(Operand) Rank             { return m }
+func (m mapBackedRank) Div(Operand) Rank             { return m }
+func (m mapBackedRank) Negate() Rank                 { return m }
+func (m mapBackedRank) Abs() Rank                    { return m }
+func (m mapBackedRank) Exp() Rank                    { return m }
+func (m mapBackedRank) Log() Rank                    { return m }
+func (m mapBackedRank) Max(Operand) Rank             { return m }
+func (m mapBackedRank) Min(Operand) Rank             { return m }
+func (m mapBackedRank) UnmarshalJSON([]byte) error   { return nil }
+func (m mapBackedRank) MarshalJSON() ([]byte, error) { return json.Marshal(map[string]string(m)) }
 
 func TestIsNilInterfaceNillableKinds(t *testing.T) {
 	var nilMap map[string]string

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1006,10 +1006,10 @@ func TestNilOptionSentinels(t *testing.T) {
 }
 
 // mapBackedRank is a caller-supplied Rank implementation backed by a nillable
-// non-pointer type, which external packages may legitimately write. It does
-// not implement depthAwareRank; TestMarshalRankFallbackForNestedNonDepthAwareChild
-// (rank_test.go) verifies marshalRank falls back to its plain MarshalJSON()
-// when it's nested inside a depth-tracked composite Rank.
+// non-pointer type, which external packages may legitimately write.
+// TestMarshalRankFallbackForNestedNonCompositeChild (rank_test.go) verifies
+// marshalRank falls back to its plain MarshalJSON() when it's nested inside a
+// depth-tracked composite Rank.
 type mapBackedRank map[string]string
 
 func (m mapBackedRank) IsOperand()                   {}


### PR DESCRIPTION
## Summary

Closes #528 by applying the shared `MaxExpressionDepth` limit to built-in Rank JSON marshaling. Deep expressions now return a normal error before recursive serialization can exhaust the process stack.

The guard preserves existing valid JSON, nil-rank behavior, and caller-defined Rank implementations. External types—including types that embed a built-in composite—continue to control their own `MarshalJSON` output.

## Changes

### Quick task 260731-nj1: Rank marshal depth guard

- Carry zero-based depth through every recursive built-in Rank serializer.
- Reject recursion beyond `MaxExpressionDepth` with the existing shared error text.
- Route generated RRF expressions and `SearchRequest` marshaling through the guarded path.

### Quick task 260731-pb1: Coverage and compatibility hardening

- Cover both sides of the effective depth boundary for Sum, Sub, Mul, Div, Abs, Exp, Log, Max, Min, and RRF.
- Preserve RRF-specific context when its generated expression exceeds the limit.
- Dispatch only exact built-in composite types through the private depth-aware path and retain the normal `MarshalJSON` fallback for caller-defined Rank implementations.
- Add an external-package regression for a custom Rank that embeds `SumRank`.

## Requirements Addressed

- **GH-528:** Bound recursive Rank JSON marshaling at the same shared depth limit used by query embedding.

## Verification

- [x] Focused depth, fallback, external-embedding, and nil-sentinel regressions passed.
- [x] `make test` passed: 1,981 tests, 7 expected skips.
- [x] `make lint` passed with 0 issues.
- [x] `git diff --check` passed.

## Key Decisions

- Keep the public `Rank` interface externally implementable.
- Count the top-level node at depth zero and reject only values greater than 100.
- Match exact built-in composite types so embedding one does not override caller-defined serialization.
- Preserve existing leaf encoders, validation, term limits, and accepted wire shapes.
- Use squash merge after CI and review pass.
