### PR TITLE
fix(api): guard degenerate RRF compositions and fix null-element misalignment

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-10)
 Phase: 30
 Plan: Not started
 Status: Quick task 260801-qmr shipped — PR #534
-Last activity: 2026-08-02 - Completed quick task 260802-gve: verify and address issue #535
+Last activity: 2026-08-03 - Completed quick task 260803-occ: address RRF degenerate composition guards + null-element misalignment (#497 #498 #500 #501)
 
 Progress: [██████████] 100%
 
@@ -87,6 +87,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 | 260801-g9r | Review, validate, and address the scope of issue 516 | 2026-08-01 | 5dff760 | Verified | [260801-g9r-review-validate-and-address-the-scope-of](./quick/260801-g9r-review-validate-and-address-the-scope-of/) |
 | 260801-qmr | Validate and address issue #533 | 2026-08-01 | bb3ef57 | Verified | [260801-qmr-validate-and-address-issue-533](./quick/260801-qmr-validate-and-address-issue-533/) |
 | 260802-gve | verify and address issue #535 | 2026-08-02 | 7818507 | Verified | [260802-gve-verify-and-address-issue-535](./quick/260802-gve-verify-and-address-issue-535/) |
+| 260803-occ | address RRF degenerate composition guards + null-element misalignment (#497 #498 #500 #501) | 2026-08-03 | 66a63dc | Verified | [260803-occ-address-rrf-degenerate-composition-guard](./quick/260803-occ-address-rrf-degenerate-composition-guard/) |
 
 **Note (260729-p70, updated in #514):** `chroma-go-local v0.3.5` is now permanently notarized by
 `sum.golang.org` at `h1:F/vk7Nc6eC8tVFaj9O5XAkfBYGGQj5At6ccrlNxbzvU=`. **That tag must never be

--- a/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-CONTEXT.md
+++ b/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-CONTEXT.md
@@ -1,0 +1,245 @@
+# Quick Task 260803-occ: address RRF degenerate composition guards (#497 #498 #500 #501) - Context
+
+**Gathered:** 2026-08-03
+**Status:** Ready for planning
+
+<domain>
+## Task Boundary
+
+Validate and address the client-side defects in issues #497, #498, #500 (and #501,
+which has identical scope to the client-side remedy for #497/#498).
+
+All four collapse into two client-side changes in `pkg/api/v2`:
+
+1. **Build-time guard** — reject provably degenerate `*RrfRank` arithmetic
+   compositions before a query is ever serialized. Covers #497, #498, #501.
+2. **Read-time guard** — detect result-shape degeneration on `Search` responses.
+   Covers #500.
+
+Out of scope: server-side changes, upstream chroma-core reports, V1 API.
+
+</domain>
+
+<validation>
+## Pre-Planning Validation Findings
+
+Root cause (confirmed at `pkg/api/v2/rank.go:1517`): `RrfRank.marshalJSONWithDepth`
+negates the reciprocal-rank sum (`result := rrfSum.Negate()`) to match Chroma's
+lower-is-better ordering convention. Every arithmetic method on `*RrfRank`
+therefore composes against a value that is **always <= 0** on a non-empty corpus.
+
+| Issue | Original claim | Verdict |
+|-------|----------------|---------|
+| #497 | "Server-behavior defect — Log degenerates silently" | **Misframed.** `f32::ln(x<=0) = NaN`; the server drops NaN rows. Deterministic IEEE 754 behavior, not a server bug. #500's body already self-corrects this framing. Only the client-side remedy is actionable here. |
+| #498 | "`Max(Val(0))` collapses to all-zero; add client guard" | **Valid.** `max(x, 0) == 0` for all x <= 0. The client has full static visibility into the composition and can reject it. |
+| #500 | "Client does not detect result-shape mismatch" | **Valid, with a caveat.** The naive check (`IDs[0]` non-empty + `Scores[0]` empty) would fire on every ordinary query, because `Scores` is only populated when `KScore` is present in `WithSelect`. The guard MUST be gated on the request's `Select`. |
+| #501 | "Reject meaningless compositions at build time" | **Valid and identical** to the client-side remedy for #497/#498. Shipped by the same change. |
+
+Enabling fact for the read-time guard: `CollectionImpl.Search`
+(`pkg/api/v2/collection_http.go:426`) still holds the parsed `*SearchQuery`
+when it decodes the response, so per-request `Select` is available at
+validation time without any plumbing changes.
+
+### Upstream cross-check (chroma-core @ d1921129)
+
+Checked `chromadb/execution/expression/operator.py` and
+`rust/types/src/execution/operator.rs` before planning:
+
+- Python `Rrf` is a plain `Rank` subclass — inherits `.log()`, `.max()` with
+  **zero** guards. `Rrf.to_dict()` validates only ranks/k/weights, then returns
+  `(-rrf_sum).to_dict()`.
+- Rust `rrf()` (`operator.rs:2868`) is `Ok(-sum)`. `RankExpr::Logarithm`
+  evaluates to a bare `f32::ln` (`rust/worker/src/execution/operators/rank.rs:115`).
+  No guards anywhere.
+- Upstream's stated position on the log footgun is a doc comment:
+  *"Logarithm - compresses range (add constant to avoid log(0))"*.
+
+**This does NOT change the guard decisions.** See "Consistency principle" below.
+
+### The real bug — null misalignment (VERIFIED, not described in any issue)
+
+The wire contract models scores as `Vec<Option<Vec<Option<f32>>>>` and documents
+as `Vec<Option<Vec<Option<String>>>>` (`rust/types/src/api_types.rs:2493-2499`),
+so a per-element `null` is **legal, intended protocol** — not an anomaly.
+
+`SearchResultImpl.UnmarshalJSON` type-switches each element with no `null` case:
+- Scores: `pkg/api/v2/search.go:930-940` — `case float64` / `case json.Number` only.
+- Documents: `pkg/api/v2/search.go:840` — `if docStr, ok := doc.(string); ok`.
+
+A JSON `null` matches neither branch and is **silently skipped instead of
+appended**, so every later element shifts left one position while `IDs` stays
+put. `Metadatas` (`search.go:862`) and `Embeddings` (`search.go:893`) handle nil
+correctly — only Scores and Documents are broken.
+
+Empirically confirmed against `{"ids":[["a","b","c"]],"scores":[[1.5,null,3.5]],"documents":[["da",null,"dc"]]}`:
+
+```
+row id=a  score=1.5  doc="da"     correct
+row id=b  score=3.5  doc="dc"     WRONG — b receives c's score and c's document
+row id=c  score=0    doc=""       WRONG — real score silently becomes 0.0
+```
+
+This is silent data corruption binding scores/documents to the wrong document.
+It fires on ANY query returning a null score or document — no RRF involved. It
+is the actual mechanism behind #500's "result-shape mismatch" symptom; the issue
+diagnosed RRF degeneration as the cause, which is wrong.
+
+**Ordering constraint:** the alignment fix MUST land with the read-time guard.
+Without it, `len(Scores[g]) != len(IDs[g])` is caused by ordinary nulls, so the
+guard would false-positive on legitimate responses.
+
+</validation>
+
+<consistency_principle>
+## Consistency Principle (governs the guard decisions)
+
+The deciding invariant is **the Go client's own contract**, not parity with the
+Python/Rust SDKs. `pkg/api/v2` already rejects, with typed errors, many things
+upstream accepts silently:
+
+| Go behavior | Upstream equivalent |
+|-------------|---------------------|
+| `MaxExpressionDepth = 100` (#530) | no limit |
+| `MaxRrfRanks = 100` | no limit |
+| `MaxExpressionTerms = 1000` | no limit |
+| NaN/Inf weights rejected (`rank.go:1392`) | not checked |
+| `ErrNilRank` on nil operands (#531) | n/a |
+| eager option validation (#532) | validated at request time |
+
+That divergence is a deliberate, sustained house style: **reject invalid or
+degenerate input eagerly with an exported sentinel error**. Going permissive on
+RRF degeneration to match Python would make the client inconsistent with itself,
+which is the worse failure.
+
+Scope limit: strictness applies to **caller mistakes**, not to legal server
+responses. Per-element `null` in scores/documents is explicitly modeled in the
+wire protocol, so it must be handled correctly — never errored on.
+
+</consistency_principle>
+
+<decisions>
+## Implementation Decisions
+
+### Build-time guard scope — LOCKED
+Reject **only** `rrf.Log()` and `rrf.Max(Val(0))`.
+
+Explicitly left legal:
+- `rrf.Abs()` — reverses ordering, but well-defined; the doc comment at
+  `rank.go:1321` already warns.
+- `rrf.Negate()` — same; legitimate when the caller genuinely wants ascending order.
+- `rrf.Min(Val(0))` — a harmless no-op (`min(x,0) == x` for x <= 0). Do **not**
+  silently rewrite it away; silently mutating the user's expression tree is its
+  own surprise.
+
+Rationale: lowest false-positive risk. Only provably-degenerate cases are blocked.
+
+### Guard mechanism — LOCKED
+Deferred-error pattern, per the sketch in #501 and the existing `*UnknownRank`
+precedent at `rank.go:85-105`: the arithmetic method returns a `Rank` whose
+`MarshalJSON` fails with a descriptive error. This keeps the fluent API
+ergonomic (no `(Rank, error)` return-type break) while making the query
+impossible to send.
+
+`Max` must only reject when the operand is a **literal zero constant** that is
+statically knowable at build time. A non-constant operand, or a non-zero
+constant, stays legal.
+
+### Null-element alignment fix — LOCKED (new, highest severity)
+`SearchResultImpl.UnmarshalJSON` must **preserve position** for `null` elements
+in `scores` and `documents` instead of skipping them. Add an explicit nil case to
+both type switches so index `i` always corresponds to `IDs[g][i]`.
+
+Match the nil-handling already used for Metadatas (`search.go:862`) and
+Embeddings (`search.go:893`) — this makes all four field parsers consistent.
+
+### Absence representation — LOCKED
+`ResultRow` gains **additive** boolean companions; existing fields are unchanged
+so this is backward compatible:
+
+```go
+type ResultRow struct {
+    ID          DocumentID
+    Document    string
+    HasDocument bool // false when the server sent null / field not selected
+    Metadata    DocumentMetadata
+    Embedding   []float32
+    Score       float64
+    HasScore    bool // false when the server sent null / field not selected
+}
+```
+
+Rejected: changing `Score` to `*float64` — cleaner model, but a breaking change
+to a public struct field.
+
+Note `ResultRow` is shared by Search, Query, and Get (`pkg/api/v2/results.go:14`).
+Set the new booleans correctly on **all** construction paths, not just Search, or
+the field means different things depending on which call produced the row.
+
+### Read-time guard behavior — LOCKED
+`Search` returns an **error** when, for any query group `g`:
+- the corresponding request selected `KScore`, AND
+- `len(IDs[g]) > 0`, AND
+- `len(Scores[g]) != len(IDs[g])`
+
+Use an **exported sentinel** so callers can `errors.Is` it, matching `ErrNilRank`
+(`pkg/api/v2/options.go:936`). Return `(nil, err)` — same shape as every other
+guard in this package.
+
+Only meaningful after the alignment fix: once nulls preserve position, a
+cardinality mismatch can only come from genuine server-side degeneration.
+
+Rejected alternatives:
+- Returning result-plus-sentinel-error: Go callers routinely drop the result on
+  non-nil err, so the extra payload is wasted, and it deviates from how every
+  other guard in this package returns.
+- A `Degenerate() bool` predicate: opt-in, so most callers never call it — which
+  is precisely the silent-failure mode #500 exists to close.
+- Gating behind a client option for one release: leaves the silent failure as the
+  default for a release; #531/#532 shipped their guards without a deprecation
+  window.
+
+### Issue disposition — LOCKED
+The PR closes **all four**: #497, #498, #500, #501.
+
+Note in the PR body that #497's "server-behavior defect" framing is incorrect —
+the behavior is deterministic IEEE 754 math and upstream has no guard; the Go
+client addresses it client-side per the consistency principle above.
+
+### Claude's Discretion
+- Exact error variable names, wording, and whether the sentinel errors are
+  exported (prefer exported sentinels so callers can `errors.Is` them).
+- Placement of the read-time check (inline in `Search` vs. a helper on
+  `SearchResultImpl`) — but it must run inside `Search` so the error surfaces
+  without caller opt-in.
+- Test structure and table shape.
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Existing cloud test `TestCloudClientSearchRRFArithmetic` in
+  `pkg/api/v2/client_cloud_test.go` currently **pins the degenerate behavior**
+  as a regression assertion for both the `Log` and `Max_0` cases. Those pins
+  must flip to assert the new error paths.
+- Per CLAUDE.md: no panics in production code, no `Must*` functions, run
+  `make lint` before committing, conventional commits.
+- Unit tests are the primary bar here since the guards are client-side and
+  need no server round-trip; the cloud test pins still need updating so
+  `make test-cloud` stays green.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+- `pkg/api/v2/rank.go:1305-1328` — existing doc comment enumerating the
+  degenerate transforms (Log, Max(0), Abs, Negate).
+- `pkg/api/v2/rank.go:85-105` — `*UnknownRank`, the deferred-error precedent.
+- `pkg/api/v2/rank.go:1517` — the auto-negation that causes all of this.
+- `pkg/api/v2/collection_http.go:426-457` — `Search`, where the read-time guard lands.
+- `pkg/api/v2/search.go:773-793` — `SearchResultImpl` field shape.
+- `pkg/api/v2/search.go:177` — `KScore`.
+- Chroma docs: results ordered by score ascending (lower is better).
+
+</canonical_refs>

--- a/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-PLAN.md
+++ b/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-PLAN.md
@@ -1,0 +1,252 @@
+---
+task: 260803-occ-address-rrf-degenerate-composition-guard
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - pkg/api/v2/search.go
+  - pkg/api/v2/results.go
+  - pkg/api/v2/rank.go
+  - pkg/api/v2/collection_http.go
+  - pkg/api/v2/search_test.go
+  - pkg/api/v2/rank_test.go
+  - pkg/api/v2/collection_http_test.go
+  - pkg/api/v2/client_cloud_test.go
+autonomous: true
+requirements: ["#497", "#498", "#500", "#501"]
+
+must_haves:
+  truths:
+    - "A search response with a per-element null score or document keeps every remaining element bound to its original ID position"
+    - "ResultRow reports HasScore/HasDocument consistently for rows produced by Search, Query and Get"
+    - "rrf.Log() produces a Rank that cannot be sent: it fails with an exported sentinel error"
+    - "rrf.Max(Val(0)) / rrf.Max(FloatOperand(0)) / rrf.Max(IntOperand(0)) fail with an exported sentinel error; non-zero and non-constant operands stay legal"
+    - "rrf.Abs(), rrf.Negate() and rrf.Min(Val(0)) remain legal and unchanged"
+    - "Search returns (nil, err) with an exported sentinel when a group selected KScore but score cardinality does not match ID cardinality"
+    - "make test (basicv2) and make lint pass; cloud test pins for Log and Max_0 assert the new error paths"
+  artifacts:
+    - path: "pkg/api/v2/search.go"
+      provides: "null-preserving score/document parsing plus presence tracking"
+    - path: "pkg/api/v2/results.go"
+      provides: "ResultRow.HasScore / ResultRow.HasDocument"
+    - path: "pkg/api/v2/rank.go"
+      provides: "deferred-error degenerate RRF rank + exported sentinels"
+    - path: "pkg/api/v2/collection_http.go"
+      provides: "read-time cardinality guard in CollectionImpl.Search"
+  key_links:
+    - from: "pkg/api/v2/collection_http.go Search"
+      to: "sq.Searches[g].Select"
+      via: "per-group KScore gating of the cardinality guard"
+    - from: "pkg/api/v2/rank.go RrfRank.Log/Max"
+      to: "marshalRank / validateBuiltInRankWithDepth"
+      via: "deferred-error rank leaf, UnknownRank precedent"
+---
+
+<objective>
+Fix silent score/document misalignment on null elements in Search responses, then add the
+two guards that only become sound once alignment is correct: a build-time deferred-error
+guard on provably degenerate `*RrfRank` compositions, and a read-time cardinality guard in
+`CollectionImpl.Search`.
+
+Purpose: closes #497, #498, #500, #501. The alignment bug is silent data corruption and is
+the actual mechanism behind #500's symptom.
+Output: three ordered changes in `pkg/api/v2` plus unit-test coverage and flipped cloud pins.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+</execution_context>
+
+<context>
+@.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-CONTEXT.md
+@CLAUDE.md
+@pkg/api/v2/search.go
+@pkg/api/v2/results.go
+@pkg/api/v2/rank.go
+@pkg/api/v2/collection_http.go
+
+<interfaces>
+Existing shapes the executor must build against (already in the codebase — do not re-derive):
+
+pkg/api/v2/results.go:14
+  type ResultRow struct { ID DocumentID; Document string; Metadata DocumentMetadata; Embedding []float32; Score float64 }
+
+pkg/api/v2/search.go:773
+  type SearchResultImpl struct { IDs [][]DocumentID; Documents [][]string; Metadatas [][]DocumentMetadata; Embeddings [][][]float32; Scores [][]float64 }
+  Null-preserving precedent already present: Metadatas at search.go:862, Embeddings at search.go:893.
+
+pkg/api/v2/search.go:177   KScore Key = "#score"
+pkg/api/v2/search.go:282   type SearchRequest struct { Filter *SearchFilter; Limit *SearchPage; Rank Rank; Select *SearchSelect; GroupBy *GroupBy }
+pkg/api/v2/search.go:105   type SearchQuery struct { ...; Searches []SearchRequest `json:"searches"` }
+  SearchSelect carries `Keys []Key` (see WithSelectAll at search.go:613).
+
+pkg/api/v2/rank.go:100  UnknownRank — deferred-error precedent (embeds ValRank, MarshalJSON returns an error)
+pkg/api/v2/rank.go:108  marshalRank — built-in type switch, falls through to rank.MarshalJSON()
+pkg/api/v2/rank.go:178  validateBuiltInRankWithDepth — `case *UnknownRank, *ValRank:` calls rank.MarshalJSON()
+pkg/api/v2/rank.go:1453 func (r *RrfRank) Log() Rank
+pkg/api/v2/rank.go:1457 func (r *RrfRank) Max(operand Operand) Rank
+pkg/api/v2/rank.go:1534 operandToRank — supports Rank, IntOperand, FloatOperand
+pkg/api/v2/collection_http.go:475 cloneRank — `default: return rank` (a new immutable leaf needs no case)
+pkg/api/v2/options.go:936  ErrNilRank — exported-sentinel style to match
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Preserve null positions in Search scores/documents and add ResultRow presence flags</name>
+  <files>pkg/api/v2/search.go, pkg/api/v2/results.go, pkg/api/v2/search_test.go, pkg/api/v2/results_test.go</files>
+  <behavior>
+    - `{"ids":[["a","b","c"]],"scores":[[1.5,null,3.5]],"documents":[["da",null,"dc"]]}` yields rows: a/1.5/"da", b/0/"" with HasScore=false and HasDocument=false, c/3.5/"dc". This is the exact regression case from CONTEXT.md.
+    - A group whose scores/documents contain no nulls yields HasScore=true and HasDocument=true for every row.
+    - A group where scores were not selected at all (field absent) yields HasScore=false for every row.
+    - QueryResultImpl rows: HasScore=true only where a distance exists at that index; HasDocument=true only where the document pointer is non-nil.
+    - GetResultImpl rows: HasScore=false always (Get carries no score); HasDocument=true only where the document pointer is non-nil.
+  </behavior>
+  <action>
+    In `SearchResultImpl.UnmarshalJSON`, add an explicit nil case to the scores element type
+    switch (search.go:930) and the documents element check (search.go:840) so a JSON null
+    appends a zero value at its own index instead of being skipped. Mirror the shape already
+    used for Metadatas and Embeddings so all four parsers read the same way.
+
+    Because `Documents [][]string` and `Scores [][]float64` cannot represent absence, track it
+    in two new unexported parallel slices on `SearchResultImpl` (e.g. `documentPresent [][]bool`,
+    `scorePresent [][]bool`), populated only by `UnmarshalJSON`. Keep the exported fields and
+    their JSON tags unchanged — this must stay backward compatible.
+
+    Add `HasDocument bool` and `HasScore bool` to `ResultRow` (results.go:14) as additive fields
+    per the LOCKED absence-representation decision. Do NOT change `Score` to `*float64`.
+
+    Set both flags on ALL three construction paths, since `ResultRow` is shared:
+      - `SearchResultImpl.buildRow` (search.go:997): flag is true when the index is in range AND
+        the corresponding presence slice either has no entry for that group (direct struct
+        construction, not unmarshalled) or records true. This keeps hand-constructed
+        SearchResultImpl values behaving sanely.
+      - `QueryResultImpl.buildRow` (results.go:459): HasScore from DistancesLists index-in-range,
+        HasDocument from the existing non-nil document check.
+      - `GetResultImpl.buildRow` (results.go:192): HasScore always false, HasDocument from the
+        existing non-nil document check.
+
+    Document the two new ResultRow fields with a one-line comment each stating that false means
+    the server sent null or the field was not selected. No other comments.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 -run 'TestSearchResult|TestResultRow|TestQueryResult|TestGetResult' ./pkg/api/v2/... </automated>
+  </verify>
+  <done>The three-element null fixture round-trips with every score and document bound to its original ID; HasScore/HasDocument are correct on Search, Query and Get rows; existing basicv2 tests still pass.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Deferred-error build-time guard for rrf.Log() and rrf.Max(literal zero)</name>
+  <files>pkg/api/v2/rank.go, pkg/api/v2/rank_test.go</files>
+  <behavior>
+    - `rrf.Log()` returns a non-nil Rank; `json.Marshal` on it and `WithRank(...)` both fail, and the error satisfies `errors.Is(err, ErrDegenerateRrfLog)`.
+    - `rrf.Max(Val(0))`, `rrf.Max(FloatOperand(0))`, `rrf.Max(IntOperand(0))` and `rrf.Max(FloatOperand(-0.0))` all fail with `errors.Is(err, ErrDegenerateRrfMaxZero)`.
+    - `rrf.Max(FloatOperand(1.0))`, `rrf.Max(Val(0.5))` and `rrf.Max(someKnnRank)` marshal successfully — non-zero and non-constant operands stay legal.
+    - `rrf.Abs()`, `rrf.Negate()`, `rrf.Exp()`, `rrf.Min(FloatOperand(0))` and all of Add/Sub/Multiply/Div marshal successfully — unchanged.
+    - A degenerate rank nested inside a larger expression (e.g. `rrf.Log().Add(FloatOperand(1))`) still fails at marshal time.
+  </behavior>
+  <action>
+    Per the LOCKED guard-mechanism decision, follow the `*UnknownRank` precedent at rank.go:85-105:
+    add an unexported leaf type (e.g. `degenerateRrfRank`) that embeds `ValRank`, carries an
+    `err error` field, and whose `MarshalJSON` returns that error wrapped with a message naming
+    the offending composition and why it degenerates.
+
+    Export two sentinels next to the existing error style so callers can `errors.Is` them:
+    `ErrDegenerateRrfLog` and `ErrDegenerateRrfMaxZero`. Wording should state the cause —
+    RrfRank.MarshalJSON negates the fusion sum, so the composed value is always <= 0, making
+    log() NaN and max(x, 0) a constant zero.
+
+    Change `(*RrfRank).Log()` (rank.go:1453) to return the degenerate leaf carrying
+    ErrDegenerateRrfLog. Change `(*RrfRank).Max(operand)` (rank.go:1457) to return the degenerate
+    leaf carrying ErrDegenerateRrfMaxZero ONLY when the operand is a statically-knowable literal
+    zero; otherwise keep the existing `&MaxRank{...}` behavior. Add an unexported helper that
+    recognizes literal zero for `FloatOperand`, `IntOperand` and `*ValRank` with value 0
+    (Go's `== 0` already matches negative zero — no special case needed). Any other operand,
+    including any Rank, is not statically knowable and stays legal.
+
+    Do NOT touch Abs, Negate, Exp or Min — LOCKED as legal.
+
+    Wire the new type into `validateBuiltInRankWithDepth` (rank.go:178) by adding it to the
+    existing `case *UnknownRank, *ValRank:` leaf branch, so `WithRank` (search.go:655) rejects it
+    eagerly rather than only at request marshal time. `marshalRank` already falls through to
+    `rank.MarshalJSON()` and `cloneRank`'s default returns the value unchanged, so neither needs
+    a new case — verify that is still true rather than adding one.
+
+    Update the `RrfRank` doc comment at rank.go:1305-1328: Log and Max(0) are now rejected at
+    build time; Abs and Negate remain warnings only. No panics, no `Must*`.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 -run 'TestRrf|TestRank|TestDegenerate|TestWithRank' ./pkg/api/v2/...</automated>
+  </verify>
+  <done>Both sentinels are exported and reachable via errors.Is from json.Marshal and from WithRank; only Log and literal-zero Max are rejected; every other RRF arithmetic path is unchanged and still passes.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Read-time cardinality guard in CollectionImpl.Search and cloud-pin flip</name>
+  <files>pkg/api/v2/collection_http.go, pkg/api/v2/collection_http_test.go, pkg/api/v2/client_cloud_test.go</files>
+  <behavior>
+    - Server response with `ids[0]` of length 5 and `scores[0]` of length 0, for a request whose Select includes KScore: Search returns (nil, err) with `errors.Is(err, ErrDegenerateSearchResult)`.
+    - Same mismatched response for a request whose Select omits KScore (or Select is nil): Search returns the result with no error — this is the #500 false-positive that the gate exists to prevent.
+    - Well-formed response with equal ID and score cardinality and KScore selected: no error.
+    - Response with per-element nulls (post Task 1, cardinalities equal): no error.
+    - Empty `ids[g]`: no error regardless of scores.
+  </behavior>
+  <action>
+    In `CollectionImpl.Search` (collection_http.go:426), after the response unmarshals into
+    `result`, run the guard while `sq` is still in scope — the LOCKED decision requires it to fire
+    without caller opt-in. For each group index g where `g < len(sq.Searches)`: skip unless that
+    request's `Select` is non-nil and its `Keys` contain `KScore`; then error when
+    `len(result.IDs[g]) > 0 && len(result.Scores[g]) != len(result.IDs[g])`. Guard every index
+    access so a short or absent Scores outer slice cannot panic.
+
+    Add an exported sentinel `ErrDegenerateSearchResult` in the same style as `ErrNilRank`
+    (options.go:936). Return `(nil, wrapped)` with the group index and both lengths in the
+    message. Placement of the check body (inline vs. an unexported helper) is discretionary,
+    but it must execute inside Search.
+
+    Then flip the cloud pins in `TestCloudClientSearchRRFArithmetic`
+    (client_cloud_test.go:1728). The `Log` case (line ~1983) and `Max_0` case (line ~2002)
+    currently assert the degenerate behavior with `require.NoError`; they must now assert
+    `require.Error` plus `errors.Is` against `ErrDegenerateRrfLog` / `ErrDegenerateRrfMaxZero`,
+    and stop asserting on results. Leave `Min_0`, `Negate`, `Abs`, `Exp` and the safe bucket
+    untouched. Update the corpus-limitation comment block (line ~1846) so it no longer describes
+    Log and Max(0) as pinned server observations.
+  </action>
+  <verify>
+    <automated>go test -tags=basicv2 -run 'TestCollection.*Search|TestSearchDegenerate' ./pkg/api/v2/... && go vet -tags='cloud' ./pkg/api/v2/...</automated>
+  </verify>
+  <done>Search errors with the exported sentinel only when KScore was selected and cardinality diverges; the KScore-absent case stays error-free; the cloud test compiles and its Log/Max_0 subtests assert the new error paths.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `make test` — full basicv2 suite green.
+2. `make lint` — clean (run before any commit, per CLAUDE.md).
+3. `go vet -tags=cloud ./pkg/api/v2/...` — cloud test file still compiles after the pin flip.
+4. Manual read-back of the CONTEXT.md null fixture: for scores [1.5, null, 3.5] over ids [a,b,c],
+   row a has Score 1.5 / HasScore true, row b has Score 0 / HasScore FALSE (it must NOT receive
+   3.5), and row c has Score 3.5 / HasScore true. Same shape for documents.
+5. No `Must*` calls and no `panic(` added to production files.
+</verification>
+
+<success_criteria>
+- Null score/document elements preserve position; a regression test asserts the exact CONTEXT.md fixture.
+- `ResultRow.HasScore` / `HasDocument` set correctly on Search, Query and Get paths.
+- `ErrDegenerateRrfLog`, `ErrDegenerateRrfMaxZero`, `ErrDegenerateSearchResult` exported and `errors.Is`-matchable.
+- Only Log and literal-zero Max rejected at build time; Abs, Negate, Min(0) untouched.
+- Read-time guard gated on KScore selection; no false positive on ordinary queries.
+- `make test` and `make lint` pass; cloud pins flipped.
+</success_criteria>
+
+<output>
+Conventional commits per CLAUDE.md. Suggested split:
+- `fix(api): preserve null positions in search scores and documents`
+- `feat(api): reject degenerate RRF Log and Max(0) compositions`
+- `feat(api): guard degenerate search result cardinality`
+
+PR body must close #497, #498, #500, #501 and note that #497's "server-behavior defect"
+framing is incorrect — the behavior is deterministic IEEE 754 math with no upstream guard;
+the Go client addresses it client-side per its own eager-rejection house style.
+</output>

--- a/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-SUMMARY.md
+++ b/.planning/quick/260803-occ-address-rrf-degenerate-composition-guard/260803-occ-SUMMARY.md
@@ -1,0 +1,112 @@
+---
+task: 260803-occ-address-rrf-degenerate-composition-guard
+type: execute
+status: complete
+requirements: ["#497", "#498", "#500", "#501"]
+key-files:
+  modified:
+    - pkg/api/v2/search.go
+    - pkg/api/v2/results.go
+    - pkg/api/v2/rank.go
+    - pkg/api/v2/collection_http.go
+    - pkg/api/v2/search_test.go
+    - pkg/api/v2/results_test.go
+    - pkg/api/v2/rank_test.go
+    - pkg/api/v2/collection_http_test.go
+    - pkg/api/v2/client_cloud_test.go
+commits:
+  - 528fcd2 fix(api): preserve null positions in search scores and documents
+  - db664d2 feat(api): reject degenerate RRF Log and Max(0) compositions
+  - 66a63dc feat(api): guard degenerate search result cardinality
+---
+
+# Quick Task 260803-occ: RRF degenerate composition guards — Summary
+
+Fixed silent score/document misalignment on null elements in Search responses, then added
+the build-time guard on degenerate `*RrfRank` compositions and the read-time cardinality
+guard in `CollectionImpl.Search` that only become sound once alignment is correct.
+
+## Task 1 — null-position preservation (528fcd2)
+
+- `SearchResultImpl.UnmarshalJSON` now appends a zero value at the original index for a
+  JSON `null` (or any non-matching type) in `scores` and `documents`, matching the
+  nil-handling already used for `Metadatas` and `Embeddings`.
+- Two unexported parallel slices (`documentPresent`, `scorePresent`) track per-element
+  presence; exported fields and JSON tags are unchanged (backward compatible).
+- `ResultRow` gained additive `HasDocument` / `HasScore` booleans, set on all three
+  construction paths (`SearchResultImpl.buildRow`, `QueryResultImpl.buildRow`,
+  `GetResultImpl.buildRow`). `elementPresent` treats a missing presence entry as present,
+  so hand-constructed `SearchResultImpl` values still report `true`.
+- Regression test asserts the exact CONTEXT.md fixture: ids `[a,b,c]`, scores
+  `[1.5,null,3.5]`, documents `["da",null,"dc"]` → row b keeps score 0 / `HasScore=false`
+  and row c keeps 3.5.
+
+## Task 2 — build-time degenerate RRF guard (db664d2)
+
+- Exported sentinels `ErrDegenerateRrfLog` and `ErrDegenerateRrfMaxZero` in `rank.go`.
+- New unexported `degenerateRrfRank` leaf embeds `ValRank` and fails in `MarshalJSON`,
+  following the `*UnknownRank` deferred-error precedent. Its own arithmetic methods return
+  the receiver so the error survives further composition
+  (`rrf.Log().Add(FloatOperand(1))` still fails).
+- `(*RrfRank).Log()` always returns the leaf. `(*RrfRank).Max(operand)` returns it only for
+  a statically-knowable literal zero (`IntOperand`, `FloatOperand`, `*ValRank`; negative
+  zero compares equal so needs no case). Everything else keeps `&MaxRank{...}`.
+- Wired into `validateBuiltInRankWithDepth`'s leaf branch so `WithRank` rejects eagerly.
+  `marshalRank` (falls through to `MarshalJSON`) and `cloneRank` (default returns the
+  value) needed no new cases — verified, not modified.
+- `RrfRank` doc comment updated: Log and Max(0) are build-time rejections; Abs and Negate
+  remain warnings only.
+
+## Task 3 — read-time cardinality guard and cloud pin flip (66a63dc)
+
+- Exported `ErrDegenerateSearchResult` plus `checkSearchResultCardinality` / `selectsScore`
+  in `collection_http.go`, invoked inside `Search` right after the response unmarshals so
+  it fires without caller opt-in.
+- Gate: only for group `g` where `sq.Searches[g].Select` is non-nil and includes `KScore`,
+  and `len(IDs[g]) > 0`; errors when the score count differs. All index accesses are bounds
+  checked, so a short or absent `Scores` outer slice cannot panic. `Search` returns
+  `(nil, err)` wrapped with the group index and both lengths.
+- Cloud pins in `TestCloudClientSearchRRFArithmetic` flipped: `Log` and `Max_0` now assert
+  `require.Error` + `errors.Is` against the new sentinels and stop asserting on results.
+  `Min_0`, `Negate`, `Abs`, `Exp` and the safe bucket are untouched. The corpus-limitation
+  comment no longer describes Log and Max(0) as pinned server observations.
+
+## Deviations from Plan
+
+**1. [Rule 3 - Blocking] Existing `TestRrfRankArithmetic` pinned the old behavior**
+- Found during: Task 2.
+- Issue: the table cases `Log` and `Max` (with `FloatOperand(0.0)`) and the
+  "wrappers remain independent" subtest asserted successful marshaling of the now-rejected
+  compositions.
+- Fix: removed the `Log` case, changed the `Max` case operand to `FloatOperand(2.0)`, and
+  switched the independence subtest's third wrapper from `rrf.Log()` to `rrf.Exp()`. The new
+  `TestDegenerateRrfCompositions` covers the rejected paths.
+- Commit: db664d2.
+
+**2. [Scope] `degenerateRrfRank` overrides the promoted arithmetic methods**
+- The plan only specified `MarshalJSON`. Because `ValRank` is embedded by value, promoted
+  methods would compose against the zero-valued embedded `ValRank` and silently drop the
+  error, which contradicts the plan's own behavior requirement that a nested degenerate rank
+  still fails. Ten one-line methods return the receiver instead.
+
+**3. [Test shape] Query/Get null-document tests use direct construction**
+- `NewTextDocumentsFromInterface` rejects a JSON `null` document with an error on the
+  Query/Get paths, so a null-document wire fixture cannot reach `buildRow` there. Those two
+  tests construct `Documents{doc, nil}` directly. Changing the Query/Get document parser is
+  out of scope for this task and was not touched.
+
+No architectural changes, no auth gates, no deferred issues.
+
+## Verification
+
+- `make lint` — 0 issues (run before each commit).
+- `make test` (basicv2) — 2087 tests, 7 skipped, all passing.
+- `go vet -tags=cloud ./pkg/api/v2/...` — clean; the cloud test file compiles after the pin
+  flip. Cloud tests were not run (no credentials); compilation was the agreed bar.
+- No `Must*` calls and no `panic(` added to production files.
+
+## Self-Check: PASSED
+
+- All four production files and five test files exist and are committed.
+- Commits 528fcd2, db664d2, 66a63dc all present in `git log`.
+- Working tree clean after Task 3.

--- a/pkg/api/v2/client_cloud_test.go
+++ b/pkg/api/v2/client_cloud_test.go
@@ -1848,15 +1848,13 @@ func TestCloudClientSearchRRFArithmetic(t *testing.T) {
 	// tree operates on `-rrf_sum` which is always non-positive here. Consequences:
 	//   - Negate and Abs are empirically equivalent: both flip the order with
 	//     identical scores (|baseline|). abs(x) == -x for x <= 0.
-	//   - Max(0) collapses all scores to zero (max(x, 0) == 0 for x <= 0), producing
-	//     an all-tied result set that falls back to default insertion order.
-	//   - Log returns an inner-empty Scores slice (log of non-positive is undefined),
-	//     with IDs falling back to default insertion order.
+	//   - Max(0) and Log are rejected client-side before the request is sent, so the
+	//     degenerate server behavior they used to pin is no longer observable here.
 	//   - Min(0) is a mathematical identity (min(x, 0) == x for x <= 0), making it
 	//     indistinguishable from the baseline RRF run.
 	// This corpus is intentionally pinned as a regression baseline. A richer corpus
-	// that produces at least one positive fused score would let Min(0)/Max(0)/Log/Abs
-	// exercise non-identity branches meaningfully — tracked separately.
+	// that produces at least one positive fused score would let Min(0)/Abs exercise
+	// non-identity branches meaningfully — tracked separately.
 	for _, tt := range rows {
 		t.Run(tt.name, func(t *testing.T) {
 			// Capture variables populated after Search and register a deferred logger
@@ -1981,45 +1979,16 @@ func TestCloudClientSearchRRFArithmetic(t *testing.T) {
 						"Exp: Scores must differ from baseline (monotonic transform changes values)")
 
 				case "Log":
-					// Server bug: applying Log to non-positive fused scores silently
-					// falls back to insertion order with an empty inner Scores slice
-					// instead of returning a structured error. Pinned as a regression
-					// baseline — tracked separately in the issue tracker.
-					require.NoError(t, err, "Log: no error returned (server silently degenerates)")
-					require.NotNil(t, results, "Log: results must not be nil")
-					sr, srOk := results.(*SearchResultImpl)
-					require.True(t, srOk, "Log: result must be *SearchResultImpl")
-					require.NotEmpty(t, sr.IDs, "Log: outer IDs must not be empty")
-					require.Len(t, sr.IDs, 1, "Log: outer IDs must have exactly one query entry")
-					require.Len(t, sr.IDs[0], 5, "Log: inner IDs must have all 5 docs in insertion order")
-					require.Equal(t, []DocumentID{"1", "2", "3", "4", "5"}, sr.IDs[0],
-						"Log: IDs must fall back to default insertion order when server silently degenerates")
-					require.NotEmpty(t, sr.Scores, "Log: outer Scores must not be empty")
-					require.Len(t, sr.Scores, 1, "Log: outer Scores must have exactly one query entry")
-					require.Empty(t, sr.Scores[0],
-						"Log: inner Scores must be empty (degenerate — server dropped scores for log of non-positive)")
+					// The client rejects rrf.Log() at build time, so the request is
+					// never sent and there is no server observation to pin.
+					require.Error(t, err, "Log: search must fail before sending")
+					require.ErrorIs(t, err, ErrDegenerateRrfLog)
 
 				case "Max_0":
-					// Max(0) on an all-negative corpus collapses every score to exactly 0
-					// (max(x, 0) == 0 for x <= 0), producing an all-tied result set that
-					// falls back to default insertion order. The client could reject this
-					// construction at build time — tracked separately as an enhancement.
-					require.NoError(t, err, "Max(0): search must succeed")
-					require.NotNil(t, results, "Max(0): results must not be nil")
-					sr, srOk := results.(*SearchResultImpl)
-					require.True(t, srOk, "Max(0): result must be *SearchResultImpl")
-					require.NotEmpty(t, sr.IDs, "Max(0): outer IDs must not be empty")
-					require.NotEmpty(t, sr.Scores, "Max(0): outer Scores must not be empty")
-					require.Len(t, sr.IDs, 1, "Max(0): outer IDs must have exactly one query entry")
-					require.Len(t, sr.IDs[0], 5, "Max(0): inner IDs must have all 5 docs")
-					require.Equal(t, []DocumentID{"1", "2", "3", "4", "5"}, sr.IDs[0],
-						"Max(0): IDs must fall back to default insertion order when all scores tied at 0")
-					require.Len(t, sr.Scores, 1, "Max(0): outer Scores must have exactly one query entry")
-					require.Len(t, sr.Scores[0], 5, "Max(0): inner Scores must have 5 entries")
-					for i, s := range sr.Scores[0] {
-						require.Equal(t, float64(0), s,
-							"Max(0): expected zero score at index %d, got %v (max(-rrf_sum, 0) collapses to 0 for -rrf_sum<=0)", i, s)
-					}
+					// The client rejects rrf.Max(literal 0) at build time, so the
+					// request is never sent and there is no server observation to pin.
+					require.Error(t, err, "Max(0): search must fail before sending")
+					require.ErrorIs(t, err, ErrDegenerateRrfMaxZero)
 
 				case "Min_0":
 					// Min(0) is a mathematical identity on an all-negative baseline

--- a/pkg/api/v2/collection_http.go
+++ b/pkg/api/v2/collection_http.go
@@ -452,8 +452,47 @@ func (c *CollectionImpl) Search(ctx context.Context, opts ...SearchCollectionOpt
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, errors.Wrap(err, "error unmarshalling search result")
 	}
+	if err := checkSearchResultCardinality(sq, &result); err != nil {
+		return nil, err
+	}
 
 	return &result, nil
+}
+
+// ErrDegenerateSearchResult is returned by [CollectionImpl.Search] when a
+// response selected scores but returned a different number of scores than IDs,
+// which means the ranking expression collapsed server-side.
+var ErrDegenerateSearchResult = errors.New("search result is degenerate")
+
+func checkSearchResultCardinality(sq *SearchQuery, result *SearchResultImpl) error {
+	for g := range result.IDs {
+		if g >= len(sq.Searches) {
+			break
+		}
+		if !selectsScore(sq.Searches[g].Select) || len(result.IDs[g]) == 0 {
+			continue
+		}
+		scoreCount := 0
+		if g < len(result.Scores) {
+			scoreCount = len(result.Scores[g])
+		}
+		if scoreCount != len(result.IDs[g]) {
+			return errors.Wrapf(ErrDegenerateSearchResult, "group %d returned %d ids but %d scores", g, len(result.IDs[g]), scoreCount)
+		}
+	}
+	return nil
+}
+
+func selectsScore(sel *SearchSelect) bool {
+	if sel == nil {
+		return false
+	}
+	for _, key := range sel.Keys {
+		if key == KScore {
+			return true
+		}
+	}
+	return false
 }
 
 // embedTextQueries embeds any text queries in the search request.

--- a/pkg/api/v2/collection_http_test.go
+++ b/pkg/api/v2/collection_http_test.go
@@ -1335,3 +1335,98 @@ func TestCloneRank(t *testing.T) {
 		require.JSONEq(t, string(originalJSON), string(clonedJSON))
 	})
 }
+
+func TestCollectionSearchDegenerateCardinality(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectKey []Key
+		response  string
+		expectErr bool
+	}{
+		{
+			name:      "score selected and scores empty",
+			selectKey: []Key{KID, KScore},
+			response:  `{"ids":[["a","b","c","d","e"]],"scores":[[]]}`,
+			expectErr: true,
+		},
+		{
+			name:      "score selected and scores absent",
+			selectKey: []Key{KID, KScore},
+			response:  `{"ids":[["a","b"]]}`,
+			expectErr: true,
+		},
+		{
+			name:      "score not selected",
+			selectKey: []Key{KID, KDocument},
+			response:  `{"ids":[["a","b","c","d","e"]],"scores":[[]]}`,
+			expectErr: false,
+		},
+		{
+			name:      "no select",
+			selectKey: nil,
+			response:  `{"ids":[["a","b","c","d","e"]],"scores":[[]]}`,
+			expectErr: false,
+		},
+		{
+			name:      "matching cardinality",
+			selectKey: []Key{KID, KScore},
+			response:  `{"ids":[["a","b"]],"scores":[[1.5,2.5]]}`,
+			expectErr: false,
+		},
+		{
+			name:      "null score element keeps cardinality",
+			selectKey: []Key{KID, KScore},
+			response:  `{"ids":[["a","b"]],"scores":[[1.5,null]]}`,
+			expectErr: false,
+		},
+		{
+			name:      "empty ids group",
+			selectKey: []Key{KID, KScore},
+			response:  `{"ids":[[]],"scores":[[]]}`,
+			expectErr: false,
+		},
+	}
+
+	const searchPath = "/api/v2/tenants/default_tenant/databases/default_database/collections/8ecf0f7e-e806-47f8-96a1-4732ef42359e/search"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != searchPath {
+					http.NotFound(w, r)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				if _, err := w.Write([]byte(tt.response)); err != nil {
+					t.Errorf("write search response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewHTTPClient(WithBaseURL(server.URL), WithLogger(testLogger()))
+			require.NoError(t, err)
+			collection := &CollectionImpl{
+				name:              "test",
+				id:                "8ecf0f7e-e806-47f8-96a1-4732ef42359e",
+				tenant:            NewDefaultTenant(),
+				database:          NewDefaultDatabase(),
+				metadata:          NewMetadata(),
+				client:            client.(*APIClientV2),
+				embeddingFunction: embeddings.NewConsistentHashEmbeddingFunction(),
+			}
+
+			req := NewSearchRequest(WithKnnRank(KnnQueryText("query")))
+			if tt.selectKey != nil {
+				req = NewSearchRequest(WithKnnRank(KnnQueryText("query")), WithSelect(tt.selectKey...))
+			}
+
+			result, searchErr := collection.Search(context.Background(), req)
+			if tt.expectErr {
+				require.Nil(t, result)
+				require.ErrorIs(t, searchErr, ErrDegenerateSearchResult)
+				return
+			}
+			require.NoError(t, searchErr)
+			require.NotNil(t, result)
+		})
+	}
+}

--- a/pkg/api/v2/rank.go
+++ b/pkg/api/v2/rank.go
@@ -105,6 +105,55 @@ func (u *UnknownRank) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("UnknownRank: cannot marshal unknown operand type - this indicates a programming error")
 }
 
+var (
+	// ErrDegenerateRrfLog is returned when a rank built from rrf.Log() is
+	// marshalled or passed to [WithRank].
+	ErrDegenerateRrfLog = errors.New("RrfRank.Log is degenerate: RrfRank negates the fusion sum, so its value is always <= 0 and log() of a non-positive value is NaN, which the server drops")
+
+	// ErrDegenerateRrfMaxZero is returned when a rank built from rrf.Max with a
+	// literal zero operand is marshalled or passed to [WithRank].
+	ErrDegenerateRrfMaxZero = errors.New("RrfRank.Max(0) is degenerate: RrfRank negates the fusion sum, so its value is always <= 0 and max(x, 0) is a constant zero, leaving every result tied")
+)
+
+// degenerateRrfRank is a leaf returned by provably degenerate *RrfRank
+// compositions. Like [UnknownRank] it defers the failure to MarshalJSON so the
+// fluent arithmetic API keeps its single return value, and its own arithmetic
+// methods return the receiver so the error survives further composition.
+type degenerateRrfRank struct {
+	ValRank
+	err error
+}
+
+func (d *degenerateRrfRank) MarshalJSON() ([]byte, error) {
+	return nil, d.err
+}
+
+func (d *degenerateRrfRank) Multiply(_ Operand) Rank { return d }
+func (d *degenerateRrfRank) Sub(_ Operand) Rank      { return d }
+func (d *degenerateRrfRank) Add(_ Operand) Rank      { return d }
+func (d *degenerateRrfRank) Div(_ Operand) Rank      { return d }
+func (d *degenerateRrfRank) Negate() Rank            { return d }
+func (d *degenerateRrfRank) Abs() Rank               { return d }
+func (d *degenerateRrfRank) Exp() Rank               { return d }
+func (d *degenerateRrfRank) Log() Rank               { return d }
+func (d *degenerateRrfRank) Max(_ Operand) Rank      { return d }
+func (d *degenerateRrfRank) Min(_ Operand) Rank      { return d }
+
+// isLiteralZeroOperand reports whether the operand is a statically knowable
+// zero constant. Negative zero compares equal to zero, so it needs no case.
+func isLiteralZeroOperand(operand Operand) bool {
+	switch v := operand.(type) {
+	case IntOperand:
+		return v == 0
+	case FloatOperand:
+		return v == 0
+	case *ValRank:
+		return v != nil && v.value == 0
+	default:
+		return false
+	}
+}
+
 func marshalRank(rank Rank, depth int) ([]byte, error) {
 	if isNilRank(rank) {
 		return nil, ErrNilRank
@@ -176,7 +225,7 @@ func validateBuiltInRankWithDepth(rank Rank, depth int) error {
 	}
 
 	switch rank := rank.(type) {
-	case *UnknownRank, *ValRank:
+	case *UnknownRank, *ValRank, *degenerateRrfRank:
 		// These SDK-owned leaves have no descendants. Their own marshalers are
 		// side-effect free and retain JSON's finite-number validation for ValRank.
 		_, err := rank.MarshalJSON()
@@ -1313,11 +1362,12 @@ func WithRrfNormalize() RrfOption {
 // rank sum so that a smaller (more negative) score means a better match. As a
 // result, the operand to composition is always non-positive on non-empty
 // corpora, and the following transforms misbehave on that input:
-//   - Log degenerates silently: log of a non-positive value is NaN, and the
-//     server drops NaN rows, leaving an empty inner Scores slice and IDs
-//     in insertion order.
-//   - Max(Val(0)) collapses every score to 0 (max(x, 0) == 0 for x <= 0),
-//     producing an all-tied result that falls back to insertion order.
+//   - Log is rejected at build time with [ErrDegenerateRrfLog]: log of a
+//     non-positive value is NaN and the server drops NaN rows.
+//   - Max with a literal zero operand is rejected at build time with
+//     [ErrDegenerateRrfMaxZero]: max(x, 0) == 0 for x <= 0, producing an
+//     all-tied result that falls back to insertion order. A non-zero or
+//     non-constant operand stays legal.
 //   - Abs flips the ordering on RRF's non-positive output (abs(x) == -x
 //     for x <= 0, reversing the sign).
 //   - Negate inverts result ordering the same way Abs does on this input
@@ -1451,10 +1501,13 @@ func (r *RrfRank) Exp() Rank {
 }
 
 func (r *RrfRank) Log() Rank {
-	return &LogRank{rank: r}
+	return &degenerateRrfRank{err: ErrDegenerateRrfLog}
 }
 
 func (r *RrfRank) Max(operand Operand) Rank {
+	if isLiteralZeroOperand(operand) {
+		return &degenerateRrfRank{err: ErrDegenerateRrfMaxZero}
+	}
 	return &MaxRank{ranks: []Rank{r, operandToRank(operand)}}
 }
 

--- a/pkg/api/v2/rank_test.go
+++ b/pkg/api/v2/rank_test.go
@@ -903,14 +903,9 @@ func TestRrfRankArithmetic(t *testing.T) {
 			expected: `{"$exp":` + rrfStr + `}`,
 		},
 		{
-			name:     "Log",
-			apply:    func(r *RrfRank) Rank { return r.Log() },
-			expected: `{"$log":` + rrfStr + `}`,
-		},
-		{
 			name:     "Max",
-			apply:    func(r *RrfRank) Rank { return r.Max(FloatOperand(0.0)) },
-			expected: `{"$max":[` + rrfStr + `,{"$val":0}]}`,
+			apply:    func(r *RrfRank) Rank { return r.Max(FloatOperand(2.0)) },
+			expected: `{"$max":[` + rrfStr + `,{"$val":2}]}`,
 		},
 		{
 			name:     "Min",
@@ -957,7 +952,7 @@ func TestRrfRankArithmetic(t *testing.T) {
 	t.Run("wrappers remain independent across sequential calls", func(t *testing.T) {
 		a := rrf.Add(FloatOperand(1))
 		b := rrf.Multiply(FloatOperand(2))
-		c := rrf.Log()
+		c := rrf.Exp()
 
 		bJSON, err := b.MarshalJSON()
 		require.NoError(t, err)
@@ -968,7 +963,7 @@ func TestRrfRankArithmetic(t *testing.T) {
 
 		require.JSONEq(t, `{"$sum":[`+rrfStr+`,{"$val":1}]}`, string(aJSON))
 		require.JSONEq(t, `{"$mul":[`+rrfStr+`,{"$val":2}]}`, string(bJSON))
-		require.JSONEq(t, `{"$log":`+rrfStr+`}`, string(cJSON))
+		require.JSONEq(t, `{"$exp":`+rrfStr+`}`, string(cJSON))
 	})
 }
 
@@ -1208,4 +1203,82 @@ func TestMarshalRankFallbackForNestedNonCompositeChild(t *testing.T) {
 	mrData, err := mr.MarshalJSON()
 	require.NoError(t, err)
 	require.JSONEq(t, string(mrData), string(terms[1]))
+}
+
+func testRrfRank(t *testing.T) *RrfRank {
+	t.Helper()
+	knn1, err := NewKnnRank(KnnQueryText("alpha"), WithKnnReturnRank())
+	require.NoError(t, err)
+	knn2, err := NewKnnRank(KnnQueryText("beta"), WithKnnReturnRank())
+	require.NoError(t, err)
+	rrf, err := NewRrfRank(WithRrfRanks(knn1.WithWeight(1), knn2.WithWeight(1)), WithRrfK(60))
+	require.NoError(t, err)
+	return rrf
+}
+
+func TestDegenerateRrfCompositions(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func(rrf *RrfRank) Rank
+		sentinel error
+	}{
+		{"log", func(rrf *RrfRank) Rank { return rrf.Log() }, ErrDegenerateRrfLog},
+		{"max val zero", func(rrf *RrfRank) Rank { return rrf.Max(Val(0)) }, ErrDegenerateRrfMaxZero},
+		{"max float zero", func(rrf *RrfRank) Rank { return rrf.Max(FloatOperand(0)) }, ErrDegenerateRrfMaxZero},
+		{"max negative zero", func(rrf *RrfRank) Rank { return rrf.Max(FloatOperand(math.Copysign(0, -1))) }, ErrDegenerateRrfMaxZero},
+		{"max int zero", func(rrf *RrfRank) Rank { return rrf.Max(IntOperand(0)) }, ErrDegenerateRrfMaxZero},
+		{"nested log", func(rrf *RrfRank) Rank { return rrf.Log().Add(FloatOperand(1)) }, ErrDegenerateRrfLog},
+		{"nested max zero", func(rrf *RrfRank) Rank { return rrf.Max(Val(0)).Multiply(FloatOperand(2)) }, ErrDegenerateRrfMaxZero},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rank := tt.build(testRrfRank(t))
+			require.NotNil(t, rank)
+
+			_, err := json.Marshal(rank)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.sentinel)
+
+			req := &SearchRequest{}
+			require.ErrorIs(t, WithRank(rank).ApplyToSearchRequest(req), tt.sentinel)
+			require.Nil(t, req.Rank)
+		})
+	}
+}
+
+func TestLegalRrfCompositions(t *testing.T) {
+	knn, err := NewKnnRank(KnnQueryText("alpha"), WithKnnReturnRank())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		build func(rrf *RrfRank) Rank
+	}{
+		{"max non-zero float", func(rrf *RrfRank) Rank { return rrf.Max(FloatOperand(1.0)) }},
+		{"max non-zero val", func(rrf *RrfRank) Rank { return rrf.Max(Val(0.5)) }},
+		{"max rank operand", func(rrf *RrfRank) Rank { return rrf.Max(knn) }},
+		{"min zero", func(rrf *RrfRank) Rank { return rrf.Min(FloatOperand(0)) }},
+		{"min val zero", func(rrf *RrfRank) Rank { return rrf.Min(Val(0)) }},
+		{"abs", func(rrf *RrfRank) Rank { return rrf.Abs() }},
+		{"negate", func(rrf *RrfRank) Rank { return rrf.Negate() }},
+		{"exp", func(rrf *RrfRank) Rank { return rrf.Exp() }},
+		{"add", func(rrf *RrfRank) Rank { return rrf.Add(FloatOperand(1)) }},
+		{"sub", func(rrf *RrfRank) Rank { return rrf.Sub(FloatOperand(1)) }},
+		{"multiply", func(rrf *RrfRank) Rank { return rrf.Multiply(FloatOperand(2)) }},
+		{"div", func(rrf *RrfRank) Rank { return rrf.Div(FloatOperand(2)) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rank := tt.build(testRrfRank(t))
+			data, err := json.Marshal(rank)
+			require.NoError(t, err)
+			require.NotEmpty(t, data)
+
+			req := &SearchRequest{}
+			require.NoError(t, WithRank(rank).ApplyToSearchRequest(req))
+			require.NotNil(t, req.Rank)
+		})
+	}
 }

--- a/pkg/api/v2/results.go
+++ b/pkg/api/v2/results.go
@@ -12,11 +12,13 @@ import (
 // ResultRow represents a single result item with all associated data.
 // Use this with Rows() or At() for ergonomic iteration over results.
 type ResultRow struct {
-	ID        DocumentID
-	Document  string           // Empty if not included in results
-	Metadata  DocumentMetadata // nil if not included in results
-	Embedding []float32        // nil if not included in results
-	Score     float64          // Search: relevance score (higher=better); Query: distance (lower=better); Get: 0
+	ID          DocumentID
+	Document    string           // Empty if not included in results
+	HasDocument bool             // false when the server sent null or the field was not selected
+	Metadata    DocumentMetadata // nil if not included in results
+	Embedding   []float32        // nil if not included in results
+	Score       float64          // Search: relevance score (higher=better); Query: distance (lower=better); Get: 0
+	HasScore    bool             // false when the server sent null or the field was not selected
 }
 
 type GetResult interface {
@@ -195,6 +197,7 @@ func (r *GetResultImpl) buildRow(i int) ResultRow {
 	}
 	if i < len(r.Documents) && r.Documents[i] != nil {
 		row.Document = r.Documents[i].ContentString()
+		row.HasDocument = true
 	}
 	if i < len(r.Metadatas) {
 		row.Metadata = r.Metadatas[i]
@@ -462,6 +465,7 @@ func (r *QueryResultImpl) buildRow(g, i int) ResultRow {
 	}
 	if g < len(r.DocumentsLists) && i < len(r.DocumentsLists[g]) && r.DocumentsLists[g][i] != nil {
 		row.Document = r.DocumentsLists[g][i].ContentString()
+		row.HasDocument = true
 	}
 	if g < len(r.MetadatasLists) && i < len(r.MetadatasLists[g]) {
 		row.Metadata = r.MetadatasLists[g][i]
@@ -471,6 +475,7 @@ func (r *QueryResultImpl) buildRow(g, i int) ResultRow {
 	}
 	if g < len(r.DistancesLists) && i < len(r.DistancesLists[g]) {
 		row.Score = float64(r.DistancesLists[g][i])
+		row.HasScore = true
 	}
 	return row
 }

--- a/pkg/api/v2/results_test.go
+++ b/pkg/api/v2/results_test.go
@@ -309,3 +309,42 @@ func TestQueryResultImpl_At(t *testing.T) {
 	_, ok = result.At(0, 2)
 	require.False(t, ok)
 }
+
+func TestQueryResultRowPresenceFlags(t *testing.T) {
+	result := &QueryResultImpl{
+		IDLists:        []DocumentIDs{{"a", "b"}},
+		DocumentsLists: []Documents{{NewTextDocument("da"), nil}},
+		DistancesLists: []embeddings.Distances{{0.1}},
+	}
+
+	rows := result.Rows()
+	require.Len(t, rows, 2)
+	require.True(t, rows[0].HasScore)
+	require.True(t, rows[0].HasDocument)
+	require.False(t, rows[1].HasScore)
+	require.False(t, rows[1].HasDocument)
+}
+
+func TestQueryResultRowPresenceFlagsNoDistances(t *testing.T) {
+	var result QueryResultImpl
+	require.NoError(t, json.Unmarshal([]byte(`{"ids":[["a"]],"documents":[["da"]]}`), &result))
+
+	rows := result.Rows()
+	require.Len(t, rows, 1)
+	require.False(t, rows[0].HasScore)
+	require.True(t, rows[0].HasDocument)
+}
+
+func TestGetResultRowPresenceFlags(t *testing.T) {
+	result := &GetResultImpl{
+		Ids:       DocumentIDs{"a", "b"},
+		Documents: Documents{NewTextDocument("da"), nil},
+	}
+
+	rows := result.Rows()
+	require.Len(t, rows, 2)
+	require.False(t, rows[0].HasScore)
+	require.True(t, rows[0].HasDocument)
+	require.False(t, rows[1].HasScore)
+	require.False(t, rows[1].HasDocument)
+}

--- a/pkg/api/v2/search.go
+++ b/pkg/api/v2/search.go
@@ -790,6 +790,12 @@ type SearchResultImpl struct {
 	// Scores contains ranking scores for each query result set.
 	// Only populated if [WithSelect] included [KScore].
 	Scores [][]float64 `json:"scores,omitempty"`
+
+	// Presence of documents and scores per element, populated by UnmarshalJSON.
+	// A null element keeps its position in the exported slices, which cannot
+	// distinguish a null from a zero value on their own.
+	documentPresent [][]bool
+	scorePresent    [][]bool
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for SearchResultImpl.
@@ -829,19 +835,23 @@ func (r *SearchResultImpl) UnmarshalJSON(data []byte) error {
 	if docsRaw, ok := temp["documents"]; ok && docsRaw != nil {
 		if docsList, ok := docsRaw.([]interface{}); ok {
 			r.Documents = make([][]string, 0, len(docsList))
+			r.documentPresent = make([][]bool, 0, len(docsList))
 			for _, docsGroup := range docsList {
 				if docsGroup == nil {
 					r.Documents = append(r.Documents, nil)
+					r.documentPresent = append(r.documentPresent, nil)
 					continue
 				}
 				if group, ok := docsGroup.([]interface{}); ok {
 					docs := make([]string, 0, len(group))
+					present := make([]bool, 0, len(group))
 					for _, doc := range group {
-						if docStr, ok := doc.(string); ok {
-							docs = append(docs, docStr)
-						}
+						docStr, ok := doc.(string)
+						docs = append(docs, docStr)
+						present = append(present, ok)
 					}
 					r.Documents = append(r.Documents, docs)
+					r.documentPresent = append(r.documentPresent, present)
 				}
 			}
 		}
@@ -920,26 +930,35 @@ func (r *SearchResultImpl) UnmarshalJSON(data []byte) error {
 	if scoresRaw, ok := temp["scores"]; ok && scoresRaw != nil {
 		if scoresList, ok := scoresRaw.([]interface{}); ok {
 			r.Scores = make([][]float64, 0, len(scoresList))
+			r.scorePresent = make([][]bool, 0, len(scoresList))
 			for _, scoresGroup := range scoresList {
 				if scoresGroup == nil {
 					r.Scores = append(r.Scores, nil)
+					r.scorePresent = append(r.scorePresent, nil)
 					continue
 				}
 				if group, ok := scoresGroup.([]interface{}); ok {
 					scores := make([]float64, 0, len(group))
+					present := make([]bool, 0, len(group))
 					for _, score := range group {
 						switch scoreVal := score.(type) {
 						case float64:
 							scores = append(scores, scoreVal)
+							present = append(present, true)
 						case json.Number:
 							v, err := scoreVal.Float64()
 							if err != nil {
 								return errors.Wrapf(err, "invalid score value: %v", scoreVal)
 							}
 							scores = append(scores, v)
+							present = append(present, true)
+						default:
+							scores = append(scores, 0)
+							present = append(present, false)
 						}
 					}
 					r.Scores = append(r.Scores, scores)
+					r.scorePresent = append(r.scorePresent, present)
 				}
 			}
 		}
@@ -1000,6 +1019,7 @@ func (r *SearchResultImpl) buildRow(g, i int) ResultRow {
 	}
 	if g < len(r.Documents) && i < len(r.Documents[g]) {
 		row.Document = r.Documents[g][i]
+		row.HasDocument = elementPresent(r.documentPresent, g, i)
 	}
 	if g < len(r.Metadatas) && i < len(r.Metadatas[g]) {
 		row.Metadata = r.Metadatas[g][i]
@@ -1009,6 +1029,17 @@ func (r *SearchResultImpl) buildRow(g, i int) ResultRow {
 	}
 	if g < len(r.Scores) && i < len(r.Scores[g]) {
 		row.Score = r.Scores[g][i]
+		row.HasScore = elementPresent(r.scorePresent, g, i)
 	}
 	return row
+}
+
+// elementPresent reports whether the element at [g][i] was present on the wire.
+// A missing presence entry means the value was not produced by UnmarshalJSON,
+// so a directly constructed SearchResultImpl reports its values as present.
+func elementPresent(present [][]bool, g, i int) bool {
+	if g >= len(present) || i >= len(present[g]) {
+		return true
+	}
+	return present[g][i]
 }

--- a/pkg/api/v2/search_test.go
+++ b/pkg/api/v2/search_test.go
@@ -1429,3 +1429,94 @@ func TestSearchRequestMarshalTypedNilRank(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, string(data), `"rank"`)
 }
+
+func TestSearchResultNullElementsPreservePosition(t *testing.T) {
+	const payload = `{"ids":[["a","b","c"]],"scores":[[1.5,null,3.5]],"documents":[["da",null,"dc"]]}`
+
+	var result SearchResultImpl
+	require.NoError(t, json.Unmarshal([]byte(payload), &result))
+
+	require.Equal(t, [][]float64{{1.5, 0, 3.5}}, result.Scores)
+	require.Equal(t, [][]string{{"da", "", "dc"}}, result.Documents)
+
+	rows := result.Rows()
+	require.Len(t, rows, 3)
+
+	require.Equal(t, DocumentID("a"), rows[0].ID)
+	require.Equal(t, 1.5, rows[0].Score)
+	require.True(t, rows[0].HasScore)
+	require.Equal(t, "da", rows[0].Document)
+	require.True(t, rows[0].HasDocument)
+
+	require.Equal(t, DocumentID("b"), rows[1].ID)
+	require.Equal(t, float64(0), rows[1].Score)
+	require.False(t, rows[1].HasScore)
+	require.Equal(t, "", rows[1].Document)
+	require.False(t, rows[1].HasDocument)
+
+	require.Equal(t, DocumentID("c"), rows[2].ID)
+	require.Equal(t, 3.5, rows[2].Score)
+	require.True(t, rows[2].HasScore)
+	require.Equal(t, "dc", rows[2].Document)
+	require.True(t, rows[2].HasDocument)
+}
+
+func TestSearchResultPresenceFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		hasScore    []bool
+		hasDocument []bool
+	}{
+		{
+			name:        "no nulls",
+			payload:     `{"ids":[["a","b"]],"scores":[[1,2]],"documents":[["da","db"]]}`,
+			hasScore:    []bool{true, true},
+			hasDocument: []bool{true, true},
+		},
+		{
+			name:        "scores not selected",
+			payload:     `{"ids":[["a","b"]],"documents":[["da","db"]]}`,
+			hasScore:    []bool{false, false},
+			hasDocument: []bool{true, true},
+		},
+		{
+			name:        "documents not selected",
+			payload:     `{"ids":[["a","b"]],"scores":[[1,2]]}`,
+			hasScore:    []bool{true, true},
+			hasDocument: []bool{false, false},
+		},
+		{
+			name:        "null group",
+			payload:     `{"ids":[["a","b"]],"scores":[null],"documents":[null]}`,
+			hasScore:    []bool{false, false},
+			hasDocument: []bool{false, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result SearchResultImpl
+			require.NoError(t, json.Unmarshal([]byte(tt.payload), &result))
+			rows := result.Rows()
+			require.Len(t, rows, len(tt.hasScore))
+			for i, row := range rows {
+				require.Equal(t, tt.hasScore[i], row.HasScore, "row %d HasScore", i)
+				require.Equal(t, tt.hasDocument[i], row.HasDocument, "row %d HasDocument", i)
+			}
+		})
+	}
+}
+
+func TestSearchResultPresenceFlagsDirectConstruction(t *testing.T) {
+	result := &SearchResultImpl{
+		IDs:       [][]DocumentID{{"a", "b"}},
+		Documents: [][]string{{"da", "db"}},
+		Scores:    [][]float64{{1, 2}},
+	}
+
+	for i, row := range result.Rows() {
+		require.True(t, row.HasScore, "row %d HasScore", i)
+		require.True(t, row.HasDocument, "row %d HasDocument", i)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the RRF degenerate-composition cluster (#497, #498, #500, #501) plus a
silent data-corruption bug found while validating them.

Three changes, in dependency order:

1. **Preserve null positions in search scores/documents** — the actual bug behind #500's symptom.
2. **Reject degenerate RRF compositions at build time** — #497, #498, #501.
3. **Guard degenerate search result cardinality at read time** — #500.

## 1. Null-element misalignment (silent data corruption)

The wire contract models scores as `Vec<Option<Vec<Option<f32>>>>` and documents as
`Vec<Option<Vec<Option<String>>>>`, so a per-element `null` is legal, intended protocol.

`SearchResultImpl.UnmarshalJSON` type-switched each element with no `null` case, so a
`null` was **silently skipped instead of appended**. Every later element shifted left one
position while `IDs` stayed put — binding scores and documents to the wrong document:

```
input:  ids=[a,b,c]  scores=[1.5, null, 3.5]  documents=["da", null, "dc"]

before:  a -> 1.5 / "da"   b -> 3.5 / "dc"   c -> 0 / ""
                            ^ b receives c's score and document
                                              ^ real value silently becomes zero
after:   a -> 1.5 / "da"   b -> 0 / "" (HasScore=false)   c -> 3.5 / "dc"
```

`Metadatas` and `Embeddings` already handled nil correctly — only scores and documents
were affected. This fires on **any** query returning a null score or document; no RRF
involved. It is the real mechanism behind #500's "result-shape mismatch", which the issue
attributed to RRF degeneration.

Because `[][]float64` and `[][]string` cannot represent absence, `ResultRow` gains two
additive companions:

```go
row.Score       float64
row.HasScore    bool  // false when the server sent null or the field was not selected
row.Document    string
row.HasDocument bool
```

Existing fields and JSON tags are unchanged — backward compatible. The flags are set on all
three construction paths (Search, Query, Get), since `ResultRow` is shared.

## 2. Build-time guards (#497, #498, #501)

`RrfRank.MarshalJSON` negates the fusion sum to match Chroma's lower-is-better ordering, so
every arithmetic method on `*RrfRank` composes against a value that is always `<= 0`. Two
compositions are provably degenerate on that input:

| Composition | Behavior | Now |
|---|---|---|
| `rrf.Log()` | `ln(x<=0)` is NaN; server drops NaN rows | `ErrDegenerateRrfLog` |
| `rrf.Max(0)` | `max(x, 0) == 0`; every result ties | `ErrDegenerateRrfMaxZero` |

Both use the deferred-error pattern already established by `UnknownRank`, so the fluent API
keeps its single return value. Sentinels are exported and `errors.Is`-matchable, matching
`ErrNilRank`. `WithRank` rejects them eagerly rather than deferring to request-marshal time.

Deliberately left legal, per scope:

- `rrf.Abs()` and `rrf.Negate()` — reverse ordering, but well-defined; documented warnings only.
- `rrf.Min(Val(0))` — a harmless no-op. Not silently rewritten away.
- `rrf.Max` with any non-zero or non-constant operand — not statically knowable.
- `rrf.Add(Val(1)).Log()` — the documented safe idiom; only *direct* `rrf.Log()` is rejected.

## 3. Read-time cardinality guard (#500)

`Search` now returns `ErrDegenerateSearchResult` when a request selected `KScore` but the
response's score cardinality diverges from its ID cardinality. Gated on `Select` so it cannot
false-positive on queries that never asked for scores.

This only becomes sound after change 1 — until nulls preserve position, ordinary null-bearing
responses would trip it.

## Note on #497's framing

#497 is filed as a server-behavior defect. That framing is incorrect. Checked against
`chroma-core/chroma`: Python's `Rrf` is a plain `Rank` subclass inheriting `.log()`/`.max()`
with zero guards, Rust's `rrf()` is `Ok(-sum)`, and `RankExpr::Logarithm` evaluates to a bare
`f32::ln`. The behavior is deterministic IEEE 754 math and upstream has no guard — upstream's
stated position is a doc comment ("add constant to avoid log(0)").

The Go client addresses it client-side per its own established contract: reject caller
mistakes eagerly with exported sentinels, as with `MaxExpressionDepth` (#530), `MaxRrfRanks`,
NaN/Inf weight rejection, `ErrNilRank` (#531), and eager option validation (#532) — none of
which exist upstream either. Strictness applies to caller mistakes, not to legal server
responses, which is why per-element `null` is handled rather than rejected.

## Testing

- `make test` — 2087 tests green, 7 skipped.
- `make lint` — 0 issues.
- `go vet -tags=cloud ./pkg/api/v2/...` — clean after flipping the cloud pins.
- `TestCloudClientSearchRRFArithmetic` pins for `Log` and `Max_0` previously asserted the
  degenerate behavior; they now assert the new error paths.

## Follow-up

`NewTextDocumentsFromInterface` (`pkg/api/v2/document.go:85`) returns `invalid document type`
for a `null` element, so the Query/Get paths cannot represent a null document at all. Same
family as the bug fixed here, but a separate parser — worth its own issue.

Closes #497
Closes #498
Closes #500
Closes #501
