### PR TITLE
refactor(api): share compound Where validation

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 30
 Plan: Not started
 Status: Quick task 260801-qmr shipped — PR #534
-Last activity: 2026-08-02
+Last activity: 2026-08-02 - Completed quick task 260802-gve: verify and address issue #535
 
 Progress: [██████████] 100%
 
@@ -86,6 +86,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-tq1 | Verify and address issue 499 | 2026-07-31 | 96fade3 | Verified | [260731-tq1-verify-and-address-issue-499](./quick/260731-tq1-verify-and-address-issue-499/) |
 | 260801-g9r | Review, validate, and address the scope of issue 516 | 2026-08-01 | 5dff760 | Verified | [260801-g9r-review-validate-and-address-the-scope-of](./quick/260801-g9r-review-validate-and-address-the-scope-of/) |
 | 260801-qmr | Validate and address issue #533 | 2026-08-01 | bb3ef57 | Verified | [260801-qmr-validate-and-address-issue-533](./quick/260801-qmr-validate-and-address-issue-533/) |
+| 260802-gve | verify and address issue #535 | 2026-08-02 | 891b0db | Verified | [260802-gve-verify-and-address-issue-535](./quick/260802-gve-verify-and-address-issue-535/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -86,7 +86,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260731-tq1 | Verify and address issue 499 | 2026-07-31 | 96fade3 | Verified | [260731-tq1-verify-and-address-issue-499](./quick/260731-tq1-verify-and-address-issue-499/) |
 | 260801-g9r | Review, validate, and address the scope of issue 516 | 2026-08-01 | 5dff760 | Verified | [260801-g9r-review-validate-and-address-the-scope-of](./quick/260801-g9r-review-validate-and-address-the-scope-of/) |
 | 260801-qmr | Validate and address issue #533 | 2026-08-01 | bb3ef57 | Verified | [260801-qmr-validate-and-address-issue-533](./quick/260801-qmr-validate-and-address-issue-533/) |
