### PR TITLE
fix(api): guard nested Where-clause depth

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Completed quick task 260801-g9r: Review, validate, and address the scope of issue 516"
+status: "Completed quick task 260801-qmr: Validate and address issue #533"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-08-01T09:43:09Z"
+last_updated: "2026-08-01T16:27:36Z"
 last_activity: 2026-08-01
 progress:
   total_phases: 11
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Completed quick task 260801-g9r: Review, validate, and address the scope of issue 516
-Last activity: 2026-08-01 - Completed quick task 260801-g9r: Review, validate, and address the scope of issue 516
+Status: Completed quick task 260801-qmr: Validate and address issue #533
+Last activity: 2026-08-01 - Completed quick task 260801-qmr: Validate and address issue #533
 
 Progress: [██████████] 100%
 
@@ -85,6 +85,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-pb1 | Harden Rank depth tracking and add complete depth-guard coverage, including RrfRank | 2026-07-31 | 3243aa4 | Complete | [260731-pb1-harden-rank-depth-tracking-and-add-compl](./quick/260731-pb1-harden-rank-depth-tracking-and-add-compl/) |
 | 260731-tq1 | Verify and address issue 499 | 2026-07-31 | 96fade3 | Verified | [260731-tq1-verify-and-address-issue-499](./quick/260731-tq1-verify-and-address-issue-499/) |
 | 260801-g9r | Review, validate, and address the scope of issue 516 | 2026-08-01 | 5dff760 | Verified | [260801-g9r-review-validate-and-address-the-scope-of](./quick/260801-g9r-review-validate-and-address-the-scope-of/) |
+| 260801-qmr | Validate and address issue #533 | 2026-08-01 | bb3ef57 | Verified | [260801-qmr-validate-and-address-issue-533](./quick/260801-qmr-validate-and-address-issue-533/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,10 +2,10 @@
 gsd_state_version: 1.0
 milestone: v0.4.2
 milestone_name: Bug Fixes and Robustness
-status: "Completed quick task 260801-qmr: Validate and address issue #533"
+status: "Quick task 260801-qmr shipped — PR #534"
 stopped_at: "Phase 26 shipped — PR #509"
-last_updated: "2026-08-01T16:27:36Z"
-last_activity: 2026-08-01
+last_updated: "2026-08-02T07:14:42.295Z"
+last_activity: 2026-08-02
 progress:
   total_phases: 11
   completed_phases: 7
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 
 Phase: 30
 Plan: Not started
-Status: Completed quick task 260801-qmr: Validate and address issue #533
-Last activity: 2026-08-01 - Completed quick task 260801-qmr: Validate and address issue #533
+Status: Quick task 260801-qmr shipped — PR #534
+Last activity: 2026-08-02
 
 Progress: [██████████] 100%
 

--- a/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-PLAN.md
+++ b/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-PLAN.md
@@ -1,0 +1,179 @@
+---
+phase: quick-260801-qmr
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/where.go
+  - pkg/api/v2/where_test.go
+autonomous: true
+requirements:
+  - GH-533
+
+must_haves:
+  truths:
+    - "A caller can validate a nested $and/$or Where expression within MaxExpressionDepth without changing its current valid result."
+    - "A Where expression one recursive child beyond MaxExpressionDepth returns a deterministic validation error instead of continuing unbounded recursion."
+    - "JSON marshalling a too-deep Where expression returns that validation error without panicking or encoding a partial expression."
+    - "Existing operator, empty-operand, and typed-nil validation behavior remains unchanged."
+  artifacts:
+    - path: "pkg/api/v2/where.go"
+      provides: "Depth-aware recursive validation for built-in compound Where clauses"
+      contains: "MaxExpressionDepth"
+    - path: "pkg/api/v2/where_test.go"
+      provides: "Boundary and JSON-path regressions for nested Where expressions"
+      contains: "TestWhereClauseExpressionDepthGuard"
+  key_links:
+    - from: "pkg/api/v2/where.go:WhereClauseWhereClauses.Validate"
+      to: "pkg/api/v2/rank.go:MaxExpressionDepth"
+      via: "shared package-level expression-depth limit"
+      pattern: "MaxExpressionDepth"
+    - from: "pkg/api/v2/where.go:WhereClauseWhereClauses.MarshalJSON"
+      to: "pkg/api/v2/where.go:WhereClauseWhereClauses.Validate"
+      via: "validation before json.Marshal"
+      pattern: "w\\.Validate\\(\\)"
+---
+
+<objective>
+Close issue 533 by putting a bounded recursive validation path around nested `$and` and `$or` metadata clauses.
+
+Purpose: adversarial or accidental nesting must fail predictably before it can exhaust the Go call stack during validation or JSON marshalling, using the SDK's established expression-depth policy.
+Output: a depth-aware `WhereClauseWhereClauses` validator and focused boundary regressions.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@.planning/PROJECT.md
+@pkg/api/v2/where.go
+@pkg/api/v2/where_test.go
+@pkg/api/v2/rank.go
+@pkg/api/v2/rank_test.go
+
+**Working directory:** `/Users/tazarov/GolandProjects/chroma-go`
+
+**Scope and compatibility constraints:**
+- Reuse the existing package-level `MaxExpressionDepth = 100`; do not add a Where-specific limit or dependency.
+- Match rank's zero-based convention: validate the root compound at depth `0`, permit at most `MaxExpressionDepth` recursive child calls below it, and reject only the next level with `where expression exceeds maximum depth of %d`.
+- Keep the public `WhereClause` interface, `And`/`Or` constructors, existing JSON shape, and lazy validation behavior for non-compound clauses unchanged.
+- Preserve the current validation order for each compound node: invalid operator, empty operand, and nil/typed-nil child errors must retain their existing behavior before a child is delegated for recursive validation.
+- Keep the change confined to `pkg/api/v2/where.go` and its colocated build-tagged test file. Preserve unrelated working-tree edits; do not add packages, services, or configuration. Execution creates one atomic local commit for this task and performs no push, pull-request, or merge operation; any later merge must use squash merge.
+</context>
+
+<interfaces>
+<!-- Existing contracts the executor should use directly. -->
+
+From `pkg/api/v2/where.go`:
+
+```go
+type WhereClause interface {
+	Operator() WhereFilterOperator
+	Key() string
+	Operand() interface{}
+	String() string
+	Validate() error
+	MarshalJSON() ([]byte, error)
+	UnmarshalJSON(b []byte) error
+}
+
+type WhereClauseWhereClauses struct {
+	WhereClauseBase
+	operand []WhereClause
+}
+
+func (w *WhereClauseWhereClauses) Validate() error
+func (w *WhereClauseWhereClauses) MarshalJSON() ([]byte, error)
+func And(clauses ...WhereClause) WhereClause
+func Or(clauses ...WhereClause) WhereClause
+```
+
+`WhereClauseWhereClauses.MarshalJSON` already calls `Validate` before encoding, so the depth guard belongs in the validation path and protects both direct validation and JSON marshalling.
+
+From `pkg/api/v2/rank.go`:
+
+```go
+const MaxExpressionDepth = 100
+```
+
+The rank implementation uses a zero-based depth counter and errors when `depth > MaxExpressionDepth`; retain that boundary convention without changing rank behavior.
+</interfaces>
+
+<source_audit>
+
+| Source | ID | Required item | Plan | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| GOAL | — | Bound recursive `$and`/`$or` Where validation to prevent stack exhaustion | 01 | COVERED | Implemented and exercised through `Validate` and JSON marshalling. |
+| REQ | GH-533 | Reuse `MaxExpressionDepth` and add focused tests | 01 | COVERED | Uses the existing package constant and boundary regressions. |
+| RESEARCH | — | Follow the rank depth-guard convention and retain existing API behavior | 01 | COVERED | Root-zero accounting, same limit, no new public API. |
+| CONTEXT | — | No CONTEXT.md or locked decisions were supplied for this quick task | 01 | N/A | No deferred ideas or decisions to implement. |
+
+</source_audit>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Guard recursive compound Where validation at the shared expression limit</name>
+  <files>pkg/api/v2/where.go, pkg/api/v2/where_test.go</files>
+  <behavior>
+    - A generated alternating `And`/`Or` expression with exactly `MaxExpressionDepth` recursive child calls below its root validates and marshals successfully.
+    - The next recursive child level fails both `WhereClause.Validate` and `json.Marshal` without a panic, with `where expression exceeds maximum depth of 100` in the returned error.
+    - A shallow valid compound expression retains its existing JSON output.
+    - Existing invalid operator, empty compound operand, nil child, and typed-nil child results keep their established errors.
+  </behavior>
+  <action>
+    Start with a failing `TestWhereClauseExpressionDepthGuard` in `pkg/api/v2/where_test.go`, following the file's `basicv2 && !cloud` build tag, `testify/require` assertions, and `encoding/json` usage. Add a local test builder that starts from a valid leaf such as `EqString(K("depth"), "leaf")` and wraps it with alternating `And` and `Or` compound clauses. Exercise the zero-based boundary precisely: a tree with `MaxExpressionDepth` recursive child calls below the root succeeds, while the next child level fails. For the rejection case, separately call `Validate` and `json.Marshal`; use `require.NotPanics`, require an error, and assert it contains `fmt.Sprintf("where expression exceeds maximum depth of %d", MaxExpressionDepth)`. Include a shallow compound JSON assertion so the test names the compatibility baseline.
+
+    In `pkg/api/v2/where.go`, retain `WhereClauseWhereClauses.Validate()` as the public entry point but have it invoke a private depth-aware compound validator at depth `0`. Add a small unexported child-validation helper that receives the current depth. It must preserve the existing parent checks for a nil or typed-nil `WhereClause` before delegating, route an exact `*WhereClauseWhereClauses` child to the private depth-aware validator with `depth + 1` instead of calling its public `Validate` method, and call `Validate` normally for all other `WhereClause` implementations. At each recursive child boundary, reject `depth > MaxExpressionDepth` using `errors.Errorf("where expression exceeds maximum depth of %d", MaxExpressionDepth)`. This counts every recursive validation call, including the final leaf, exactly as the rank guard counts recursive marshalling calls.
+
+    Do not introduce a new exported helper, alter the `WhereClause` interface, change `And`/`Or`, weaken the existing typed-nil protection in `MarshalJSON`, or change rank code. `MarshalJSON` must continue to call the public `Validate` once before it constructs the existing `$and`/`$or` map, so a too-deep tree is rejected before `encoding/json` traverses it. This task is one atomic implementation commit.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s</automated>
+  </verify>
+  <done>`WhereClauseWhereClauses.Validate` has a root-zero, shared-limit recursion guard; nesting one child past `MaxExpressionDepth` returns the stable Where-depth error through both validation and JSON marshalling without panic; and the focused tagged regression passes.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+| --- | --- |
+| Caller-controlled `WhereClause` tree -> recursive validation | A public `$and`/`$or` expression can contain arbitrarily deep nested compound clauses before it reaches the SDK's validator or JSON encoder. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --- | --- | --- | --- | --- |
+| T-qmr-533-01 | Denial of Service | `WhereClauseWhereClauses.Validate` | mitigate | Track recursion with the existing `MaxExpressionDepth` and reject the first over-limit child before recursive validation or JSON encoding continues. |
+| T-qmr-533-02 | Tampering | `WhereClauseWhereClauses.MarshalJSON` | mitigate | Retain validate-before-encode wiring and prove a too-deep caller tree returns an error rather than producing a partial JSON expression. |
+| T-qmr-533-SC | Tampering | Package installation | accept | This plan performs no package-manager operation or dependency change. |
+</threat_model>
+
+<verification>
+
+Run the focused regression, then the tagged package suite and whitespace check:
+
+```text
+go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s
+go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=60s
+git diff --check
+```
+</verification>
+
+<success_criteria>
+
+- One package-level expression limit bounds all recursive built-in `$and`/`$or` child validation; no separate limit or public API is introduced.
+- The deepest permitted expression validates and has the existing JSON form, while one additional child returns the stable depth error from both public paths without panic.
+- The complete `basicv2` V2 package test suite passes with unchanged existing validation behavior.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-SUMMARY.md` when implementation is complete.
+</output>

--- a/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-SUMMARY.md
+++ b/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-SUMMARY.md
@@ -1,0 +1,91 @@
+---
+phase: quick-260801-qmr
+plan: 01
+status: complete
+subsystem: api
+tags: [go, api-v2, validation, json, recursion-safety]
+requires:
+  - phase: prior-rank-depth-guard
+    provides: MaxExpressionDepth boundary convention
+provides:
+  - Bounded validation for nested built-in Where compound clauses
+  - Regression coverage for validation and JSON depth boundaries
+affects: [where-clauses, search-filter-validation]
+tech-stack:
+  added: []
+  patterns:
+    - Reuse shared expression-depth limits with a private recursive validator
+key-files:
+  created: []
+  modified:
+    - pkg/api/v2/where.go
+    - pkg/api/v2/where_test.go
+key-decisions:
+  - "Use the package-level MaxExpressionDepth with root depth zero to match rank expressions."
+  - "Validate nested built-in compound clauses through a private helper while preserving external WhereClause validation behavior."
+patterns-established:
+  - "Recursive built-in Where clauses carry depth explicitly; public Validate starts at depth zero."
+requirements-completed: [GH-533]
+duration: 5min
+completed: 2026-08-01
+---
+
+# Quick Task 260801-qmr Summary
+
+**Nested `$and` and `$or` Where clauses now stop at the shared expression-depth boundary before validation or JSON encoding can recurse indefinitely.**
+
+## Performance
+
+- **Duration:** 5 min
+- **Tasks:** 1/1
+- **Files modified:** 2
+
+## Accomplishments
+
+- Added a root-zero, private depth-aware validation path for built-in compound Where clauses.
+- Reused `MaxExpressionDepth` and return a stable error for the first over-limit child.
+- Covered the permitted boundary, rejection from `Validate`, rejection from `json.Marshal`, and unchanged shallow JSON output.
+
+## Task Commit
+
+1. **Task 1: Guard recursive compound Where validation at the shared expression limit** - `bb3ef57` (squash commit)
+
+## Files Created/Modified
+
+- `pkg/api/v2/where.go` - Delegates compound child validation through a depth-aware private helper.
+- `pkg/api/v2/where_test.go` - Adds depth-boundary and JSON-marshalling regressions.
+
+## Verification
+
+- `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s` — passed.
+- `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=60s` — passed.
+- `git diff --check` — passed.
+
+## Decisions Made
+
+- Root compound expressions start at depth `0`; the final leaf at depth `MaxExpressionDepth` remains valid, matching rank's boundary semantics.
+- Only exact built-in `*WhereClauseWhereClauses` children use the private recursive path; other `WhereClause` implementations keep their existing `Validate` behavior.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+The depth guard was squash-merged into the PR branch and is ready for verification.
+
+## Self-Check: PASSED
+
+- Implementation files exist and commit `bb3ef57` is present.
+
+---
+*Quick task: 260801-qmr*
+*Completed: 2026-08-01*

--- a/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-VERIFICATION.md
+++ b/.planning/quick/260801-qmr-validate-and-address-issue-533/260801-qmr-VERIFICATION.md
@@ -1,0 +1,85 @@
+---
+phase: quick-260801-qmr
+verified: 2026-08-01T16:25:49Z
+status: passed
+score: 4/4 must-haves verified
+overrides_applied: 0
+---
+
+# Quick Task: Issue 533 Where-expression Depth Guard Verification Report
+
+**Task Goal:** Validate and address GitHub issue #533 by bounding recursive `$and`/`$or` `WhereClauseWhereClauses.Validate()` using the existing `MaxExpressionDepth`, protecting the JSON-marshalling path without changing existing public behavior.
+
+**Verified:** 2026-08-01T16:25:49Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | A caller can validate a nested `$and`/`$or` Where expression within `MaxExpressionDepth` without changing its current valid result. | ✓ VERIFIED | `Validate()` begins at depth 0 in `where.go:460-461`. The regression builds exactly 100 recursive child calls and requires both `Validate` and `json.Marshal` to succeed (`where_test.go:401-408`); the focused test passed. |
+| 2 | A Where expression one recursive child beyond `MaxExpressionDepth` returns a deterministic validation error instead of continuing unbounded recursion. | ✓ VERIFIED | Every compound child is checked by `validateWhereClauseChild`; after the preserved nil check it rejects `depth > MaxExpressionDepth` with `where expression exceeds maximum depth of %d` (`where.go:479-489`). The 101st-child test asserts this error with `NotPanics` (`where_test.go:410-417`) and passed. |
+| 3 | JSON marshalling a too-deep Where expression returns that validation error without panicking or encoding a partial expression. | ✓ VERIFIED | `MarshalJSON` calls public `Validate` before constructing the map or calling `json.Marshal` (`where.go:494-501`). The regression calls `json.Marshal` on the over-limit expression inside `NotPanics`, asserts a nil byte slice, and asserts the same error (`where_test.go:419-425`); the focused test passed. |
+| 4 | Existing operator, empty-operand, and typed-nil validation behavior remains unchanged. | ✓ VERIFIED | The public `WhereClause` interface and `And`/`Or` constructors are unchanged (`where.go:26-34`, `where.go:743-758`). The committed diff changes only the compound recursion dispatch: the invalid-operator and empty-operand checks and their error strings are retained before child processing (`where.go:464-476`); nil/typed-nil detection remains first in the child helper (`where.go:479-482`). Existing empty-operand/nil and typed-nil marshal regressions remain in `where_test.go:282-380`; the complete tagged package suite passed. |
+
+**Score:** 4/4 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `pkg/api/v2/where.go` | Depth-aware recursive validation for built-in compound Where clauses using `MaxExpressionDepth` | ✓ VERIFIED | Exists (898 lines); substantive private `validateWithDepth` and `validateWhereClauseChild` enforce the shared limit. Wired through public `Validate` and `MarshalJSON`. No public API additions; the committed diff modifies only this behavior. |
+| `pkg/api/v2/where_test.go` | Boundary and JSON-path regressions for nested Where expressions | ✓ VERIFIED | Exists (423 lines); `TestWhereClauseExpressionDepthGuard` covers shallow JSON compatibility, the exact boundary, one level too deep, no panic, and nil output. The file has the existing `basicv2 && !cloud` build tag and ran in both test commands. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `WhereClauseWhereClauses.Validate` | `MaxExpressionDepth` in `pkg/api/v2/rank.go` | shared package-level expression-depth limit | ✓ WIRED | `Validate` delegates to depth 0; its child helper references `MaxExpressionDepth` (`where.go:460-489`). The sole package-level constant remains `const MaxExpressionDepth = 100` (`rank.go:1353-1357`). |
+| `WhereClauseWhereClauses.MarshalJSON` | `WhereClauseWhereClauses.Validate` | validation before `json.Marshal` | ✓ WIRED | `MarshalJSON` returns immediately on `w.Validate()` error before it constructs the operator map or calls `json.Marshal` (`where.go:494-501`). |
+
+`gsd-sdk query verify.key-links` reported both links as missing because it treats symbol-qualified `from:` values as source-file paths. Direct source inspection above verifies the actual links.
+
+### Data-Flow Trace (Level 4)
+
+Not applicable: this is synchronous validation/serialization logic, not an artifact that renders or fetches dynamic data. The direct control flow is fully traced in the key-link table.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Exact depth boundary; over-limit `Validate` and `json.Marshal` paths | `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.572s` | ✓ PASS |
+| Existing V2 validation and serialization behavior | `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=60s` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 22.086s` | ✓ PASS |
+| Whitespace/conflict-marker safety | `git diff --check` and `git diff --check HEAD^ HEAD -- pkg/api/v2/where.go pkg/api/v2/where_test.go` | Both exited 0 with no output. | ✓ PASS |
+
+### Probe Execution
+
+Skipped — the plan declares no probe and no `scripts/**/tests/probe-*.sh` file exists.
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| `GH-533` | `260801-qmr-PLAN.md` | Reuse `MaxExpressionDepth` and add focused tests to bound nested built-in Where validation. | ✓ SATISFIED | The source references the existing shared constant without adding another limit; focused boundary/JSON-path regression and full tagged package suite pass. `GH-533` is a quick-task requirement and has no entry in `.planning/REQUIREMENTS.md`. |
+
+### Anti-Patterns Found
+
+None. The committed implementation changes only `pkg/api/v2/where.go` and `pkg/api/v2/where_test.go`. The anti-pattern scan found no `TBD`, `FIXME`, `XXX`, `TODO`, `HACK`, or placeholder markers in either file. Normal `return nil` success/error paths were inspected and are not stubs.
+
+### Adversarial Checks
+
+- **Off-by-one:** The source starts the root at 0 and rejects only a child at depth 101; the dedicated test exercises both 100 and 101 recursive child calls.
+- **Marshal bypass:** The source validates before encoding, and the test verifies the rejected marshal returns no partial byte slice.
+- **Public/non-compound regression:** `git diff HEAD^ HEAD` shows only the two planned source files changed; interface and constructors are unchanged, while the complete tagged package suite includes the pre-existing Where validation tests.
+
+### Human Verification Required
+
+None. All requirements are deterministic library behavior covered by source tracing and automated tests; no visual, interactive, external-service, or performance judgment remains.
+
+---
+
+_Verified: 2026-08-01T16:25:49Z_
+_Verifier: the agent (gsd-verifier)_