-| 260802-gve | verify and address issue #535 | 2026-08-02 | 891b0db | Verified | [260802-gve-verify-and-address-issue-535](./quick/260802-gve-verify-and-address-issue-535/) |
+| 260802-gve | verify and address issue #535 | 2026-08-02 | 7818507 | Verified | [260802-gve-verify-and-address-issue-535](./quick/260802-gve-verify-and-address-issue-535/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-PLAN.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-PLAN.md
@@ -1,0 +1,128 @@
+---
+phase: quick-260802-gve
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/where.go
+autonomous: true
+requirements:
+  - GH-535
+
+must_haves:
+  truths:
+    - "Future maintainers can see from either compound Where helper that its operator and operand checks deliberately mirror the other helper."
+    - "Compound Where validation and JSON marshalling retain their current behavior, including their single-pass depth-aware traversal."
+  artifacts:
+    - path: "pkg/api/v2/where.go"
+      provides: "Reciprocal maintenance comments on the paired compound Where validation and JSON-marshalling helpers"
+      contains: "marshalJSONWithDepth"
+  key_links:
+    - from: "pkg/api/v2/where.go:WhereClauseWhereClauses.validateWithDepth"
+      to: "pkg/api/v2/where.go:WhereClauseWhereClauses.marshalJSONWithDepth"
+      via: "reciprocal documentation comments"
+      pattern: "validateWithDepth|marshalJSONWithDepth"
+---
+
+<objective>
+Close issue 535 with reciprocal maintenance comments on the two intentionally duplicated compound-Where traversal helpers.
+
+Purpose: preserve the deliberate single-pass design by making the coupling visible to future maintainers, without changing executable code or API behavior.
+Output: one documentation-only change in `pkg/api/v2/where.go`, backed by the existing focused regression.
+</objective>
+
+<execution_context>
+@/Users/tazarov/.codex/get-shit-done/workflows/execute-plan.md
+@/Users/tazarov/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/STATE.md
+@pkg/api/v2/where.go
+@pkg/api/v2/where_test.go
+
+**Working directory:** `/Users/tazarov/GolandProjects/chroma-go`
+
+**Scope and compatibility constraints:**
+- Work on the existing `fix/issue-535-where-clause-cross-reference` branch; do not switch branches, discard, or edit unrelated working-tree changes.
+- This is a no-behavior-change maintainability fix: modify only comments in `pkg/api/v2/where.go`; do not change conditionals, error text, control flow, interfaces, tests, dependencies, formatting outside the comment area, or generated files.
+- The existing checks in `validateWithDepth` and `marshalJSONWithDepth` are intentionally duplicated so each path validates and processes its children in one depth-aware pass. The comments must preserve that rationale, not recommend extracting shared validation.
+- Do not create a commit, push, pull request, or merge from this quick plan. Any later merge must use squash merge.
+</context>
+
+<interfaces>
+<!-- Existing paired private helpers. Their behavior is intentionally coupled, while both remain separate single-pass traversals. -->
+
+From `pkg/api/v2/where.go`:
+
+```go
+func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error
+func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error)
+```
+
+`validateWithDepth` rejects invalid `$and`/`$or` operators and empty operands before depth-aware child validation. `marshalJSONWithDepth` repeats those checks while validating and encoding every child in one traversal, avoiding repeated nested-subtree validation.
+</interfaces>
+
+<source_audit>
+
+| Source | ID | Required item | Plan | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| GOAL | — | Prevent future drift between intentionally duplicated compound-Where validation and marshalling checks | 01 | COVERED | Reciprocal comments make the maintenance dependency explicit at both functions. |
+| REQ | GH-535 | Add a short cross-reference comment to `validateWithDepth` and `marshalJSONWithDepth` with no behavior change | 01 | COVERED | One documentation-only edit; focused regression proves the current path remains intact. |
+| RESEARCH | — | No RESEARCH.md supplied; existing source establishes the deliberate single-pass design | 01 | COVERED | Retain separate validations and the current traversal shape. |
+| CONTEXT | — | No CONTEXT.md or locked decisions supplied for this quick task | 01 | N/A | No deferred ideas or decisions to implement. |
+
+</source_audit>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add reciprocal single-pass maintenance comments to compound Where helpers</name>
+  <files>pkg/api/v2/where.go</files>
+  <action>Add a short Go-style documentation comment immediately above `WhereClauseWhereClauses.validateWithDepth` that explicitly points maintainers to `marshalJSONWithDepth` and says their operator/operand checks intentionally remain synchronized for separate single-pass traversal paths. Amend the existing `marshalJSONWithDepth` documentation comment so it explicitly points back to `validateWithDepth` and states that its repeated operator/operand checks are deliberate and must stay synchronized with that validator. Keep both comments concise and accurate to the current implementation. Do not alter either function body, nearby helpers, imports, whitespace outside the comment blocks, or test files; this task must be a documentation-only diff.</action>
+  <verify>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s</automated>
+  </verify>
+  <done>`pkg/api/v2/where.go` has concise reciprocal comments immediately associated with both private helpers; each names the other helper and preserves the intentional single-pass, synchronized-check rationale, while the file's executable code is unchanged and the existing depth regression passes.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+| --- | --- |
+| Future maintainer -> compound Where traversal helpers | A future change to one of the paired private helpers could accidentally make validation and JSON marshalling accept different operator or operand states. |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+| --- | --- | --- | --- | --- |
+| T-gve-535-01 | Tampering | `WhereClauseWhereClauses.validateWithDepth` and `marshalJSONWithDepth` | mitigate | Add reciprocal comments that name the paired helper and require their deliberately duplicated operator/operand checks to stay synchronized. |
+| T-gve-535-02 | Denial of Service | Compound Where JSON traversal | accept | No executable behavior changes are authorized; retain the existing single-pass depth-aware implementation and verify its focused depth regression. |
+| T-gve-535-SC | Tampering | Package installation | accept | This plan performs no package-manager operation or dependency change. |
+</threat_model>
+
+<verification>
+
+Run the existing focused compound-Where depth regression and inspect the diff:
+
+```text
+go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s
+git diff --check
+git diff -- pkg/api/v2/where.go
+```
+</verification>
+
+<success_criteria>
+
+- Both private compound-Where helpers have concise reciprocal comments that explain why their validation checks remain deliberately duplicated.
+- The diff for `pkg/api/v2/where.go` contains comment-only changes.
+- The existing focused depth regression passes unchanged.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md` when implementation is complete.
+</output>

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-PLAN.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-PLAN.md
@@ -6,30 +6,38 @@ wave: 1
 depends_on: []
 files_modified:
   - pkg/api/v2/where.go
+  - pkg/api/v2/where_test.go
 autonomous: true
 requirements:
   - GH-535
 
 must_haves:
   truths:
-    - "Future maintainers can see from either compound Where helper that its operator and operand checks deliberately mirror the other helper."
+    - "Compound Where validation and JSON marshalling use one implementation of their shared operator and operand checks."
     - "Compound Where validation and JSON marshalling retain their current behavior, including their single-pass depth-aware traversal."
   artifacts:
     - path: "pkg/api/v2/where.go"
-      provides: "Reciprocal maintenance comments on the paired compound Where validation and JSON-marshalling helpers"
-      contains: "marshalJSONWithDepth"
+      provides: "Shared node-local validation used by the compound Where validation and JSON-marshalling helpers"
+      contains: "validateOperatorAndOperand"
+    - path: "pkg/api/v2/where_test.go"
+      provides: "Regression coverage for shared compound Where validation"
+      contains: "TestCompoundWhereClauseSharedValidation"
   key_links:
     - from: "pkg/api/v2/where.go:WhereClauseWhereClauses.validateWithDepth"
-      to: "pkg/api/v2/where.go:WhereClauseWhereClauses.marshalJSONWithDepth"
-      via: "reciprocal documentation comments"
-      pattern: "validateWithDepth|marshalJSONWithDepth"
+      to: "pkg/api/v2/where.go:WhereClauseWhereClauses.validateOperatorAndOperand"
+      via: "direct method call"
+      pattern: "validateOperatorAndOperand"
+    - from: "pkg/api/v2/where.go:WhereClauseWhereClauses.marshalJSONWithDepth"
+      to: "pkg/api/v2/where.go:WhereClauseWhereClauses.validateOperatorAndOperand"
+      via: "direct method call"
+      pattern: "validateOperatorAndOperand"
 ---
 
 <objective>
-Close issue 535 with reciprocal maintenance comments on the two intentionally duplicated compound-Where traversal helpers.
+Close issue 535 by removing the duplicated node-local checks from the compound-Where traversal helpers.
 
-Purpose: preserve the deliberate single-pass design by making the coupling visible to future maintainers, without changing executable code or API behavior.
-Output: one documentation-only change in `pkg/api/v2/where.go`, backed by the existing focused regression.
+Purpose: apply DRY to the operator and operand invariants while preserving the separate single-pass validation and JSON-encoding traversals.
+Output: one private shared validation helper in `pkg/api/v2/where.go` and focused regression coverage in `pkg/api/v2/where_test.go`.
 </objective>
 
 <execution_context>
@@ -46,8 +54,8 @@ Output: one documentation-only change in `pkg/api/v2/where.go`, backed by the ex
 
 **Scope and compatibility constraints:**
 - Work on the existing `fix/issue-535-where-clause-cross-reference` branch; do not switch branches, discard, or edit unrelated working-tree changes.
-- This is a no-behavior-change maintainability fix: modify only comments in `pkg/api/v2/where.go`; do not change conditionals, error text, control flow, interfaces, tests, dependencies, formatting outside the comment area, or generated files.
-- The existing checks in `validateWithDepth` and `marshalJSONWithDepth` are intentionally duplicated so each path validates and processes its children in one depth-aware pass. The comments must preserve that rationale, not recommend extracting shared validation.
+- This is a behavior-preserving maintainability refactor: centralize only the node-local operator and empty-operand checks; do not change error text, public interfaces, dependencies, or generated files.
+- Keep `validateWithDepth` and `marshalJSONWithDepth` as separate traversals. Calling full validation before marshalling would add a second tree walk, while a generic visitor would add more abstraction than the two shared checks justify.
 - Do not create a commit, push, pull request, or merge from this quick plan. Any later merge must use squash merge.
 </context>
 
@@ -59,18 +67,19 @@ From `pkg/api/v2/where.go`:
 ```go
 func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error
 func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error)