--- a/pkg/api/v2/where.go
+++ b/pkg/api/v2/where.go
@@ -489,16 +489,46 @@ func validateWhereClauseChild(clause WhereClause, operator WhereFilterOperator, 
 	return clause.Validate()
 }
 
-// MarshalJSON validates before encoding, matching WhereDocumentClauseAnd/Or. Without
-// it a typed-nil operand reaches its own MarshalJSON with a nil receiver and panics.
 func (w *WhereClauseWhereClauses) MarshalJSON() ([]byte, error) {
-	if err := w.Validate(); err != nil {
+	return w.marshalJSONWithDepth(0)
+}
+
+// marshalJSONWithDepth validates and encodes each child at the depth it was
+// reached, instead of delegating to json.Marshal and letting each nested
+// compound child's own MarshalJSON restart validation from depth 0 (which
+// would revalidate every remaining subtree once per level).
+func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error) {
+	if w.operator != OrOperator && w.operator != AndOperator {
+		return nil, errors.New("invalid operator, expected $and or $or")
+	}
+	if len(w.operand) == 0 {
+		return nil, errors.Errorf("invalid operand for %s, expected at least one clause", w.operator)
+	}
+	rawOperand := make([]json.RawMessage, len(w.operand))
+	for i, clause := range w.operand {
+		data, err := marshalWhereClauseChild(clause, w.operator, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		rawOperand[i] = data
+	}
+	return json.Marshal(map[WhereFilterOperator][]json.RawMessage{w.operator: rawOperand})
+}
+
+func marshalWhereClauseChild(clause WhereClause, operator WhereFilterOperator, depth int) ([]byte, error) {
+	if isNilInterface(clause) {
+		return nil, errors.Errorf("nil clause in %s expression", operator)
+	}
+	if depth > MaxExpressionDepth {
+		return nil, errors.Errorf("where expression exceeds maximum depth of %d", MaxExpressionDepth)
+	}
+	if compound, ok := clause.(*WhereClauseWhereClauses); ok {
+		return compound.marshalJSONWithDepth(depth)
+	}
+	if err := clause.Validate(); err != nil {
 		return nil, err
 	}
-	var x = map[WhereFilterOperator][]WhereClause{
-		w.operator: w.operand,
-	}
-	return json.Marshal(x)
+	return clause.MarshalJSON()
 }
 
 func (w *WhereClauseWhereClauses) UnmarshalJSON(b []byte) error {

--- a/pkg/api/v2/where.go
+++ b/pkg/api/v2/where.go
@@ -458,6 +458,10 @@ func (w *WhereClauseWhereClauses) Operand() interface{} {
 }
 
 func (w *WhereClauseWhereClauses) Validate() error {
+	return w.validateWithDepth(0)
+}
+
+func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error {
 	if w.operator != OrOperator && w.operator != AndOperator {
 		return errors.New("invalid operator, expected $and or $or")
 	}
@@ -465,14 +469,24 @@ func (w *WhereClauseWhereClauses) Validate() error {
 		return errors.Errorf("invalid operand for %s, expected at least one clause", w.operator)
 	}
 	for _, clause := range w.operand {
-		if isNilInterface(clause) {
-			return errors.Errorf("nil clause in %s expression", w.operator)
-		}
-		if err := clause.Validate(); err != nil {
+		if err := validateWhereClauseChild(clause, w.operator, depth+1); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func validateWhereClauseChild(clause WhereClause, operator WhereFilterOperator, depth int) error {
+	if isNilInterface(clause) {
+		return errors.Errorf("nil clause in %s expression", operator)
+	}
+	if depth > MaxExpressionDepth {
+		return errors.Errorf("where expression exceeds maximum depth of %d", MaxExpressionDepth)
+	}
+	if compound, ok := clause.(*WhereClauseWhereClauses); ok {
+		return compound.validateWithDepth(depth)
+	}
+	return clause.Validate()
 }
 
 // MarshalJSON validates before encoding, matching WhereDocumentClauseAnd/Or. Without

--- a/pkg/api/v2/where_document.go
+++ b/pkg/api/v2/where_document.go
@@ -124,14 +124,21 @@ type WhereDocumentClauseOr struct {
 }
 
 func (w *WhereDocumentClauseOr) MarshalJSON() ([]byte, error) {
-	err := w.Validate()
+	return w.marshalJSONWithDepth(0)
+}
+
+func (w *WhereDocumentClauseOr) marshalJSONWithDepth(depth int) ([]byte, error) {
+	if w.operator != OrDocumentOperator {
+		return nil, errors.New("invalid operator, expected in or")
+	}
+	if len(w.content) == 0 {
+		return nil, errors.New("invalid content, expected at least one")
+	}
+	rawContent, err := marshalWhereDocumentFilterChildren(w.content, w.operator, depth)
 	if err != nil {
 		return nil, err
 	}
-	var x = map[WhereDocumentFilterOperator][]WhereDocumentFilter{
-		w.operator: w.content,
-	}
-	return json.Marshal(x)
+	return json.Marshal(map[WhereDocumentFilterOperator][]json.RawMessage{w.operator: rawContent})
 }
 
 func (w *WhereDocumentClauseOr) UnmarshalJSON(b []byte) error {
@@ -167,14 +174,21 @@ type WhereDocumentClauseAnd struct {
 }
 
 func (w *WhereDocumentClauseAnd) MarshalJSON() ([]byte, error) {
-	err := w.Validate()
+	return w.marshalJSONWithDepth(0)
+}
+
+func (w *WhereDocumentClauseAnd) marshalJSONWithDepth(depth int) ([]byte, error) {
+	if w.operator != AndDocumentOperator {
+		return nil, errors.New("invalid operator, expected in and")
+	}
+	if len(w.content) == 0 {
+		return nil, errors.New("invalid content, expected at least one")
+	}
+	rawContent, err := marshalWhereDocumentFilterChildren(w.content, w.operator, depth)
 	if err != nil {
 		return nil, err
 	}
-	var x = map[WhereDocumentFilterOperator][]WhereDocumentFilter{
-		w.operator: w.content,
-	}
-	return json.Marshal(x)
+	return json.Marshal(map[WhereDocumentFilterOperator][]json.RawMessage{w.operator: rawContent})
 }
 
 func (w *WhereDocumentClauseAnd) UnmarshalJSON(b []byte) error {
@@ -214,6 +228,42 @@ func validateWhereDocumentFilterChild(filter WhereDocumentFilter, operator Where
 		return filter.validateWithDepth(depth)
 	default:
 		return filter.Validate()
+	}
+}
+
+// marshalWhereDocumentFilterChildren validates and encodes each child at the
+// depth it was reached, instead of delegating to json.Marshal and letting
+// each nested compound child's own MarshalJSON restart validation from depth
+// 0 (which would revalidate every remaining subtree once per level).
+func marshalWhereDocumentFilterChildren(content []WhereDocumentFilter, operator WhereDocumentFilterOperator, depth int) ([]json.RawMessage, error) {
+	rawContent := make([]json.RawMessage, len(content))
+	for i, v := range content {
+		data, err := marshalWhereDocumentFilterChild(v, operator, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		rawContent[i] = data
+	}
+	return rawContent, nil
+}
+
+func marshalWhereDocumentFilterChild(filter WhereDocumentFilter, operator WhereDocumentFilterOperator, depth int) ([]byte, error) {
+	if isNilInterface(filter) {
+		return nil, errors.Errorf("nil clause in %s expression", operator)
+	}
+	if depth > MaxExpressionDepth {
+		return nil, errors.Errorf("where document expression exceeds maximum depth of %d", MaxExpressionDepth)
+	}
+	switch filter := filter.(type) {
+	case *WhereDocumentClauseOr:
+		return filter.marshalJSONWithDepth(depth)
+	case *WhereDocumentClauseAnd:
+		return filter.marshalJSONWithDepth(depth)
+	default:
+		if err := filter.Validate(); err != nil {
+			return nil, err
+		}
+		return filter.MarshalJSON()
 	}
 }
 

--- a/pkg/api/v2/where_document.go
+++ b/pkg/api/v2/where_document.go
@@ -139,6 +139,10 @@ func (w *WhereDocumentClauseOr) UnmarshalJSON(b []byte) error {
 }
 
 func (w *WhereDocumentClauseOr) Validate() error {
+	return w.validateWithDepth(0)
+}
+
+func (w *WhereDocumentClauseOr) validateWithDepth(depth int) error {
 	if w.operator != OrDocumentOperator {
 		return errors.New("invalid operator, expected in or")
 	}
@@ -146,10 +150,7 @@ func (w *WhereDocumentClauseOr) Validate() error {
 		return errors.New("invalid content, expected at least one")
 	}
 	for _, v := range w.content {
-		if isNilInterface(v) {
-			return errors.Errorf("nil clause in %s expression", w.operator)
-		}
-		if err := v.Validate(); err != nil {
+		if err := validateWhereDocumentFilterChild(v, w.operator, depth+1); err != nil {
 			return err
 		}
 	}
@@ -181,6 +182,10 @@ func (w *WhereDocumentClauseAnd) UnmarshalJSON(b []byte) error {
 }
 
 func (w *WhereDocumentClauseAnd) Validate() error {
+	return w.validateWithDepth(0)
+}
+
+func (w *WhereDocumentClauseAnd) validateWithDepth(depth int) error {
 	if w.operator != AndDocumentOperator {
 		return errors.New("invalid operator, expected in and")
 	}
@@ -188,14 +193,28 @@ func (w *WhereDocumentClauseAnd) Validate() error {
 		return errors.New("invalid content, expected at least one")
 	}
 	for _, v := range w.content {
-		if isNilInterface(v) {
-			return errors.Errorf("nil clause in %s expression", w.operator)
-		}
-		if err := v.Validate(); err != nil {
+		if err := validateWhereDocumentFilterChild(v, w.operator, depth+1); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func validateWhereDocumentFilterChild(filter WhereDocumentFilter, operator WhereDocumentFilterOperator, depth int) error {
+	if isNilInterface(filter) {
+		return errors.Errorf("nil clause in %s expression", operator)
+	}
+	if depth > MaxExpressionDepth {
+		return errors.Errorf("where document expression exceeds maximum depth of %d", MaxExpressionDepth)
+	}
+	switch filter := filter.(type) {
+	case *WhereDocumentClauseOr:
+		return filter.validateWithDepth(depth)
+	case *WhereDocumentClauseAnd:
+		return filter.validateWithDepth(depth)
+	default:
+		return filter.Validate()
+	}
 }
 
 func (w *WhereDocumentClauseAnd) String() string {

--- a/pkg/api/v2/where_document_test.go
+++ b/pkg/api/v2/where_document_test.go
@@ -3,6 +3,8 @@
 package v2
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -90,5 +92,56 @@ func TestNestedNilWhereDocumentClause(t *testing.T) {
 	t.Run("valid compound document clauses still validate", func(t *testing.T) {
 		require.NoError(t, AndDocument(Contains("a"), Contains("b")).Validate())
 		require.NoError(t, OrDocument(Contains("a"), Contains("b")).Validate())
+	})
+}
+
+func TestWhereDocumentExpressionDepthGuard(t *testing.T) {
+	buildExpression := func(recursiveChildCalls int) WhereDocumentFilter {
+		var filter WhereDocumentFilter = Contains("leaf")
+		for i := 0; i < recursiveChildCalls; i++ {
+			if i%2 == 0 {
+				filter = AndDocument(filter)
+			} else {
+				filter = OrDocument(filter)
+			}
+		}
+		return filter
+	}
+
+	t.Run("permits shared expression depth", func(t *testing.T) {
+		filter := buildExpression(MaxExpressionDepth)
+		require.NoError(t, filter.Validate())
+
+		data, err := json.Marshal(filter)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+	})
+
+	t.Run("validates each compound sibling from the parent depth", func(t *testing.T) {
+		filter := AndDocument(
+			buildExpression(MaxExpressionDepth-1),
+			Contains("shallow"),
+		)
+
+		require.NoError(t, filter.Validate())
+
+		data, err := json.Marshal(filter)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
+	})
+
+	t.Run("rejects one child beyond shared expression depth", func(t *testing.T) {
+		filter := buildExpression(MaxExpressionDepth + 1)
+		expectedErr := fmt.Sprintf("where document expression exceeds maximum depth of %d", MaxExpressionDepth)
+
+		var validateErr error
+		require.NotPanics(t, func() { validateErr = filter.Validate() })
+		require.ErrorContains(t, validateErr, expectedErr)
+
+		var data []byte
+		var marshalErr error
+		require.NotPanics(t, func() { data, marshalErr = json.Marshal(filter) })
+		require.Nil(t, data)
+		require.ErrorContains(t, marshalErr, expectedErr)
 	})
 }

--- a/pkg/api/v2/where_test.go
+++ b/pkg/api/v2/where_test.go
@@ -402,8 +402,22 @@ func TestWhereClauseExpressionDepthGuard(t *testing.T) {
 		clause := buildExpression(MaxExpressionDepth)
 		require.NoError(t, clause.Validate())
 
-		_, err := json.Marshal(clause)
+		data, err := json.Marshal(clause)
 		require.NoError(t, err)
+		require.NotEmpty(t, data)
+	})
+
+	t.Run("validates each compound sibling from the parent depth", func(t *testing.T) {
+		clause := And(
+			buildExpression(MaxExpressionDepth-1),
+			EqString(K("shallow"), "leaf"),
+		)
+
+		require.NoError(t, clause.Validate())
+
+		data, err := json.Marshal(clause)
+		require.NoError(t, err)
+		require.NotEmpty(t, data)
 	})
 
 	t.Run("rejects one child beyond shared expression depth", func(t *testing.T) {

--- a/pkg/api/v2/where_test.go
+++ b/pkg/api/v2/where_test.go
@@ -4,6 +4,7 @@ package v2
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -375,5 +376,48 @@ func TestWhereClausesMarshalTypedNil(t *testing.T) {
 		data, err := json.Marshal(And(EqString("a", "1"), EqString("b", "2")))
 		require.NoError(t, err)
 		require.Contains(t, string(data), "$and")
+	})
+}
+
+func TestWhereClauseExpressionDepthGuard(t *testing.T) {
+	buildExpression := func(recursiveChildCalls int) WhereClause {
+		var clause WhereClause = EqString(K("depth"), "leaf")
+		for i := 0; i < recursiveChildCalls; i++ {
+			if i%2 == 0 {
+				clause = And(clause)
+			} else {
+				clause = Or(clause)
+			}
+		}
+		return clause
+	}
+
+	t.Run("shallow compound retains JSON shape", func(t *testing.T) {
+		data, err := json.Marshal(And(EqString(K("status"), "active")))
+		require.NoError(t, err)
+		require.JSONEq(t, `{"$and":[{"status":{"$eq":"active"}}]}`, string(data))
+	})
+
+	t.Run("permits shared expression depth", func(t *testing.T) {
+		clause := buildExpression(MaxExpressionDepth)
+		require.NoError(t, clause.Validate())
+
+		_, err := json.Marshal(clause)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects one child beyond shared expression depth", func(t *testing.T) {
+		clause := buildExpression(MaxExpressionDepth + 1)
+		expectedErr := fmt.Sprintf("where expression exceeds maximum depth of %d", MaxExpressionDepth)
+
+		var validateErr error
+		require.NotPanics(t, func() { validateErr = clause.Validate() })
+		require.ErrorContains(t, validateErr, expectedErr)
+
+		var data []byte
+		var marshalErr error
+		require.NotPanics(t, func() { data, marshalErr = json.Marshal(clause) })
+		require.Nil(t, data)
+		require.ErrorContains(t, marshalErr, expectedErr)
 	})
 }


### PR DESCRIPTION
## Summary

**Issue #533 — Where-clause depth guard**

Bounds recursive built-in `$and` and `$or` Where clauses using the existing `MaxExpressionDepth`. Over-limit expressions now fail deterministically during validation and JSON marshalling, while valid boundary-depth expressions and external `WhereClause` implementations keep their existing behavior.

## Changes

- Added a private depth-aware validation path for built-in compound Where and WhereDocument clauses.
- Reused the shared `MaxExpressionDepth` limit with a root depth of zero.
- Threaded depth through `MarshalJSON` (matching `rank.go`'s `marshalJSONWithDepth` convention) so each nested compound clause is validated once at the depth it was reached, instead of every nested `MarshalJSON` re-validating its own subtree from depth 0.
- Added regression coverage for the exact boundary, over-limit validation and JSON marshalling, plus sibling-depth behavior.

**Key files:**

- `pkg/api/v2/where.go`
- `pkg/api/v2/where_test.go`
- `pkg/api/v2/where_document.go`
- `pkg/api/v2/where_document_test.go`

## Requirements Addressed

- [x] GH-533 — Bound nested built-in Where validation with the existing shared expression-depth limit.

## Verification

- [x] `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=60s`
- [x] `git diff --check origin/main...HEAD`
- [x] Verified valid depth-boundary and rejected over-limit paths for both `Validate` and `json.Marshal`.

## Key Decisions

- Start public compound validation at depth `0`, matching the existing rank-expression convention.
- Apply depth-aware recursion only to exact built-in compound clauses; preserve normal validation for other `WhereClause` implementations.

Closes #533