+func (w *WhereClauseWhereClauses) validateOperatorAndOperand() error
 ```
 
-`validateWithDepth` rejects invalid `$and`/`$or` operators and empty operands before depth-aware child validation. `marshalJSONWithDepth` repeats those checks while validating and encoding every child in one traversal, avoiding repeated nested-subtree validation.
+`validateOperatorAndOperand` owns the invalid-operator and empty-operand checks. `validateWithDepth` and `marshalJSONWithDepth` both call it before their distinct depth-aware child traversals.
 </interfaces>
 
 <source_audit>
 
 | Source | ID | Required item | Plan | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| GOAL | — | Prevent future drift between intentionally duplicated compound-Where validation and marshalling checks | 01 | COVERED | Reciprocal comments make the maintenance dependency explicit at both functions. |
-| REQ | GH-535 | Add a short cross-reference comment to `validateWithDepth` and `marshalJSONWithDepth` with no behavior change | 01 | COVERED | One documentation-only edit; focused regression proves the current path remains intact. |
-| RESEARCH | — | No RESEARCH.md supplied; existing source establishes the deliberate single-pass design | 01 | COVERED | Retain separate validations and the current traversal shape. |
+| GOAL | — | Prevent drift between compound-Where validation and marshalling checks | 01 | COVERED | Both paths call one private implementation of their shared invariants. |
+| REQ | GH-535 | Address the duplicated operator and operand checks without changing behavior | 01 | COVERED | A private helper removes the duplication; focused regression covers both callers. |
+| RESEARCH | — | No RESEARCH.md supplied; existing source establishes the single-pass performance requirement | 01 | COVERED | Share the node-local guard while retaining each traversal. |
 | CONTEXT | — | No CONTEXT.md or locked decisions supplied for this quick task | 01 | N/A | No deferred ideas or decisions to implement. |
 
 </source_audit>
@@ -78,13 +87,13 @@ func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error
 <tasks>
 
 <task type="auto">
-  <name>Task 1: Add reciprocal single-pass maintenance comments to compound Where helpers</name>
-  <files>pkg/api/v2/where.go</files>
-  <action>Add a short Go-style documentation comment immediately above `WhereClauseWhereClauses.validateWithDepth` that explicitly points maintainers to `marshalJSONWithDepth` and says their operator/operand checks intentionally remain synchronized for separate single-pass traversal paths. Amend the existing `marshalJSONWithDepth` documentation comment so it explicitly points back to `validateWithDepth` and states that its repeated operator/operand checks are deliberate and must stay synchronized with that validator. Keep both comments concise and accurate to the current implementation. Do not alter either function body, nearby helpers, imports, whitespace outside the comment blocks, or test files; this task must be a documentation-only diff.</action>
+  <name>Task 1: Share compound Where node validation without merging traversals</name>
+  <files>pkg/api/v2/where.go, pkg/api/v2/where_test.go</files>
+  <action>Extract the duplicated operator and empty-operand checks into a private `validateOperatorAndOperand` method. Call it from both `validateWithDepth` and `marshalJSONWithDepth`, preserving their error text, ordering, depth handling, JSON shape, and separate single-pass child traversals. Add a focused table test that exercises invalid operators and empty operands through both `Validate` and `MarshalJSON`.</action>
   <verify>
-    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s</automated>
+    <automated>go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCompoundWhereClauseSharedValidation|TestWhereClauseExpressionDepthGuard|TestWhereClauseEmptyOperandValidation)$' -count=1 -timeout=60s</automated>
   </verify>
-  <done>`pkg/api/v2/where.go` has concise reciprocal comments immediately associated with both private helpers; each names the other helper and preserves the intentional single-pass, synchronized-check rationale, while the file's executable code is unchanged and the existing depth regression passes.</done>
+  <done>Both traversal helpers call one node-local validator; focused tests prove both public paths retain the same errors and depth behavior.</done>
 </task>
 
 </tasks>
@@ -100,8 +109,8 @@ func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error
 
 | Threat ID | Category | Component | Disposition | Mitigation Plan |
 | --- | --- | --- | --- | --- |
-| T-gve-535-01 | Tampering | `WhereClauseWhereClauses.validateWithDepth` and `marshalJSONWithDepth` | mitigate | Add reciprocal comments that name the paired helper and require their deliberately duplicated operator/operand checks to stay synchronized. |
-| T-gve-535-02 | Denial of Service | Compound Where JSON traversal | accept | No executable behavior changes are authorized; retain the existing single-pass depth-aware implementation and verify its focused depth regression. |
+| T-gve-535-01 | Tampering | `WhereClauseWhereClauses.validateWithDepth` and `marshalJSONWithDepth` | mitigate | Route both callers through one private implementation of their shared invariants. |
+| T-gve-535-02 | Denial of Service | Compound Where JSON traversal | mitigate | Retain the existing single-pass depth-aware marshalling traversal and verify its focused depth regression. |
 | T-gve-535-SC | Tampering | Package installation | accept | This plan performs no package-manager operation or dependency change. |
 </threat_model>
 
@@ -110,17 +119,18 @@ func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error
 Run the existing focused compound-Where depth regression and inspect the diff:
 
 ```text
-go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s
+go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCompoundWhereClauseSharedValidation|TestWhereClauseExpressionDepthGuard|TestWhereClauseEmptyOperandValidation)$' -count=1 -timeout=60s
+go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=5m
 git diff --check
-git diff -- pkg/api/v2/where.go
+git diff -- pkg/api/v2/where.go pkg/api/v2/where_test.go
 ```
 </verification>
 
 <success_criteria>
 
-- Both private compound-Where helpers have concise reciprocal comments that explain why their validation checks remain deliberately duplicated.
-- The diff for `pkg/api/v2/where.go` contains comment-only changes.
-- The existing focused depth regression passes unchanged.
+- Both private compound-Where helpers use the same operator and operand validation implementation.
+- Validation and marshalling retain their separate single-pass traversals and existing errors.
+- The new shared-validation regression and existing focused depth regression pass.
 </success_criteria>
 
 <output>

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md
@@ -5,25 +5,25 @@ subsystem: api
 tags: [go, v2-api, where-clause, maintainability]
 requires: []
 provides:
-  - "Reciprocal maintenance comments for paired compound Where traversal helpers"
+  - "Shared operator and operand validation for paired compound Where traversal helpers"
 affects: [compound-where-traversal]
 tech-stack:
   added: []
   patterns:
-    - "Keep intentionally duplicated single-pass validation checks explicitly synchronized."
+    - "Share node-local invariants while keeping validation and encoding traversals separate."
 key-files:
   created: [".planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md"]
-  modified: ["pkg/api/v2/where.go"]
+  modified: ["pkg/api/v2/where.go", "pkg/api/v2/where_test.go"]
 key-decisions:
-  - "Retained separate validation and marshalling traversals so each continues to validate and process children in one depth-aware pass."
+  - "Extracted only the duplicated node-local checks; retained separate validation and marshalling traversals so marshalling stays single-pass."
 requirements-completed: [GH-535]
 duration: 4min
 completed: 2026-08-02
 ---
 
-# Quick Task 260802-gve: Compound Where Traversal Cross-References Summary
+# Quick Task 260802-gve: Shared Compound Where Validation Summary
 
-**Reciprocal comments now identify the intentionally synchronized validation checks in the compound Where validator and JSON marshaller.**
+**Compound Where validation and JSON marshalling now share one implementation of their common operator and operand checks.**
 
 ## Performance
 
@@ -34,32 +34,36 @@ completed: 2026-08-02
 
 ## Accomplishments
 
-- Added a reciprocal comment above `validateWithDepth` pointing to `marshalJSONWithDepth`.
-- Updated the marshalling helper comment to point back to `validateWithDepth`.
-- Preserved the deliberate separate, depth-aware single-pass traversal design and all executable code.
+- Extracted `validateOperatorAndOperand` as the single source of truth for compound operator and empty-operand validation.
+- Routed both `validateWithDepth` and `marshalJSONWithDepth` through the shared guard.
+- Added focused regression coverage for both entry points while preserving separate depth-aware traversals.
 
 ## Verification
 
-- Passed: `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s`
+- Passed: `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCompoundWhereClauseSharedValidation|TestWhereClauseExpressionDepthGuard|TestWhereClauseEmptyOperandValidation)$' -count=1 -timeout=60s`
+- Passed: `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=5m`
 - Passed: `git diff --check`
-- Confirmed: `git diff -- pkg/api/v2/where.go` was comment-only before commit.
+- Confirmed: error text, JSON shape, depth limits, and the public API are unchanged.
 
-## Task Commit
+## Change History
 
-1. **Task 1: Add reciprocal single-pass maintenance comments to compound Where helpers** - `891b0db` (`docs`)
+1. `891b0db` introduced the original comment-only interpretation.
+2. `7818507` replaces that interpretation with the shared-validation refactor and regression coverage.
 
 ## Files Created/Modified
 
-- `pkg/api/v2/where.go` - Reciprocal comments for the paired private compound-Where helpers.
+- `pkg/api/v2/where.go` - Shared node-local validator used by both private compound-Where traversal helpers.
+- `pkg/api/v2/where_test.go` - Regression coverage for identical validation and marshalling precondition errors.
 - `.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md` - Execution and verification record.
 
 ## Decisions Made
 
-- Retained the duplicated operator and operand checks because the helpers intentionally perform separate single-pass traversal paths.
+- Shared the operator and operand checks because they are the same invariant.
+- Did not merge the full traversals: validation returns only an error, while marshalling emits bytes and must remain one-pass to avoid extra work and changed error ordering.
 
 ## Deviations from Plan
 
-The execution instruction required the source change to be committed atomically; no implementation scope changed.
+The original documentation-only interpretation was broadened to a behavior-preserving refactor after scope clarification.
 
 ## Issues Encountered
 

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: quick-260802-gve
+plan: "01"
+subsystem: api
+tags: [go, v2-api, where-clause, maintainability]
+requires: []
+provides:
+  - "Reciprocal maintenance comments for paired compound Where traversal helpers"
+affects: [compound-where-traversal]
+tech-stack:
+  added: []
+  patterns:
+    - "Keep intentionally duplicated single-pass validation checks explicitly synchronized."
+key-files:
+  created: [".planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md"]
+  modified: ["pkg/api/v2/where.go"]
+key-decisions:
+  - "Retained separate validation and marshalling traversals so each continues to validate and process children in one depth-aware pass."
+requirements-completed: [GH-535]
+duration: 4min
+completed: 2026-08-02
+---
+
+# Quick Task 260802-gve: Compound Where Traversal Cross-References Summary
+
+**Reciprocal comments now identify the intentionally synchronized validation checks in the compound Where validator and JSON marshaller.**
+
+## Performance
+
+- **Duration:** 4 min
+- **Completed:** 2026-08-02T09:12:39Z
+- **Tasks:** 1/1
+- **Source files modified:** 1
+
+## Accomplishments
+
+- Added a reciprocal comment above `validateWithDepth` pointing to `marshalJSONWithDepth`.
+- Updated the marshalling helper comment to point back to `validateWithDepth`.
+- Preserved the deliberate separate, depth-aware single-pass traversal design and all executable code.
+
+## Verification
+
+- Passed: `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s`
+- Passed: `git diff --check`
+- Confirmed: `git diff -- pkg/api/v2/where.go` was comment-only before commit.
+
+## Task Commit
+
+1. **Task 1: Add reciprocal single-pass maintenance comments to compound Where helpers** - `891b0db` (`docs`)
+
+## Files Created/Modified
+
+- `pkg/api/v2/where.go` - Reciprocal comments for the paired private compound-Where helpers.
+- `.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-SUMMARY.md` - Execution and verification record.
+
+## Decisions Made
+
+- Retained the duplicated operator and operand checks because the helpers intentionally perform separate single-pass traversal paths.
+
+## Deviations from Plan
+
+The execution instruction required the source change to be committed atomically; no implementation scope changed.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Steps
+
+The branch is ready for the orchestrator to handle planning metadata and subsequent review steps.

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-VERIFICATION.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-VERIFICATION.md
@@ -1,6 +1,6 @@
 ---
 phase: quick-260802-gve
-verified: 2026-08-02T09:14:39Z
+verified: 2026-08-02T10:47:08Z
 status: passed
 score: 2/2 must-haves verified
 overrides_applied: 0
@@ -8,8 +8,8 @@ overrides_applied: 0
 
 # Quick Task 260802-gve: Verification Report
 
-**Task Goal:** Verify and address issue #535: make the intentionally duplicated compound-Where traversal checks visibly coupled, without changing behavior.
-**Verified:** 2026-08-02T09:14:39Z
+**Task Goal:** Verify and address issue #535 by sharing compound-Where operator and operand validation without changing behavior or adding another tree walk.
+**Verified:** 2026-08-02T10:47:08Z
 **Status:** passed
 **Re-verification:** No — initial verification
 
@@ -19,8 +19,8 @@ overrides_applied: 0
 
 | # | Truth | Status | Evidence |
 | --- | --- | --- | --- |
-| 1 | Future maintainers can see from either compound `Where` helper that its operator and operand checks deliberately mirror the other helper. | ✓ VERIFIED | `where.go:464-465` names `marshalJSONWithDepth` from `validateWithDepth`; `where.go:498-499` names `validateWithDepth` from `marshalJSONWithDepth`. Both say the checks remain synchronized and both helpers are separate single-pass traversal paths. |
-| 2 | Compound `Where` validation and JSON marshalling retain their current behavior, including their single-pass depth-aware traversal. | ✓ VERIFIED | Commit `891b0db` changes only two comment blocks in `pkg/api/v2/where.go` (8 additions, 4 comment-line rewraps); the executable function bodies and call graph are unchanged. The focused depth regression passed. |
+| 1 | Compound `Where` validation and JSON marshalling use one implementation of their shared operator and operand checks. | ✓ VERIFIED | `validateWithDepth` and `marshalJSONWithDepth` both call the private `validateOperatorAndOperand` method. |
+| 2 | Compound `Where` validation and JSON marshalling retain their current behavior, including their single-pass depth-aware traversal. | ✓ VERIFIED | The refactor leaves both child loops and depth-aware recursive helpers intact. Focused and package-level regressions pass. |
 
 **Score:** 2/2 truths verified
 
@@ -28,15 +28,15 @@ overrides_applied: 0
 
 | Artifact | Expected | Status | Details |
 | --- | --- | --- | --- |
-| `pkg/api/v2/where.go` | Reciprocal maintenance comments on paired compound-`Where` validation and marshalling helpers | ✓ VERIFIED | L1: file exists. L2: substantive comments are directly attached to the two private helpers and state the precise invariant. L3: public `Validate` calls `validateWithDepth(0)` and public `MarshalJSON` calls `marshalJSONWithDepth(0)`; each helper recursively invokes its own corresponding depth-aware child path. |
+| `pkg/api/v2/where.go` | Shared node-local validation used by paired compound-`Where` traversal helpers | ✓ VERIFIED | `validateOperatorAndOperand` owns both shared checks, and both traversal helpers call it before visiting children. |
+| `pkg/api/v2/where_test.go` | Regression coverage for both public paths | ✓ VERIFIED | `TestCompoundWhereClauseSharedValidation` requires identical invalid-operator and empty-operand errors from `Validate` and `MarshalJSON`. |
 
 ### Key Link Verification
 
 | From | To | Via | Status | Details |
 | --- | --- | --- | --- | --- |
-| `WhereClauseWhereClauses.validateWithDepth` | `WhereClauseWhereClauses.marshalJSONWithDepth` | reciprocal documentation comments | ✓ WIRED | The validator’s immediately preceding comment explicitly names `marshalJSONWithDepth`, while the marshaller’s immediately preceding comment explicitly names `validateWithDepth`. The shared operator and empty-operand checks are present at `where.go:467-471` and `where.go:505-509`. |
-
-`gsd-sdk query verify.key-links` reported a parser-level “Source file not found” for the qualified Go symbol path; direct source inspection above verifies the planned documentation link.
+| `WhereClauseWhereClauses.validateWithDepth` | `WhereClauseWhereClauses.validateOperatorAndOperand` | direct method call | ✓ WIRED | Validation returns the shared guard's error before traversing children. |
+| `WhereClauseWhereClauses.marshalJSONWithDepth` | `WhereClauseWhereClauses.validateOperatorAndOperand` | direct method call | ✓ WIRED | Marshalling returns the same shared guard's error before allocating its raw operand slice. |
 
 ### Data-Flow Trace (Level 4)
 
@@ -46,8 +46,9 @@ Not applicable. This task changes only source comments; neither artifact renders
 
 | Behavior | Command | Result | Status |
 | --- | --- | --- | --- |
-| Compound validation and JSON marshalling retain shared depth behavior | `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.463s` | ✓ PASS |
-| Source change is documentation-only and clean | `git diff --unified=0 891b0db^ 891b0db -- pkg/api/v2/where.go && git diff --check 891b0db^ 891b0db` | Only the two comment blocks changed; whitespace check produced no findings. | ✓ PASS |
+| Both paths retain shared precondition and depth behavior | `go test -tags=basicv2 ./pkg/api/v2 -run '^(TestCompoundWhereClauseSharedValidation|TestWhereClauseExpressionDepthGuard|TestWhereClauseEmptyOperandValidation)$' -count=1 -timeout=60s` | Focused tests pass. | ✓ PASS |
+| API v2 package remains green | `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=5m` | Package tests pass. | ✓ PASS |
+| Source and planning changes are clean | `git diff --check` | No whitespace findings. | ✓ PASS |
 
 ### Probe Execution
 
@@ -57,21 +58,21 @@ SKIPPED — neither the plan nor summary declares a probe, and no conventional `
 
 | Requirement | Source Plan | Description | Status | Evidence |
 | --- | --- | --- | --- | --- |
-| `GH-535` | `260802-gve-PLAN.md` | Add short reciprocal comments to the paired helpers with no behavior change. | ✓ SATISFIED | Reciprocal, accurate comments are present; the committed source diff is comment-only; focused regression passes. |
+| `GH-535` | `260802-gve-PLAN.md` | Remove duplicated compound operator and operand checks without changing behavior. | ✓ SATISFIED | Both traversal helpers call one private guard; focused and package-level regressions pass. |
 
 ### Anti-Patterns Found
 
-None. `pkg/api/v2/where.go` contains no `TBD`, `FIXME`, `XXX`, `TODO`, `HACK`, or placeholder markers. No empty implementation or hardcoded-empty-data pattern is involved.
+None. The helper centralizes two identical checks without introducing an abstraction over the distinct child traversals.
 
 ### Human Verification Required
 
-None. The required outcome is source-level maintainability plus unchanged executable behavior, both directly verifiable from the code and focused regression.
+None. The required outcome is directly verifiable from source and automated regression coverage.
 
 ### Disconfirmation Checks
 
-- Partial-requirement check: both directions of the cross-reference exist; neither comment merely claims synchronization without naming its paired helper.
-- Misleading-test check: the focused test exercises both `Validate()` and `json.Marshal()` at permitted, sibling, and over-depth boundaries, rather than only checking comment presence.
-- Uncovered-path note: the focused test does not individually assert invalid compound operator or empty compound operand behavior, but `891b0db` contains no executable changes, so those existing paths are unchanged by this task.
+- Partial-requirement check: both traversal helpers directly call the shared guard; neither retains a private copy of the checks.
+- Misleading-test check: the new regression individually asserts invalid operator and empty operand behavior through both entry points, while the existing depth regression covers valid and over-depth trees.
+- Performance check: marshalling does not call `validateWithDepth`; it still validates and emits each child during one traversal.
 
 ### Gaps Summary
 
@@ -79,5 +80,5 @@ No gaps found. The task goal is achieved.
 
 ---
 
-_Verified: 2026-08-02T09:14:39Z_
+_Verified: 2026-08-02T10:47:08Z_
 _Verifier: the agent (gsd-verifier)_

--- a/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-VERIFICATION.md
+++ b/.planning/quick/260802-gve-verify-and-address-issue-535/260802-gve-VERIFICATION.md
@@ -1,0 +1,83 @@
+---
+phase: quick-260802-gve
+verified: 2026-08-02T09:14:39Z
+status: passed
+score: 2/2 must-haves verified
+overrides_applied: 0
+---
+
+# Quick Task 260802-gve: Verification Report
+
+**Task Goal:** Verify and address issue #535: make the intentionally duplicated compound-Where traversal checks visibly coupled, without changing behavior.
+**Verified:** 2026-08-02T09:14:39Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Future maintainers can see from either compound `Where` helper that its operator and operand checks deliberately mirror the other helper. | ✓ VERIFIED | `where.go:464-465` names `marshalJSONWithDepth` from `validateWithDepth`; `where.go:498-499` names `validateWithDepth` from `marshalJSONWithDepth`. Both say the checks remain synchronized and both helpers are separate single-pass traversal paths. |
+| 2 | Compound `Where` validation and JSON marshalling retain their current behavior, including their single-pass depth-aware traversal. | ✓ VERIFIED | Commit `891b0db` changes only two comment blocks in `pkg/api/v2/where.go` (8 additions, 4 comment-line rewraps); the executable function bodies and call graph are unchanged. The focused depth regression passed. |
+
+**Score:** 2/2 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `pkg/api/v2/where.go` | Reciprocal maintenance comments on paired compound-`Where` validation and marshalling helpers | ✓ VERIFIED | L1: file exists. L2: substantive comments are directly attached to the two private helpers and state the precise invariant. L3: public `Validate` calls `validateWithDepth(0)` and public `MarshalJSON` calls `marshalJSONWithDepth(0)`; each helper recursively invokes its own corresponding depth-aware child path. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `WhereClauseWhereClauses.validateWithDepth` | `WhereClauseWhereClauses.marshalJSONWithDepth` | reciprocal documentation comments | ✓ WIRED | The validator’s immediately preceding comment explicitly names `marshalJSONWithDepth`, while the marshaller’s immediately preceding comment explicitly names `validateWithDepth`. The shared operator and empty-operand checks are present at `where.go:467-471` and `where.go:505-509`. |
+
+`gsd-sdk query verify.key-links` reported a parser-level “Source file not found” for the qualified Go symbol path; direct source inspection above verifies the planned documentation link.
+
+### Data-Flow Trace (Level 4)
+
+Not applicable. This task changes only source comments; neither artifact renders or sources dynamic data.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Compound validation and JSON marshalling retain shared depth behavior | `go test -tags=basicv2 ./pkg/api/v2 -run '^TestWhereClauseExpressionDepthGuard$' -count=1 -timeout=60s` | `ok github.com/amikos-tech/chroma-go/pkg/api/v2 0.463s` | ✓ PASS |
+| Source change is documentation-only and clean | `git diff --unified=0 891b0db^ 891b0db -- pkg/api/v2/where.go && git diff --check 891b0db^ 891b0db` | Only the two comment blocks changed; whitespace check produced no findings. | ✓ PASS |
+
+### Probe Execution
+
+SKIPPED — neither the plan nor summary declares a probe, and no conventional `scripts/*/tests/probe-*.sh` files exist.
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| --- | --- | --- | --- | --- |
+| `GH-535` | `260802-gve-PLAN.md` | Add short reciprocal comments to the paired helpers with no behavior change. | ✓ SATISFIED | Reciprocal, accurate comments are present; the committed source diff is comment-only; focused regression passes. |
+
+### Anti-Patterns Found
+
+None. `pkg/api/v2/where.go` contains no `TBD`, `FIXME`, `XXX`, `TODO`, `HACK`, or placeholder markers. No empty implementation or hardcoded-empty-data pattern is involved.
+
+### Human Verification Required
+
+None. The required outcome is source-level maintainability plus unchanged executable behavior, both directly verifiable from the code and focused regression.
+
+### Disconfirmation Checks
+
+- Partial-requirement check: both directions of the cross-reference exist; neither comment merely claims synchronization without naming its paired helper.
+- Misleading-test check: the focused test exercises both `Validate()` and `json.Marshal()` at permitted, sibling, and over-depth boundaries, rather than only checking comment presence.
+- Uncovered-path note: the focused test does not individually assert invalid compound operator or empty compound operand behavior, but `891b0db` contains no executable changes, so those existing paths are unchanged by this task.
+
+### Gaps Summary
+
+No gaps found. The task goal is achieved.
+
+---
+
+_Verified: 2026-08-02T09:14:39Z_
+_Verifier: the agent (gsd-verifier)_

--- a/pkg/api/v2/where.go
+++ b/pkg/api/v2/where.go
@@ -461,8 +461,7 @@ func (w *WhereClauseWhereClauses) Validate() error {
 	return w.validateWithDepth(0)
 }
 
-// validateWithDepth keeps its operator and operand checks synchronized with
-// marshalJSONWithDepth; both remain separate single-pass traversal paths.
+// Mirrors marshalJSONWithDepth's checks; see there for why the paths stay separate.
 func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error {
 	if w.operator != OrOperator && w.operator != AndOperator {
 		return errors.New("invalid operator, expected $and or $or")
@@ -495,9 +494,7 @@ func (w *WhereClauseWhereClauses) MarshalJSON() ([]byte, error) {
 	return w.marshalJSONWithDepth(0)
 }
 
-// marshalJSONWithDepth keeps its operator and operand checks synchronized with
-// validateWithDepth; both remain separate single-pass traversal paths. It
-// validates and encodes each child at the depth it was reached, instead of
+// marshalJSONWithDepth validates and encodes each child at the depth it was reached, instead of
 // delegating to json.Marshal and letting each nested compound child's own
 // MarshalJSON restart validation from depth 0 (which would revalidate every
 // remaining subtree once per level).

--- a/pkg/api/v2/where.go
+++ b/pkg/api/v2/where.go
@@ -461,6 +461,8 @@ func (w *WhereClauseWhereClauses) Validate() error {
 	return w.validateWithDepth(0)
 }
 
+// validateWithDepth keeps its operator and operand checks synchronized with
+// marshalJSONWithDepth; both remain separate single-pass traversal paths.
 func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error {
 	if w.operator != OrOperator && w.operator != AndOperator {
 		return errors.New("invalid operator, expected $and or $or")
@@ -493,10 +495,12 @@ func (w *WhereClauseWhereClauses) MarshalJSON() ([]byte, error) {
 	return w.marshalJSONWithDepth(0)
 }
 
-// marshalJSONWithDepth validates and encodes each child at the depth it was
-// reached, instead of delegating to json.Marshal and letting each nested
-// compound child's own MarshalJSON restart validation from depth 0 (which
-// would revalidate every remaining subtree once per level).
+// marshalJSONWithDepth keeps its operator and operand checks synchronized with
+// validateWithDepth; both remain separate single-pass traversal paths. It
+// validates and encodes each child at the depth it was reached, instead of
+// delegating to json.Marshal and letting each nested compound child's own
+// MarshalJSON restart validation from depth 0 (which would revalidate every
+// remaining subtree once per level).
 func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error) {
 	if w.operator != OrOperator && w.operator != AndOperator {
 		return nil, errors.New("invalid operator, expected $and or $or")

--- a/pkg/api/v2/where.go
+++ b/pkg/api/v2/where.go
@@ -461,13 +461,19 @@ func (w *WhereClauseWhereClauses) Validate() error {
 	return w.validateWithDepth(0)
 }
 
-// Mirrors marshalJSONWithDepth's checks; see there for why the paths stay separate.
-func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error {
+func (w *WhereClauseWhereClauses) validateOperatorAndOperand() error {
 	if w.operator != OrOperator && w.operator != AndOperator {
 		return errors.New("invalid operator, expected $and or $or")
 	}
 	if len(w.operand) == 0 {
 		return errors.Errorf("invalid operand for %s, expected at least one clause", w.operator)
+	}
+	return nil
+}
+
+func (w *WhereClauseWhereClauses) validateWithDepth(depth int) error {
+	if err := w.validateOperatorAndOperand(); err != nil {
+		return err
 	}
 	for _, clause := range w.operand {
 		if err := validateWhereClauseChild(clause, w.operator, depth+1); err != nil {
@@ -494,16 +500,11 @@ func (w *WhereClauseWhereClauses) MarshalJSON() ([]byte, error) {
 	return w.marshalJSONWithDepth(0)
 }
 
-// marshalJSONWithDepth validates and encodes each child at the depth it was reached, instead of
-// delegating to json.Marshal and letting each nested compound child's own
-// MarshalJSON restart validation from depth 0 (which would revalidate every
-// remaining subtree once per level).
+// marshalJSONWithDepth validates and encodes each child in one depth-aware pass.
+// Its traversal stays separate from validateWithDepth to avoid a second tree walk.
 func (w *WhereClauseWhereClauses) marshalJSONWithDepth(depth int) ([]byte, error) {
-	if w.operator != OrOperator && w.operator != AndOperator {
-		return nil, errors.New("invalid operator, expected $and or $or")
-	}
-	if len(w.operand) == 0 {
-		return nil, errors.Errorf("invalid operand for %s, expected at least one clause", w.operator)
+	if err := w.validateOperatorAndOperand(); err != nil {
+		return nil, err
 	}
 	rawOperand := make([]json.RawMessage, len(w.operand))
 	for i, clause := range w.operand {

--- a/pkg/api/v2/where_test.go
+++ b/pkg/api/v2/where_test.go
@@ -355,6 +355,39 @@ func TestWhereClauseEmptyOperandValidation(t *testing.T) {
 	}
 }
 
+func TestCompoundWhereClauseSharedValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		clause      *WhereClauseWhereClauses
+		expectedErr string
+	}{
+		{
+			name: "invalid operator",
+			clause: &WhereClauseWhereClauses{
+				WhereClauseBase: WhereClauseBase{operator: EqualOperator},
+				operand:         []WhereClause{EqString(K("status"), "active")},
+			},
+			expectedErr: "invalid operator, expected $and or $or",
+		},
+		{
+			name: "empty operand",
+			clause: &WhereClauseWhereClauses{
+				WhereClauseBase: WhereClauseBase{operator: AndOperator},
+			},
+			expectedErr: "invalid operand for $and, expected at least one clause",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, tt.clause.Validate(), tt.expectedErr)
+
+			_, err := tt.clause.MarshalJSON()
+			require.EqualError(t, err, tt.expectedErr)
+		})
+	}
+}
+
 // TestWhereClausesMarshalTypedNil covers direct marshalling of a compound clause
 // holding a typed nil, which skips the Validate() guard added for the option path.
 func TestWhereClausesMarshalTypedNil(t *testing.T) {


### PR DESCRIPTION
## Summary

- Centralize compound Where operator and operand checks in a single private helper.
- Reuse the helper from validation and JSON marshalling.
- Keep the two depth-aware child traversals separate so marshalling remains single-pass.
- Add regression coverage proving both entry points retain the same errors.

Closes #535

## Why this shape

Validation and marshalling have different jobs: one returns an error; the other emits JSON. Fully merging them would require either an extra tree walk or a generic traversal abstraction. This refactor shares only the invariant they truly have in common.

## Impact

- No public API changes.
- No JSON shape or validation error changes.
- No additional traversal or allocation during marshalling.
- Existing single-pass error ordering is preserved.
- The duplicated operator and empty-operand checks are removed.

## Verification

- [x] `go test -v -tags=basicv2 ./pkg/api/v2 -run '^(TestCompoundWhereClauseSharedValidation|TestWhereClauseExpressionDepthGuard|TestWhereClauseEmptyOperandValidation)$' -count=1 -timeout=60s`
- [x] `go test -tags=basicv2 ./pkg/api/v2 -count=1 -timeout=5m`
- [x] `git diff --check`